### PR TITLE
python3Packages.torch_2_7: default to C++11 ABI

### DIFF
--- a/pkgs/python-modules/torch_2_7/default.nix
+++ b/pkgs/python-modules/torch_2_7/default.nix
@@ -34,7 +34,7 @@
   MPISupport ? false,
   mpi,
   buildDocs ? false,
-  cxx11Abi ? false,
+  cxx11Abi ? true,
 
   # tests.cudaAvailable:
   callPackage,


### PR DESCRIPTION
This changes the derivation to be compatible with upstream builds. This is necessary if you want to use/test Hub kernels using the Torch from this repository.