### PR TITLE
rocmPackages: use the RHEL/RPM package set

### DIFF
--- a/overlay.nix
+++ b/overlay.nix
@@ -9,6 +9,18 @@ rec {
 
   fetchKernel = final.callPackage ./pkgs/fetch-kernel { };
 
+  # Used by ROCm.
+  libffi_3_2 = final.libffi_3_3.overrideAttrs (
+    finalAttrs: _: {
+      version = "3.2.1";
+      src = final.fetchurl {
+        url =
+          with finalAttrs; "https://gcc.gnu.org/pub/${pname}/${pname}-${version}.tar.gz";
+        hash = "sha256-0G67jh2aItGeONY/24OVQlPzm+3F1GIyoFZFaFciyjc=";
+      };
+    }
+  );
+
   magma-cuda-static = prev.magma-cuda-static.overrideAttrs (
     _: prevAttrs: { buildInputs = prevAttrs.buildInputs ++ [ (prev.lib.getLib prev.gfortran.cc) ]; }
   );
@@ -20,6 +32,20 @@ rec {
     }).magma;
 
   nvtx = final.callPackage ./pkgs/nvtx { };
+
+  rocmPackages = final.rocmPackages_6_3;
+
+  # Remove when we remove ROCm 6.2.
+  suitesparse_4_4 = prev.suitesparse_4_4.overrideAttrs (
+    _: prevAttrs: {
+      postInstall = prevAttrs.postInstall + ''
+        ln -s $out/lib/libsuitesparse.so $out/lib/libsuitesparse.so.4
+        # All dynamic libraries are just symplinks to the main library.
+        ln -s $out/lib/libsuitesparse.so $out/lib/libcholmod.so.3
+        ln -s $out/lib/libsuitesparse.so $out/lib/libsuitesparseconfig.so.4
+      '';
+    }
+  );
 
   pythonPackagesExtensions = prev.pythonPackagesExtensions ++ [
     (
@@ -128,8 +154,6 @@ rec {
           cutlass = final.cutlass_2_10;
         };
 
-        rocmPackages = final.rocmPackages_6_3;
-
         rotary = buildKernel rec {
           pname = "rotary";
           version = "0.0.2";
@@ -142,11 +166,11 @@ rec {
 
         torch = python-self.torch_2_7;
 
-        torch_2_6 = callPackage ./pkgs/python-modules/torch_2_6 { rocmPackages = final.rocmPackages_6_2; };
+        torch_2_6 = callPackage ./pkgs/python-modules/torch_2_6 { };
 
-        torch_2_7 = callPackage ./pkgs/python-modules/torch_2_7 { rocmPackages = final.rocmPackages_6_3; };
+        torch_2_7 = callPackage ./pkgs/python-modules/torch_2_7 { };
 
-        torch_2_8 = callPackage ./pkgs/python-modules/torch_2_8 { rocmPackages = final.rocmPackages_6_4; };
+        torch_2_8 = callPackage ./pkgs/python-modules/torch_2_8 { };
       }
     )
   ];

--- a/pkgs/python-modules/torch_2_6/default.nix
+++ b/pkgs/python-modules/torch_2_6/default.nix
@@ -551,12 +551,12 @@ buildPythonPackage rec {
     ++ lib.optionals rocmSupport (
       with rocmPackages;
       [
-        composablekernel-dev
-        hipcub-dev
+        composablekernel-devel
+        hipcub-devel
         openmp
         rocmtoolkit_joined
-        rocprim-dev
-        rocthrust-dev
+        rocprim-devel
+        rocthrust-devel
       ]
     )
     ++ lib.optionals (cudaSupport || rocmSupport) [ effectiveMagma ]

--- a/pkgs/python-modules/torch_2_7/default.nix
+++ b/pkgs/python-modules/torch_2_7/default.nix
@@ -228,7 +228,7 @@ let
       clr
       comgr
       hipblas
-      hipblas-common-dev
+      hipblas-common-devel
       hipblaslt
       hipfft
       hipify-clang
@@ -568,12 +568,12 @@ buildPythonPackage rec {
     ++ lib.optionals rocmSupport (
       with rocmPackages;
       [
-        composablekernel-dev
-        hipcub-dev
+        composablekernel-devel
+        hipcub-devel
         openmp
         rocmtoolkit_joined
-        rocprim-dev
-        rocthrust-dev
+        rocprim-devel
+        rocthrust-devel
       ]
     )
     ++ lib.optionals (cudaSupport || rocmSupport) [ effectiveMagma ]

--- a/pkgs/python-modules/torch_2_8/default.nix
+++ b/pkgs/python-modules/torch_2_8/default.nix
@@ -209,7 +209,7 @@ let
       clr
       comgr
       hipblas
-      hipblas-common-dev
+      hipblas-common-devel
       hipblaslt
       hipfft
       hipify-clang
@@ -545,13 +545,13 @@ buildPythonPackage rec {
     ++ lib.optionals rocmSupport (
       with rocmPackages;
       [
-        composablekernel-dev
-        hipcub-dev
+        composablekernel-devel
+        hipcub-devel
         libdrm
         openmp
         rocmtoolkit_joined
-        rocprim-dev
-        rocthrust-dev
+        rocprim-devel
+        rocthrust-devel
       ]
     )
     ++ lib.optionals (cudaSupport || rocmSupport) [ effectiveMagma ]

--- a/pkgs/rocm-packages/clang.nix
+++ b/pkgs/rocm-packages/clang.nix
@@ -3,7 +3,7 @@
   wrapCCWith,
   bintools,
   glibc,
-  hip-dev,
+  hip-devel,
   llvm,
   rocm-device-libs,
   rsync,
@@ -41,10 +41,12 @@ wrapCCWith rec {
       # include HIP/CUDA compatibility headers.
       chmod -R +w $out/share
       mkdir -p $out/share/hip
-      cp ${hip-dev}/share/hip/version $out/share/hip
+      cp ${hip-devel}/share/hip/version $out/share/hip
 
       runHook postInstall
     '';
+
+    dontStrip = true;
 
     passthru = {
       isClang = true;

--- a/pkgs/rocm-packages/clr.nix
+++ b/pkgs/rocm-packages/clr.nix
@@ -7,7 +7,7 @@
   clang,
   comgr,
   hipcc,
-  hip-dev,
+  hip-devel,
   hip-runtime-amd,
   hsa-rocr,
   perl,
@@ -55,7 +55,7 @@ stdenv.mkDerivation {
 
     mkdir -p $out
 
-    for path in ${hipcc} ${hip-dev} ${hip-runtime-amd} ${rocm-opencl}; do
+    for path in ${hipcc} ${hip-devel} ${hip-runtime-amd} ${rocm-opencl}; do
       rsync -a --exclude=nix-support $path/ $out/
     done
 
@@ -72,6 +72,8 @@ stdenv.mkDerivation {
 
     runHook postInstall
   '';
+
+  dontStrip = true;
 
   passthru = {
     gpuTargets = lib.forEach [

--- a/pkgs/rocm-packages/generic.nix
+++ b/pkgs/rocm-packages/generic.nix
@@ -4,7 +4,7 @@
   callPackage,
   fetchurl,
   stdenv,
-  dpkg,
+  rpmextract,
   rsync,
   rocmPackages,
 
@@ -37,8 +37,8 @@ stdenv.mkDerivation rec {
 
   nativeBuildInputs = [
     autoPatchelfHook
-    dpkg
     rocmPackages.markForRocmRootHook
+    rpmextract
     rsync
   ];
 
@@ -50,7 +50,7 @@ stdenv.mkDerivation rec {
   # dpkg hook does not seem to work for multiple sources.
   unpackPhase = ''
     for src in $srcs; do
-      dpkg-deb -x "$src" .
+      rpmextract "$src"
     done
   '';
 
@@ -60,6 +60,11 @@ stdenv.mkDerivation rec {
     cp -rT opt/rocm-* $out
     runHook postInstall
   '';
+
+  # Stripping the binaries from the RHEL packages breaks them, so disable
+  # it (seems kind of superfluous anyway, since the RPM build probably does
+  # stripping as well).
+  dontStrip = true;
 
   autoPatchelfIgnoreMissingDeps = [
     # Not sure where this comes from, not in the distribution.
@@ -72,7 +77,7 @@ stdenv.mkDerivation rec {
     # by /bin/roofline-* for older Linux distributions.
     "libamdhip64.so.5"
 
-    # Python 3.8 is not in nixpkgs anymore.
-    "libpython3.8.so.1.0"
+    # Python versions not in nixpkgs anymore.
+    "libpython3.6m.so.1.0"
   ];
 }

--- a/pkgs/rocm-packages/joins.nix
+++ b/pkgs/rocm-packages/joins.nix
@@ -10,7 +10,7 @@ final: prev: {
     inherit (final)
       comgr
       hipcc
-      hip-dev
+      hip-devel
       hip-runtime-amd
       hsa-rocr
       markForRocmRootHook
@@ -39,11 +39,13 @@ final: prev: {
 
       mkdir -p $out
 
-      for path in ${openmp-extras-dev} ${openmp-extras-runtime}; do
+      for path in ${openmp-extras-devel} ${openmp-extras-runtime}; do
         rsync --exclude=nix-support -a $path/lib/llvm/ $out/
       done
 
       runHook postInstall
     '';
+
+    dontStrip = true;
   };
 }

--- a/pkgs/rocm-packages/overrides.nix
+++ b/pkgs/rocm-packages/overrides.nix
@@ -21,13 +21,13 @@ applyOverrides {
   hipblas =
     {
       lib,
-      hipblas-common-dev ? null,
+      hipblas-common-devel ? null,
     }:
     prevAttrs: {
       # Only available starting ROCm 6.3.
       propagatedBuildInputs =
         prevAttrs.buildInputs
-        ++ lib.optionals (hipblas-common-dev != null) [ hipblas-common-dev ];
+        ++ lib.optionals (hipblas-common-devel != null) [ hipblas-common-devel ];
     };
 
   hipblaslt =
@@ -59,7 +59,7 @@ applyOverrides {
       ];
     };
 
-  openmp-extras-dev =
+  openmp-extras-devel =
     { ncurses, zlib }:
     prevAttrs: {
       buildInputs = prevAttrs.buildInputs ++ [
@@ -69,9 +69,12 @@ applyOverrides {
     };
 
   openmp-extras-runtime =
-    { rocm-llvm }:
+    { rocm-llvm, libffi_3_2 }:
     prevAttrs: {
-      buildInputs = prevAttrs.buildInputs ++ [ rocm-llvm ];
+      buildInputs = prevAttrs.buildInputs ++ [
+        libffi_3_2
+        rocm-llvm
+      ];
       # Can we change rocm-llvm to pick these up?
       installPhase =
         (prevAttrs.installPhase or "")
@@ -81,10 +84,18 @@ applyOverrides {
     };
 
   hipsolver =
-    { suitesparse }:
-    prevAttrs: {
+    { lib, suitesparse, suitesparse_4_4 }:
+    prevAttrs:
+    let
+      effectiveSuitesparse =
+        # Remove this conditional when removing ROCm 6.2.
+        if lib.versionAtLeast prevAttrs.version "2.3.0" then
+          suitesparse
+        else
+          suitesparse_4_4;
+    in {
       buildInputs = prevAttrs.buildInputs ++ [
-        suitesparse
+        effectiveSuitesparse
       ];
     };
 

--- a/pkgs/rocm-packages/rhel2nix.py
+++ b/pkgs/rocm-packages/rhel2nix.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+
+import argparse
+import json
+import sys
+import gzip
+import xml.etree.ElementTree as ET
+from typing import Set
+from urllib.parse import urljoin
+from urllib.request import urlopen
+
+BASEURL = "https://repo.radeon.com/rocm/rhel{rhel_version}/{version}/main/"
+
+RHEL_VERSIONS = ["8", "9"]
+
+# XML namespaces used in RPM repo metadata
+RPM_NAMESPACES = {
+    "common": "http://linux.duke.edu/metadata/common",
+    "rpm": "http://linux.duke.edu/metadata/rpm",
+}
+
+REPOMD_NAMESPACES = {"repo": "http://linux.duke.edu/metadata/repo"}
+
+parser = argparse.ArgumentParser(description="Parse ROCm RHEL repository")
+parser.add_argument("version", help="ROCm version")
+parser.add_argument(
+    "--rhel-version", help="RHEL version", choices=RHEL_VERSIONS, default="8"
+)
+
+
+class Package:
+    def __init__(self, package_elem, rhel_version: str, base_url: str):
+        self._elem = package_elem
+        self._rhel_version = rhel_version
+        self._base_url = base_url
+
+        # Parse package metadata.
+        name_elem = self._elem.find("common:name", RPM_NAMESPACES)
+        self._name = name_elem.text if name_elem is not None else ""
+
+        version_elem = self._elem.find("common:version", RPM_NAMESPACES)
+        self._version = version_elem.get("ver", "") if version_elem is not None else ""
+        self._release = version_elem.get("rel", "") if version_elem is not None else ""
+
+        arch_elem = self._elem.find("common:arch", RPM_NAMESPACES)
+        self._arch = arch_elem.text if arch_elem is not None else ""
+
+        checksum_elem = self._elem.find("common:checksum", RPM_NAMESPACES)
+        self._checksum = checksum_elem.text if checksum_elem is not None else ""
+
+        location_elem = self._elem.find("common:location", RPM_NAMESPACES)
+        self._location = (
+            location_elem.get("href", "") if location_elem is not None else ""
+        )
+
+    def __str__(self):
+        return f"{self._name} {self._version}"
+
+    def depends(self, version: str) -> Set[str]:
+        """Extract dependencies, filtering for ROCm packages"""
+        deps = set()
+
+        # Find requires entries in RPM format
+        format_elem = self._elem.find("common:format", RPM_NAMESPACES)
+        if format_elem is not None:
+            requires_elem = format_elem.find("rpm:requires", RPM_NAMESPACES)
+            if requires_elem is not None:
+                for entry in requires_elem.findall("rpm:entry", RPM_NAMESPACES):
+                    dep_name = entry.get("name", "")
+                    # Filter out system dependencies and focus on package names
+                    if (
+                        dep_name
+                        and not dep_name.startswith("/")
+                        and not dep_name.startswith("rpmlib(")
+                    ):
+                        # Remove any version suffix that matches the ROCm version
+                        if dep_name.endswith(version):
+                            dep_name = dep_name[: -len(version)]
+                        deps.add(dep_name)
+
+        return deps
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def sha256(self) -> str:
+        return self._checksum
+
+    @property
+    def version(self) -> str:
+        # Remove RHEL-specific version suffix (e.g., .el8)
+        version = self._version
+        if f".el{self._rhel_version}" in version:
+            version = version.split(f".el{self._rhel_version}")[0]
+        return version
+
+    @property
+    def filename(self) -> str:
+        return f"{self._name}-{self._version}-{self._release}.{self._arch}.rpm"
+
+    @property
+    def url(self) -> str:
+        return self._location
+
+
+def fetch_and_parse_repodata(repo_url: str):
+    """Fetch and parse repository metadata"""
+    repomd_url = urljoin(repo_url, "repodata/repomd.xml")
+
+    try:
+        print(f"Fetching repository metadata from {repomd_url}...", file=sys.stderr)
+        with urlopen(repomd_url) as response:
+            repomd_content = response.read()
+
+        # Parse repo metadata. From this file we can get the paths to the
+        # other metadata files.
+        repomd_root = ET.fromstring(repomd_content)
+
+        # Find the primary package metadata.
+        primary_location = None
+        for data in repomd_root.findall(
+            './/repo:data[@type="primary"]', REPOMD_NAMESPACES
+        ):
+            location_elem = data.find(".//repo:location", REPOMD_NAMESPACES)
+            if location_elem is not None:
+                primary_location = location_elem.get("href")
+                break
+
+        if not primary_location:
+            raise Exception("Could not find primary metadata in repomd.xml")
+
+        primary_url = urljoin(repo_url, primary_location)
+        print(f"Fetching primary metadata from {primary_url}...", file=sys.stderr)
+
+        with urlopen(primary_url) as response:
+            metadata = response.read()
+
+        if primary_location.endswith(".gz"):
+            metadata = gzip.decompress(metadata)
+
+        return ET.fromstring(metadata)
+
+    except Exception as e:
+        print(f"Error fetching repository metadata: {e}", file=sys.stderr)
+        sys.exit(1)
+
+
+def package_info(*, rhel_version: str, version: str):
+    """Generator that yields Package objects from the RHEL repository"""
+    repo_url = BASEURL.format(rhel_version=rhel_version, version=version)
+
+    metadata = fetch_and_parse_repodata(repo_url)
+
+    # Iterate through all packages in the metadata
+    for package_elem in metadata.findall(
+        './/common:package[@type="rpm"]', RPM_NAMESPACES
+    ):
+        yield Package(package_elem, rhel_version, repo_url)
+
+
+def __main__():
+    args = parser.parse_args()
+    packages = {}
+
+    print(
+        f"Fetching ROCm {args.version} packages for RHEL {args.rhel_version}...",
+        file=sys.stderr,
+    )
+
+    for pkg in package_info(rhel_version=args.rhel_version, version=args.version):
+        if "debuginfo" not in pkg.name and "debugsource" not in pkg.name:
+            packages[pkg.name] = pkg
+
+    print(f"Found {len(packages)} packages", file=sys.stderr)
+
+    filtered_packages = {}
+    # Filter dupes like hip-devel vs. hip-devel6.4.1
+    for name, info in packages.items():
+        if name.endswith(args.version):
+            name_without_version = name[: -len(args.version)]
+            if name_without_version not in packages:
+                filtered_packages[name_without_version] = info
+        else:
+            filtered_packages[name] = info
+    packages = filtered_packages
+
+    print(f"After filtering duplicates: {len(packages)} packages", file=sys.stderr)
+
+    # First pass: Find -devel and -rpath packages that should be merged.
+    dev_to_merge = {}
+    for name in packages.keys():
+        if name.endswith("-devel") and name[:-6] in packages:
+            dev_to_merge[name] = name[:-6]
+        elif name.endswith("-devel-rpath") and name[:-12] in packages:
+            dev_to_merge[name] = name[:-12]
+        elif name.endswith("-rpath") and name[:-6] in packages:
+            dev_to_merge[name] = name[:-6]
+
+    print(f"Found {len(dev_to_merge)} packages to merge", file=sys.stderr)
+
+    # Second pass: get ROCm dependencies and merge -devel packages.
+    metadata = {}
+
+    # sorted will put -devel after non-devel packages.
+    for name in sorted(packages.keys()):
+        info = packages[name]
+        deps = {
+            dev_to_merge.get(dep, dep)
+            for dep in info.depends(args.version)
+            if dep in packages
+        }
+
+        pkg_metadata = {
+            "name": name,
+            "sha256": info.sha256,
+            "url": urljoin(
+                BASEURL.format(rhel_version=args.rhel_version, version=args.version),
+                info.url,
+            ),
+            "version": info.version,
+        }
+
+        if name in dev_to_merge:
+            target_pkg = dev_to_merge[name]
+            if target_pkg not in metadata:
+                metadata[target_pkg] = {
+                    "deps": set(),
+                    "components": [],
+                    "version": info.version,
+                }
+            metadata[target_pkg]["components"].append(pkg_metadata)
+            metadata[target_pkg]["deps"].update(deps)
+        else:
+            metadata[name] = {
+                "deps": deps,
+                "components": [pkg_metadata],
+                "version": info.version,
+            }
+
+    # Remove self-references and convert dependencies to list.
+    for name, pkg_metadata in metadata.items():
+        deps = pkg_metadata["deps"]
+        deps -= {name, f"{name}-devel"}
+        deps -= {name, f"{name}-rpath"}
+        pkg_metadata["deps"] = list(sorted(deps))
+
+    print(f"Generated metadata for {len(metadata)} packages", file=sys.stderr)
+    print(json.dumps(metadata, indent=2))
+
+
+if __name__ == "__main__":
+    __main__()

--- a/pkgs/rocm-packages/rocm-6.2.4-metadata.json
+++ b/pkgs/rocm-packages/rocm-6.2.4-metadata.json
@@ -6,18 +6,18 @@
     "components": [
       {
         "name": "amd-smi-lib",
-        "sha256": "b40db2a41f87c84e5c7646e57c125aed802b9e5460759a066678f6615efe9c61",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/a/amd-smi-lib/amd-smi-lib_24.6.3.60204-139~20.04_amd64.deb",
-        "version": "24.6.3.60204-139"
+        "sha256": "6a16832b82e32a331b308fd03989573c970fe73edda3d51925db3b7b9f769f6c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/amd-smi-lib-24.6.3.60204-139.el8.x86_64.rpm",
+        "version": "24.6.3.60204"
       },
       {
         "name": "amd-smi-lib-rpath",
-        "sha256": "4c4b493753b36c69243ae1f19917dcd9161aff822e40189f6597b8561d6678e3",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/a/amd-smi-lib-rpath6.2.4/amd-smi-lib-rpath6.2.4_24.6.3.60204-139~20.04_amd64.deb",
-        "version": "24.6.3.60204-139"
+        "sha256": "9da21d7ff2feb6c87dcccacf47af30cfd43785ca364b3181abd1594f7c8ea76b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/amd-smi-lib-rpath6.2.4-24.6.3.60204-139.el8.x86_64.rpm",
+        "version": "24.6.3.60204"
       }
     ],
-    "version": "24.6.3.60204-139"
+    "version": "24.6.3.60204"
   },
   "amd-smi-lib-asan": {
     "deps": [
@@ -26,18 +26,46 @@
     "components": [
       {
         "name": "amd-smi-lib-asan",
-        "sha256": "7d4b8361ec99d98fff3745c21703ac02b9040187a846c52ffff89be6be49749b",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/a/amd-smi-lib-asan/amd-smi-lib-asan_24.6.3.60204-139~20.04_amd64.deb",
-        "version": "24.6.3.60204-139"
+        "sha256": "4f77846ebd7f05428e00d6026195bbe89484122c7e011570aa4465c6c55018b8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/amd-smi-lib-asan-24.6.3.60204-139.el8.x86_64.rpm",
+        "version": "24.6.3.60204"
       },
       {
         "name": "amd-smi-lib-asan-rpath",
-        "sha256": "8d94681688469e0fe578069920f88854df1827bbcc7874d07eed074e329250f1",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/a/amd-smi-lib-asan-rpath6.2.4/amd-smi-lib-asan-rpath6.2.4_24.6.3.60204-139~20.04_amd64.deb",
-        "version": "24.6.3.60204-139"
+        "sha256": "4fe45d639bb732d23088659354fb2af4cbb486922b2af1fa4ebc4a9ba0821f20",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/amd-smi-lib-asan-rpath6.2.4-24.6.3.60204-139.el8.x86_64.rpm",
+        "version": "24.6.3.60204"
       }
     ],
-    "version": "24.6.3.60204-139"
+    "version": "24.6.3.60204"
+  },
+  "amd-smi-lib-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "amd-smi-lib-asan-rpath6.2.4-rpath",
+        "sha256": "7562f6ead8393c27adf7ab6098d4a248ee3487612b0435aaefecc5752bd902de",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/amd-smi-lib-asan-rpath6.2.4-rpath6.2.4-24.6.3.60204-139.el8.x86_64.rpm",
+        "version": "24.6.3.60204"
+      }
+    ],
+    "version": "24.6.3.60204"
+  },
+  "amd-smi-lib-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "amd-smi-lib-asan6.2.4-rpath",
+        "sha256": "9d49c2fc1185503afa45eb3e39bbfce8d2d239a8a175972e8e25768b39731016",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/amd-smi-lib-asan6.2.4-rpath6.2.4-24.6.3.60204-139.el8.x86_64.rpm",
+        "version": "24.6.3.60204"
+      }
+    ],
+    "version": "24.6.3.60204"
   },
   "comgr": {
     "deps": [
@@ -46,18 +74,18 @@
     "components": [
       {
         "name": "comgr",
-        "sha256": "6cbc94779f0e8ff5b3e929786821cdf7dafbc1f4014be18274630dd3edc974e8",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/c/comgr/comgr_2.8.0.60204-139~20.04_amd64.deb",
-        "version": "2.8.0.60204-139"
+        "sha256": "4d2a898765d2ff075d63196885eb50571e730aa571821f1decab1b7848e25353",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/comgr-2.8.0.60204-139.el8.x86_64.rpm",
+        "version": "2.8.0.60204"
       },
       {
         "name": "comgr-rpath",
-        "sha256": "510ac4c8c4eb0f45ec5c6c9c08eb31ac18889530528f21cd2e571bbd0fc910e6",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/c/comgr-rpath6.2.4/comgr-rpath6.2.4_2.8.0.60204-139~20.04_amd64.deb",
-        "version": "2.8.0.60204-139"
+        "sha256": "87849fc8af0b12a8d62f88be0418216fc20710f4dc693393f53400e165b99588",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/comgr-rpath6.2.4-2.8.0.60204-139.el8.x86_64.rpm",
+        "version": "2.8.0.60204"
       }
     ],
-    "version": "2.8.0.60204-139"
+    "version": "2.8.0.60204"
   },
   "comgr-asan": {
     "deps": [
@@ -66,18 +94,46 @@
     "components": [
       {
         "name": "comgr-asan",
-        "sha256": "00cca66058919bd5db9e290ba4ad1b73b4295832f7ff4213737885481674bca1",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/c/comgr-asan/comgr-asan_2.8.0.60204-139~20.04_amd64.deb",
-        "version": "2.8.0.60204-139"
+        "sha256": "ec1c2828d2f2c1b9ab36e97da2f5663d6d5f277da97490cef53906f2c18fc078",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/comgr-asan-2.8.0.60204-139.el8.x86_64.rpm",
+        "version": "2.8.0.60204"
       },
       {
         "name": "comgr-asan-rpath",
-        "sha256": "335ea849b87cea093d9e6e52dbccdc0d4feb8c42a2e310ec9861688982eb7045",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/c/comgr-asan-rpath6.2.4/comgr-asan-rpath6.2.4_2.8.0.60204-139~20.04_amd64.deb",
-        "version": "2.8.0.60204-139"
+        "sha256": "4dea2e082645d602f254fcc699c2f4ddb7bd42fb25a5291f43bb3f77bdc57069",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/comgr-asan-rpath6.2.4-2.8.0.60204-139.el8.x86_64.rpm",
+        "version": "2.8.0.60204"
       }
     ],
-    "version": "2.8.0.60204-139"
+    "version": "2.8.0.60204"
+  },
+  "comgr-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "comgr-asan-rpath6.2.4-rpath",
+        "sha256": "927f2f4816e783caa035283ca4899209f5114259badd54f4e8d65bd5d968fb02",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/comgr-asan-rpath6.2.4-rpath6.2.4-2.8.0.60204-139.el8.x86_64.rpm",
+        "version": "2.8.0.60204"
+      }
+    ],
+    "version": "2.8.0.60204"
+  },
+  "comgr-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "comgr-asan6.2.4-rpath",
+        "sha256": "fa2b2997b63e2b5a50c22bd8388c04810772bc28c044cb7330716b68d9bdd9ef",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/comgr-asan6.2.4-rpath6.2.4-2.8.0.60204-139.el8.x86_64.rpm",
+        "version": "2.8.0.60204"
+      }
+    ],
+    "version": "2.8.0.60204"
   },
   "composablekernel-ckprofiler_gfx10": {
     "deps": [
@@ -86,18 +142,18 @@
     "components": [
       {
         "name": "composablekernel-ckprofiler_gfx10",
-        "sha256": "44990371e0abbf5d28ebf7ebcf485f641cd51f647553acbc55663746dd92a896",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/c/composablekernel-ckprofiler_gfx10/composablekernel-ckprofiler_gfx10_1.1.0.60204-139~20.04_amd64.deb",
-        "version": "1.1.0.60204-139"
+        "sha256": "41118625be8370257f58bc4c3fa09a6eecc5df62c84aeea7d0ad5226e33c299f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/composablekernel-ckprofiler_gfx10-1.1.0.60204-139.el8.x86_64.rpm",
+        "version": "1.1.0.60204"
       },
       {
         "name": "composablekernel-ckprofiler_gfx10-rpath",
-        "sha256": "2abeccba59f5ae365e712b90f8f53a3a6ab77471b9f86e0e7b9ea0434f6933cd",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/c/composablekernel-ckprofiler_gfx10-rpath6.2.4/composablekernel-ckprofiler_gfx10-rpath6.2.4_1.1.0.60204-139~20.04_amd64.deb",
-        "version": "1.1.0.60204-139"
+        "sha256": "20f7d9f1c89eac2a33487d85cf0abe8f4a1da72ce2b799c047664be391f31d40",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/composablekernel-ckprofiler_gfx10-rpath6.2.4-1.1.0.60204-139.el8.x86_64.rpm",
+        "version": "1.1.0.60204"
       }
     ],
-    "version": "1.1.0.60204-139"
+    "version": "1.1.0.60204"
   },
   "composablekernel-ckprofiler_gfx11": {
     "deps": [
@@ -106,18 +162,18 @@
     "components": [
       {
         "name": "composablekernel-ckprofiler_gfx11",
-        "sha256": "a6a19b0875c67c0dc79b43b0b0faf89dedd984c4c7d8ecf8d29c6faa3f774f40",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/c/composablekernel-ckprofiler_gfx11/composablekernel-ckprofiler_gfx11_1.1.0.60204-139~20.04_amd64.deb",
-        "version": "1.1.0.60204-139"
+        "sha256": "5dcf5a5ee5cc2bfce355728b695eadf6995b3a0ef47511f40a84180bd29b30dd",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/composablekernel-ckprofiler_gfx11-1.1.0.60204-139.el8.x86_64.rpm",
+        "version": "1.1.0.60204"
       },
       {
         "name": "composablekernel-ckprofiler_gfx11-rpath",
-        "sha256": "3dd6bd219754dfa9b8bc71eb4ef4e6e3773592d9c19fa40645291dcc72942407",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/c/composablekernel-ckprofiler_gfx11-rpath6.2.4/composablekernel-ckprofiler_gfx11-rpath6.2.4_1.1.0.60204-139~20.04_amd64.deb",
-        "version": "1.1.0.60204-139"
+        "sha256": "1af34f3ec514f2231cbcce78e269b483bc13e244b91d18423e829e2cee086e1b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/composablekernel-ckprofiler_gfx11-rpath6.2.4-1.1.0.60204-139.el8.x86_64.rpm",
+        "version": "1.1.0.60204"
       }
     ],
-    "version": "1.1.0.60204-139"
+    "version": "1.1.0.60204"
   },
   "composablekernel-ckprofiler_gfx90": {
     "deps": [
@@ -126,18 +182,18 @@
     "components": [
       {
         "name": "composablekernel-ckprofiler_gfx90",
-        "sha256": "34302fb2d5e37e0d4a39254970256e0b7771b58fa9826b054009b87f9cc596fc",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/c/composablekernel-ckprofiler_gfx90/composablekernel-ckprofiler_gfx90_1.1.0.60204-139~20.04_amd64.deb",
-        "version": "1.1.0.60204-139"
+        "sha256": "5b6a41cb23f92ae17c32a44e29cd6fffef1a1c019cc11d0d38f4bc162d754a0f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/composablekernel-ckprofiler_gfx90-1.1.0.60204-139.el8.x86_64.rpm",
+        "version": "1.1.0.60204"
       },
       {
         "name": "composablekernel-ckprofiler_gfx90-rpath",
-        "sha256": "427c1389426eb31f4c501185ee7f82c22dddbb37fab9134ac955e02ba1af7769",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/c/composablekernel-ckprofiler_gfx90-rpath6.2.4/composablekernel-ckprofiler_gfx90-rpath6.2.4_1.1.0.60204-139~20.04_amd64.deb",
-        "version": "1.1.0.60204-139"
+        "sha256": "29ff4ef6c6d2a2dd3dbb673ba8d5badd016eb36931817cd806e2777e0d2ee1f4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/composablekernel-ckprofiler_gfx90-rpath6.2.4-1.1.0.60204-139.el8.x86_64.rpm",
+        "version": "1.1.0.60204"
       }
     ],
-    "version": "1.1.0.60204-139"
+    "version": "1.1.0.60204"
   },
   "composablekernel-ckprofiler_gfx94": {
     "deps": [
@@ -146,38 +202,38 @@
     "components": [
       {
         "name": "composablekernel-ckprofiler_gfx94",
-        "sha256": "ca8409d074a76e76b0b94e6d59742fc1fbe37b147e616b703c3eba06d52d695c",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/c/composablekernel-ckprofiler_gfx94/composablekernel-ckprofiler_gfx94_1.1.0.60204-139~20.04_amd64.deb",
-        "version": "1.1.0.60204-139"
+        "sha256": "27671c463bcf5bb5a364f84bf09dd3eb66eca427b7146067e24ccdd290aa060d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/composablekernel-ckprofiler_gfx94-1.1.0.60204-139.el8.x86_64.rpm",
+        "version": "1.1.0.60204"
       },
       {
         "name": "composablekernel-ckprofiler_gfx94-rpath",
-        "sha256": "e534be834248b2baa0d2d718f4951ab48a93532ab4198df9b7792f5be4fc1ef2",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/c/composablekernel-ckprofiler_gfx94-rpath6.2.4/composablekernel-ckprofiler_gfx94-rpath6.2.4_1.1.0.60204-139~20.04_amd64.deb",
-        "version": "1.1.0.60204-139"
+        "sha256": "9ea97417eb3728afd181b002171419dd538c417a028bcacca222e0e0cbc16b06",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/composablekernel-ckprofiler_gfx94-rpath6.2.4-1.1.0.60204-139.el8.x86_64.rpm",
+        "version": "1.1.0.60204"
       }
     ],
-    "version": "1.1.0.60204-139"
+    "version": "1.1.0.60204"
   },
-  "composablekernel-dev": {
+  "composablekernel-devel": {
     "deps": [
       "rocm-core"
     ],
     "components": [
       {
-        "name": "composablekernel-dev",
-        "sha256": "cd1ce72a8aac3beed4d56880a8e44283a49261304757b0706f3de7429bd47d19",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/c/composablekernel-dev/composablekernel-dev_1.1.0.60204-139~20.04_amd64.deb",
-        "version": "1.1.0.60204-139"
+        "name": "composablekernel-devel",
+        "sha256": "cd814374eeeba9a9291d553fdfdf5de821def2693f16ba3877f5de011680aab6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/composablekernel-devel-1.1.0.60204-139.el8.x86_64.rpm",
+        "version": "1.1.0.60204"
       },
       {
-        "name": "composablekernel-dev-rpath",
-        "sha256": "4943472529747de96074f529b6769002bb34e59649068f6a46bcb70e4c4abced",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/c/composablekernel-dev-rpath6.2.4/composablekernel-dev-rpath6.2.4_1.1.0.60204-139~20.04_amd64.deb",
-        "version": "1.1.0.60204-139"
+        "name": "composablekernel-devel-rpath",
+        "sha256": "e4fb5bc945693465f41a837b1cdcb379beb77a4444ee67e2e6df3174bda652a2",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/composablekernel-devel-rpath6.2.4-1.1.0.60204-139.el8.x86_64.rpm",
+        "version": "1.1.0.60204"
       }
     ],
-    "version": "1.1.0.60204-139"
+    "version": "1.1.0.60204"
   },
   "half": {
     "deps": [
@@ -186,20 +242,20 @@
     "components": [
       {
         "name": "half",
-        "sha256": "e0ddff723a725acc177254995e52fcb738593a6b6e544cecde9ae1d26538bea4",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/half/half_1.12.0.60204-139~20.04_amd64.deb",
-        "version": "1.12.0.60204-139"
+        "sha256": "a28dbebc7b2e6156de0c1b3f14281d31aaf709736c8120d875f57a91e42ca43e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/half-1.12.0.60204-139.el8.x86_64.rpm",
+        "version": "1.12.0.60204"
       },
       {
         "name": "half-rpath",
-        "sha256": "3d5c9a20436cf5c68ec2a22f42bdc2bb8c8395a742a4106e785b90adf04ad55c",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/half-rpath6.2.4/half-rpath6.2.4_1.12.0.60204-139~20.04_amd64.deb",
-        "version": "1.12.0.60204-139"
+        "sha256": "9812c13745c3b4a9ba6ce19ab8b8d6574fc0a7642681fe2a48a1ace92cc3acca",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/half-rpath6.2.4-1.12.0.60204-139.el8.x86_64.rpm",
+        "version": "1.12.0.60204"
       }
     ],
-    "version": "1.12.0.60204-139"
+    "version": "1.12.0.60204"
   },
-  "hip-dev": {
+  "hip-devel": {
     "deps": [
       "hip-runtime-amd",
       "hsa-rocr",
@@ -208,40 +264,40 @@
     ],
     "components": [
       {
-        "name": "hip-dev",
-        "sha256": "54be05415f6fb2114ebdd5a9737e1bdf76ffb0590aa577552794c4dfba33373c",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hip-dev/hip-dev_6.2.41134.60204-139~20.04_amd64.deb",
-        "version": "6.2.41134.60204-139"
+        "name": "hip-devel",
+        "sha256": "b3e9ff884b2b1bb472884fe39dc6f5852231e592ea12fd164ddc8c407eb541da",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hip-devel-6.2.41134.60204-139.el8.x86_64.rpm",
+        "version": "6.2.41134.60204"
       },
       {
-        "name": "hip-dev-rpath",
-        "sha256": "cf2a52d36eefb96e0446bf957fdb59fa68f39db5df699528e298ae3c571c518c",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hip-dev-rpath6.2.4/hip-dev-rpath6.2.4_6.2.41134.60204-139~20.04_amd64.deb",
-        "version": "6.2.41134.60204-139"
+        "name": "hip-devel-rpath",
+        "sha256": "6a1e9a2becffd809c76c9ff1456c1596035a8e70e5f7fbedf771b3b98886c3c5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hip-devel-rpath6.2.4-6.2.41134.60204-139.el8.x86_64.rpm",
+        "version": "6.2.41134.60204"
       }
     ],
-    "version": "6.2.41134.60204-139"
+    "version": "6.2.41134.60204"
   },
   "hip-doc": {
     "deps": [
-      "hip-dev",
+      "hip-devel",
       "rocm-core"
     ],
     "components": [
       {
         "name": "hip-doc",
-        "sha256": "5028906edac2ba6bd6b5ad497676d32fba806e12684b595660be6e8263d5d436",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hip-doc/hip-doc_6.2.41134.60204-139~20.04_amd64.deb",
-        "version": "6.2.41134.60204-139"
+        "sha256": "7e987753f072a08e34e5539e2cecb1ff7db9a51bf73dd81adf268786d5acad45",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hip-doc-6.2.41134.60204-139.el8.x86_64.rpm",
+        "version": "6.2.41134.60204"
       },
       {
         "name": "hip-doc-rpath",
-        "sha256": "7f3aa8550c6a5f72887ce5bb209f67a8bb1de9c43ad1652a391edfbb310a8211",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hip-doc-rpath6.2.4/hip-doc-rpath6.2.4_6.2.41134.60204-139~20.04_amd64.deb",
-        "version": "6.2.41134.60204-139"
+        "sha256": "711f1f891368acb5176882feae23487de7efb56ec05db6e7754aecc23503ad48",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hip-doc-rpath6.2.4-6.2.41134.60204-139.el8.x86_64.rpm",
+        "version": "6.2.41134.60204"
       }
     ],
-    "version": "6.2.41134.60204-139"
+    "version": "6.2.41134.60204"
   },
   "hip-runtime-amd": {
     "deps": [
@@ -254,18 +310,18 @@
     "components": [
       {
         "name": "hip-runtime-amd",
-        "sha256": "4a3027dd9812865cf52f3b40d698ae2e6542ad73cbb6d7ad367c5dd06d467743",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hip-runtime-amd/hip-runtime-amd_6.2.41134.60204-139~20.04_amd64.deb",
-        "version": "6.2.41134.60204-139"
+        "sha256": "67013f0a6d62faf5adf99c3f639ed30caa39e98ef949cadda0b1e9875f13cd6e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hip-runtime-amd-6.2.41134.60204-139.el8.x86_64.rpm",
+        "version": "6.2.41134.60204"
       },
       {
         "name": "hip-runtime-amd-rpath",
-        "sha256": "633951c5e0ed3b1f0e248f828f1ecbb2d845fda8c0b43904fba576eda3f12c77",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hip-runtime-amd-rpath6.2.4/hip-runtime-amd-rpath6.2.4_6.2.41134.60204-139~20.04_amd64.deb",
-        "version": "6.2.41134.60204-139"
+        "sha256": "a4e4407b8e9cf66f7ff96ee50fc8873b249619aa0366fe279ed3bc5ba7a6bc63",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hip-runtime-amd-rpath6.2.4-6.2.41134.60204-139.el8.x86_64.rpm",
+        "version": "6.2.41134.60204"
       }
     ],
-    "version": "6.2.41134.60204-139"
+    "version": "6.2.41134.60204"
   },
   "hip-runtime-amd-asan": {
     "deps": [
@@ -278,18 +334,50 @@
     "components": [
       {
         "name": "hip-runtime-amd-asan",
-        "sha256": "e6debb6c811ea4f73adee6a66c7d00116d5fb0921854009cacdc20bc76d59ca7",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hip-runtime-amd-asan/hip-runtime-amd-asan_6.2.41134.60204-139~20.04_amd64.deb",
-        "version": "6.2.41134.60204-139"
+        "sha256": "51a6c8eb3a00e00db201bb104a44fb45cf97e192424cc80bef0ecd837fd1c2cc",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hip-runtime-amd-asan-6.2.41134.60204-139.el8.x86_64.rpm",
+        "version": "6.2.41134.60204"
       },
       {
         "name": "hip-runtime-amd-asan-rpath",
-        "sha256": "55ab8acd13ec538f38e12bcf551eebdc5144a97c8e276d1ec6cb35edc1493fb2",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hip-runtime-amd-asan-rpath6.2.4/hip-runtime-amd-asan-rpath6.2.4_6.2.41134.60204-139~20.04_amd64.deb",
-        "version": "6.2.41134.60204-139"
+        "sha256": "b50c52cbffa8a738a3bff5ccbcf97b0ec2dbad8cb02c47364e5b3f640b67610c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hip-runtime-amd-asan-rpath6.2.4-6.2.41134.60204-139.el8.x86_64.rpm",
+        "version": "6.2.41134.60204"
       }
     ],
-    "version": "6.2.41134.60204-139"
+    "version": "6.2.41134.60204"
+  },
+  "hip-runtime-amd-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "comgr-asan-rpath6.2.4-rpath",
+      "hsa-rocr-asan-rpath6.2.4-rpath",
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hip-runtime-amd-asan-rpath6.2.4-rpath",
+        "sha256": "158f4f37418f0af12ee50172f9a9ce5e38e34d09694e2561265ed94b741a2811",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hip-runtime-amd-asan-rpath6.2.4-rpath6.2.4-6.2.41134.60204-139.el8.x86_64.rpm",
+        "version": "6.2.41134.60204"
+      }
+    ],
+    "version": "6.2.41134.60204"
+  },
+  "hip-runtime-amd-asan6.2.4-rpath": {
+    "deps": [
+      "comgr-asan6.2.4-rpath",
+      "hsa-rocr-asan6.2.4-rpath",
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hip-runtime-amd-asan6.2.4-rpath",
+        "sha256": "4a10ba310e292028612848c2db485e36fe30c43511e0333d72886ddbed4b6496",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hip-runtime-amd-asan6.2.4-rpath6.2.4-6.2.41134.60204-139.el8.x86_64.rpm",
+        "version": "6.2.41134.60204"
+      }
+    ],
+    "version": "6.2.41134.60204"
   },
   "hip-runtime-nvidia": {
     "deps": [
@@ -299,40 +387,40 @@
     "components": [
       {
         "name": "hip-runtime-nvidia",
-        "sha256": "e23b699ecea3904be2a9c762159e5dd18d78f699eaf2f4b5a56c70943576232a",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hip-runtime-nvidia/hip-runtime-nvidia_6.2.41134.60204-139~20.04_amd64.deb",
-        "version": "6.2.41134.60204-139"
+        "sha256": "89fc920d276794242efb635cd2fc5aa2945f7e6fa4a7abbe5697f790358660d3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hip-runtime-nvidia-6.2.41134.60204-139.el8.x86_64.rpm",
+        "version": "6.2.41134.60204"
       },
       {
         "name": "hip-runtime-nvidia-rpath",
-        "sha256": "633571984d6cbc553961913ca4411d6335fe707e46fcc3dcbcd13d11b0d3e49d",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hip-runtime-nvidia-rpath6.2.4/hip-runtime-nvidia-rpath6.2.4_6.2.41134.60204-139~20.04_amd64.deb",
-        "version": "6.2.41134.60204-139"
+        "sha256": "4d8b2de1a602ef793da9a990c9f3d5cc9ad8d8d78d267bdfa595bd0949c756ab",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hip-runtime-nvidia-rpath6.2.4-6.2.41134.60204-139.el8.x86_64.rpm",
+        "version": "6.2.41134.60204"
       }
     ],
-    "version": "6.2.41134.60204-139"
+    "version": "6.2.41134.60204"
   },
   "hip-samples": {
     "deps": [
-      "hip-dev",
+      "hip-devel",
       "hipcc",
       "rocm-core"
     ],
     "components": [
       {
         "name": "hip-samples",
-        "sha256": "4daa66eeaceb15b8010e4ae8605db2d6209fee3f391aab30406b7ecf886a84f2",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hip-samples/hip-samples_6.2.41134.60204-139~20.04_amd64.deb",
-        "version": "6.2.41134.60204-139"
+        "sha256": "9a2a7191c3be4d7485cfd8ab8283f75bff6b0df4dcd643608c5363388cf7f7ea",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hip-samples-6.2.41134.60204-139.el8.x86_64.rpm",
+        "version": "6.2.41134.60204"
       },
       {
         "name": "hip-samples-rpath",
-        "sha256": "0fbaeb93abc7ce1fcca40bfb3d8363c6f106cb414f7142f195766d620b473795",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hip-samples-rpath6.2.4/hip-samples-rpath6.2.4_6.2.41134.60204-139~20.04_amd64.deb",
-        "version": "6.2.41134.60204-139"
+        "sha256": "976e35720547b61a99e83cc3093990065dc9d77f4f59aaedcbfb68e3bc766273",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hip-samples-rpath6.2.4-6.2.41134.60204-139.el8.x86_64.rpm",
+        "version": "6.2.41134.60204"
       }
     ],
-    "version": "6.2.41134.60204-139"
+    "version": "6.2.41134.60204"
   },
   "hipblas": {
     "deps": [
@@ -343,30 +431,30 @@
     "components": [
       {
         "name": "hipblas",
-        "sha256": "7ca236bbb0ac4a9fb72c65f937f237a7ba00a28341e067588f9d424a70daf6c9",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipblas/hipblas_2.2.0.60204-139~20.04_amd64.deb",
-        "version": "2.2.0.60204-139"
+        "sha256": "74078ae5654dc105b3acfe15aff392db4a48ffb3deb9e42eed5fa878515c7188",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipblas-2.2.0.60204-139.el8.x86_64.rpm",
+        "version": "2.2.0.60204"
       },
       {
-        "name": "hipblas-dev",
-        "sha256": "463c21f36a387e894bc26061ae3244ddcd5f8d3c238fdd1b6a639d3522049bf5",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipblas-dev/hipblas-dev_2.2.0.60204-139~20.04_amd64.deb",
-        "version": "2.2.0.60204-139"
+        "name": "hipblas-devel",
+        "sha256": "4cde0a0179f1b4a5d0a217aeb38dc32bea4fbb62e7054300a369a0266e6a6587",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipblas-devel-2.2.0.60204-139.el8.x86_64.rpm",
+        "version": "2.2.0.60204"
       },
       {
-        "name": "hipblas-dev-rpath",
-        "sha256": "43435d9460699696dac70480b967d7a43c6561de67aff65a1f6625211e079680",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipblas-dev-rpath6.2.4/hipblas-dev-rpath6.2.4_2.2.0.60204-139~20.04_amd64.deb",
-        "version": "2.2.0.60204-139"
+        "name": "hipblas-devel-rpath",
+        "sha256": "f489269127230ca2c808be25b2a1f8b8cfd878062b07ff658b251f325a2dc8b1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipblas-devel-rpath6.2.4-2.2.0.60204-139.el8.x86_64.rpm",
+        "version": "2.2.0.60204"
       },
       {
         "name": "hipblas-rpath",
-        "sha256": "41669189b4d0753de91b58223ede3deb6e2966c0f34e113afde9867b263e8ef0",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipblas-rpath6.2.4/hipblas-rpath6.2.4_2.2.0.60204-139~20.04_amd64.deb",
-        "version": "2.2.0.60204-139"
+        "sha256": "423c57bb90ceff7606dbf0ffafae4d5c436270caa0a0db8c4c7df919c196fefc",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipblas-rpath6.2.4-2.2.0.60204-139.el8.x86_64.rpm",
+        "version": "2.2.0.60204"
       }
     ],
-    "version": "2.2.0.60204-139"
+    "version": "2.2.0.60204"
   },
   "hipblas-asan": {
     "deps": [
@@ -377,18 +465,46 @@
     "components": [
       {
         "name": "hipblas-asan",
-        "sha256": "b7c106046e7e0b83aec1ec8d4fe18ae3f81d12a2b7dbdffec0454d1f53cc3983",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipblas-asan/hipblas-asan_2.2.0.60204-139~20.04_amd64.deb",
-        "version": "2.2.0.60204-139"
+        "sha256": "cbac2c25e11fb140124bb0720aef25658d09df9c5bd5569ddb77db984ca6740d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipblas-asan-2.2.0.60204-139.el8.x86_64.rpm",
+        "version": "2.2.0.60204"
       },
       {
         "name": "hipblas-asan-rpath",
-        "sha256": "c276b3ad8ca4d128b0c804379d288b0932d9923ecdeaa41e4787c4f847097de5",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipblas-asan-rpath6.2.4/hipblas-asan-rpath6.2.4_2.2.0.60204-139~20.04_amd64.deb",
-        "version": "2.2.0.60204-139"
+        "sha256": "6b533bc6549017f3ff14aed72ce1f84e82b5e524671ff27a3777bea098b0dfac",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipblas-asan-rpath6.2.4-2.2.0.60204-139.el8.x86_64.rpm",
+        "version": "2.2.0.60204"
       }
     ],
-    "version": "2.2.0.60204-139"
+    "version": "2.2.0.60204"
+  },
+  "hipblas-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hipblas-asan-rpath6.2.4-rpath",
+        "sha256": "5e5f54ef44a7bf1457ec70ae939f80dbfb5c016761cb4d68e8fba472d49c1a98",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipblas-asan-rpath6.2.4-rpath6.2.4-2.2.0.60204-139.el8.x86_64.rpm",
+        "version": "2.2.0.60204"
+      }
+    ],
+    "version": "2.2.0.60204"
+  },
+  "hipblas-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hipblas-asan6.2.4-rpath",
+        "sha256": "fb7a0066d5e393a11d0cd51cbee7794f41dba776d089397698f176e10cc03218",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipblas-asan6.2.4-rpath6.2.4-2.2.0.60204-139.el8.x86_64.rpm",
+        "version": "2.2.0.60204"
+      }
+    ],
+    "version": "2.2.0.60204"
   },
   "hipblaslt": {
     "deps": [
@@ -398,30 +514,30 @@
     "components": [
       {
         "name": "hipblaslt",
-        "sha256": "94a41e7252015fa6d5fee820ae5522e5eb5b2c17199bfd263efa98fd3bbdd6ba",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipblaslt/hipblaslt_0.8.0.60204-139~20.04_amd64.deb",
-        "version": "0.8.0.60204-139"
+        "sha256": "27a3d5b882768d7e446d8b3d84d53a435480b3d802eb2d0bb04ca9e6559d8cdd",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipblaslt-0.8.0.60204-139.el8.x86_64.rpm",
+        "version": "0.8.0.60204"
       },
       {
-        "name": "hipblaslt-dev",
-        "sha256": "bcfcd21f89f6a8c85fd14087e9e5dc15aaa677297467a3adc22ad09011ff3fb9",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipblaslt-dev/hipblaslt-dev_0.8.0.60204-139~20.04_amd64.deb",
-        "version": "0.8.0.60204-139"
+        "name": "hipblaslt-devel",
+        "sha256": "fc20f73fefccb953d9b46d1fe74754414d08fa9705487f4c4c34179e4ccbf36c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipblaslt-devel-0.8.0.60204-139.el8.x86_64.rpm",
+        "version": "0.8.0.60204"
       },
       {
-        "name": "hipblaslt-dev-rpath",
-        "sha256": "2390294f3beb7171ad91380613d848ddfea44edd15c327950583d9e7b3f92566",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipblaslt-dev-rpath6.2.4/hipblaslt-dev-rpath6.2.4_0.8.0.60204-139~20.04_amd64.deb",
-        "version": "0.8.0.60204-139"
+        "name": "hipblaslt-devel-rpath",
+        "sha256": "d3d436b93b12f0dcb230e28ff06b94ef311a8347b567edbcd1237c30d2b4f373",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipblaslt-devel-rpath6.2.4-0.8.0.60204-139.el8.x86_64.rpm",
+        "version": "0.8.0.60204"
       },
       {
         "name": "hipblaslt-rpath",
-        "sha256": "09ed1d8296acce84c4daf491c770a079839a2f11e25a6336547e97708124026e",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipblaslt-rpath6.2.4/hipblaslt-rpath6.2.4_0.8.0.60204-139~20.04_amd64.deb",
-        "version": "0.8.0.60204-139"
+        "sha256": "8d14b5721b24dff6b4f59aa330097420ad842a06c64ae2e679c693f7f33ae413",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipblaslt-rpath6.2.4-0.8.0.60204-139.el8.x86_64.rpm",
+        "version": "0.8.0.60204"
       }
     ],
-    "version": "0.8.0.60204-139"
+    "version": "0.8.0.60204"
   },
   "hipblaslt-asan": {
     "deps": [
@@ -431,82 +547,110 @@
     "components": [
       {
         "name": "hipblaslt-asan",
-        "sha256": "ac36b6030c0cb51bcbf04cc707bf2cadd5c909ca461406faabfe69a90553f4de",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipblaslt-asan/hipblaslt-asan_0.8.0.60204-139~20.04_amd64.deb",
-        "version": "0.8.0.60204-139"
+        "sha256": "cd04cfcf6a1eb2bb8e0a436b96a14ae30b84731a5cc97ebdff163ba13799763d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipblaslt-asan-0.8.0.60204-139.el8.x86_64.rpm",
+        "version": "0.8.0.60204"
       },
       {
         "name": "hipblaslt-asan-rpath",
-        "sha256": "f865043e74e9f145f11e14d0b925d21c8da988c467bf910f56e5ce845c2c829d",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipblaslt-asan-rpath6.2.4/hipblaslt-asan-rpath6.2.4_0.8.0.60204-139~20.04_amd64.deb",
-        "version": "0.8.0.60204-139"
+        "sha256": "bfb1401b7a463c9b6f6e6d1179fb20ecbd6ac89a08dfff6e3b185b2633308035",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipblaslt-asan-rpath6.2.4-0.8.0.60204-139.el8.x86_64.rpm",
+        "version": "0.8.0.60204"
       }
     ],
-    "version": "0.8.0.60204-139"
+    "version": "0.8.0.60204"
+  },
+  "hipblaslt-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hipblaslt-asan-rpath6.2.4-rpath",
+        "sha256": "0fb0bc8423af0c318b75985a910b6b9aa59387fe0836729b7e5b0bcb77ca0ccc",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipblaslt-asan-rpath6.2.4-rpath6.2.4-0.8.0.60204-139.el8.x86_64.rpm",
+        "version": "0.8.0.60204"
+      }
+    ],
+    "version": "0.8.0.60204"
+  },
+  "hipblaslt-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hipblaslt-asan6.2.4-rpath",
+        "sha256": "a2b05dd0aa5534fe018064794e404eba2beef5c2ee600b863088d86e92a871be",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipblaslt-asan6.2.4-rpath6.2.4-0.8.0.60204-139.el8.x86_64.rpm",
+        "version": "0.8.0.60204"
+      }
+    ],
+    "version": "0.8.0.60204"
   },
   "hipcc": {
     "deps": [
-      "hip-dev",
+      "hip-devel",
       "rocm-core",
       "rocm-llvm"
     ],
     "components": [
       {
         "name": "hipcc",
-        "sha256": "81d5b0adb6c4b4ef10e9b2ed5da824585c3ccc03753ac30da26852bd10b0414e",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipcc/hipcc_1.1.1.60204-139~20.04_amd64.deb",
-        "version": "1.1.1.60204-139"
+        "sha256": "106b98f985988fb5002e199e723676df4634a7e1b54e195f6e91ec7ad277c7f4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipcc-1.1.1.60204-139.el8.x86_64.rpm",
+        "version": "1.1.1.60204"
       },
       {
         "name": "hipcc-rpath",
-        "sha256": "265087eea9278e60161c8057453dedd35aa14a77afce580677b9065b6394ecbd",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipcc-rpath6.2.4/hipcc-rpath6.2.4_1.1.1.60204-139~20.04_amd64.deb",
-        "version": "1.1.1.60204-139"
+        "sha256": "d6448015bbb895b4169b26f97ce17cda779d7a55c216b5be2c171db5da75067a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipcc-rpath6.2.4-1.1.1.60204-139.el8.x86_64.rpm",
+        "version": "1.1.1.60204"
       }
     ],
-    "version": "1.1.1.60204-139"
+    "version": "1.1.1.60204"
   },
   "hipcc-nvidia": {
     "deps": [
-      "hip-dev",
+      "hip-devel",
       "rocm-core"
     ],
     "components": [
       {
         "name": "hipcc-nvidia",
-        "sha256": "594f1f175f985b14463fd4648b25cd461b41105b3597297eef93fd17291e4ca3",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipcc-nvidia/hipcc-nvidia_1.1.1.60204-139~20.04_amd64.deb",
-        "version": "1.1.1.60204-139"
+        "sha256": "6b02e6c9052aed124cfab0930b6cf4250ca6694c2145b776e80e847e7f22194a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipcc-nvidia-1.1.1.60204-139.el8.x86_64.rpm",
+        "version": "1.1.1.60204"
       },
       {
         "name": "hipcc-nvidia-rpath",
-        "sha256": "3091ac1205165b71b1251a76f169796e8e10e30a551b997bac7b87fab4871e7a",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipcc-nvidia-rpath6.2.4/hipcc-nvidia-rpath6.2.4_1.1.1.60204-139~20.04_amd64.deb",
-        "version": "1.1.1.60204-139"
+        "sha256": "58f3f977b007a0ad9acf123240214a185d6b1e603460a851e420ef6e63cfe48f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipcc-nvidia-rpath6.2.4-1.1.1.60204-139.el8.x86_64.rpm",
+        "version": "1.1.1.60204"
       }
     ],
-    "version": "1.1.1.60204-139"
+    "version": "1.1.1.60204"
   },
-  "hipcub-dev": {
+  "hipcub-devel": {
     "deps": [
       "rocm-core",
-      "rocprim-dev"
+      "rocprim-devel"
     ],
     "components": [
       {
-        "name": "hipcub-dev",
-        "sha256": "6f1a965613f1111d281ee4182712aae04be78f6a03f343f63ba76e25c7171ae9",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipcub-dev/hipcub-dev_3.2.1.60204-139~20.04_amd64.deb",
-        "version": "3.2.1.60204-139"
+        "name": "hipcub-devel",
+        "sha256": "ac9f953afe459628a5b207b93019af64c860fddb36b89f7534617a29cc14744b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipcub-devel-3.2.1.60204-139.el8.x86_64.rpm",
+        "version": "3.2.1.60204"
       },
       {
-        "name": "hipcub-dev-rpath",
-        "sha256": "6e40b55168c9e8d8d8a1b90c0338830b00a9690429565cbe06e5c7d840c58c49",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipcub-dev-rpath6.2.4/hipcub-dev-rpath6.2.4_3.2.1.60204-139~20.04_amd64.deb",
-        "version": "3.2.1.60204-139"
+        "name": "hipcub-devel-rpath",
+        "sha256": "4762d38d224424f032fa40a6bea267c03411755f76c0723991e851c513395ebc",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipcub-devel-rpath6.2.4-3.2.1.60204-139.el8.x86_64.rpm",
+        "version": "3.2.1.60204"
       }
     ],
-    "version": "3.2.1.60204-139"
+    "version": "3.2.1.60204"
   },
   "hipfft": {
     "deps": [
@@ -516,30 +660,30 @@
     "components": [
       {
         "name": "hipfft",
-        "sha256": "384d2013f46c4692da22eb4ebe309fbf05db828e225342d57c55418cbcd78495",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipfft/hipfft_1.0.16.60204-139~20.04_amd64.deb",
-        "version": "1.0.16.60204-139"
+        "sha256": "d3d7f96eacef288723eba3427497683a607c264f3f73a13b978ad12fbf1f8f3c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipfft-1.0.16.60204-139.el8.x86_64.rpm",
+        "version": "1.0.16.60204"
       },
       {
-        "name": "hipfft-dev",
-        "sha256": "ba7c9035eeb06d6596d8feefee9b8c762d0e5f27c7bd951b1c163f664cabe47a",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipfft-dev/hipfft-dev_1.0.16.60204-139~20.04_amd64.deb",
-        "version": "1.0.16.60204-139"
+        "name": "hipfft-devel",
+        "sha256": "b43fd8d3e559acbafe588feeec98ad9c62aa59f624cf577710a499cd18cbca19",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipfft-devel-1.0.16.60204-139.el8.x86_64.rpm",
+        "version": "1.0.16.60204"
       },
       {
-        "name": "hipfft-dev-rpath",
-        "sha256": "fd045a0c2239f9bb90d7ce6293403d8b408296d453f8e2c97e85d66f1ce8bd23",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipfft-dev-rpath6.2.4/hipfft-dev-rpath6.2.4_1.0.16.60204-139~20.04_amd64.deb",
-        "version": "1.0.16.60204-139"
+        "name": "hipfft-devel-rpath",
+        "sha256": "5273dee82259457f28772056bb9b99ce3b00cde94ae822f76d754971f97c1dad",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipfft-devel-rpath6.2.4-1.0.16.60204-139.el8.x86_64.rpm",
+        "version": "1.0.16.60204"
       },
       {
         "name": "hipfft-rpath",
-        "sha256": "edb5056a5f38e455d1e117c0fdf74659bf9f2767089f6e37489d81763c4f3981",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipfft-rpath6.2.4/hipfft-rpath6.2.4_1.0.16.60204-139~20.04_amd64.deb",
-        "version": "1.0.16.60204-139"
+        "sha256": "4d5f871e25572b402d79cd5b78743c9c902f01d5aecf155cb4703c9693298e9d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipfft-rpath6.2.4-1.0.16.60204-139.el8.x86_64.rpm",
+        "version": "1.0.16.60204"
       }
     ],
-    "version": "1.0.16.60204-139"
+    "version": "1.0.16.60204"
   },
   "hipfft-asan": {
     "deps": [
@@ -549,39 +693,67 @@
     "components": [
       {
         "name": "hipfft-asan",
-        "sha256": "0c442d7ab71e02a976dd06870d6ff2b08e42099b2de488de37eeeab928f48b33",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipfft-asan/hipfft-asan_1.0.16.60204-139~20.04_amd64.deb",
-        "version": "1.0.16.60204-139"
+        "sha256": "99871a30d4445879d68225bfa84c25493dcee8a4f4f76899cec5986f4eb82057",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipfft-asan-1.0.16.60204-139.el8.x86_64.rpm",
+        "version": "1.0.16.60204"
       },
       {
         "name": "hipfft-asan-rpath",
-        "sha256": "0f2ef19f3e8fcc2d0877d9ead88a9764ff20d20e97c696765debf5638d06aca7",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipfft-asan-rpath6.2.4/hipfft-asan-rpath6.2.4_1.0.16.60204-139~20.04_amd64.deb",
-        "version": "1.0.16.60204-139"
+        "sha256": "f1c39ffd03a7bc25940e32eecd7e902b6d56b1b350ac94e069b51dacf254fcc2",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipfft-asan-rpath6.2.4-1.0.16.60204-139.el8.x86_64.rpm",
+        "version": "1.0.16.60204"
       }
     ],
-    "version": "1.0.16.60204-139"
+    "version": "1.0.16.60204"
   },
-  "hipfort-dev": {
+  "hipfft-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hipfft-asan-rpath6.2.4-rpath",
+        "sha256": "60e7c81767bc7e0f0deed623fd02de24999a1c4f9b6fb4538a1a072acf68cfae",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipfft-asan-rpath6.2.4-rpath6.2.4-1.0.16.60204-139.el8.x86_64.rpm",
+        "version": "1.0.16.60204"
+      }
+    ],
+    "version": "1.0.16.60204"
+  },
+  "hipfft-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hipfft-asan6.2.4-rpath",
+        "sha256": "f67722377d995bab1480eaf7d38835adf68651130ef005aa501140fcd5e05d52",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipfft-asan6.2.4-rpath6.2.4-1.0.16.60204-139.el8.x86_64.rpm",
+        "version": "1.0.16.60204"
+      }
+    ],
+    "version": "1.0.16.60204"
+  },
+  "hipfort-devel": {
     "deps": [
       "hip-runtime-amd",
       "rocm-core"
     ],
     "components": [
       {
-        "name": "hipfort-dev",
-        "sha256": "41f381f81677d9543ef2e145f921c6f6511412e9eede68017814926164e2fa4d",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipfort-dev/hipfort-dev_0.4.0.60204-139~20.04_amd64.deb",
-        "version": "0.4.0.60204-139"
+        "name": "hipfort-devel",
+        "sha256": "4341b578423e1f071e813d9dc6d365bb719e71a9efb8ef7b60e593a556f2caac",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipfort-devel-0.4.0.60204-139.el8.x86_64.rpm",
+        "version": "0.4.0.60204"
       },
       {
-        "name": "hipfort-dev-rpath",
-        "sha256": "059ea4f0ec1d95754ee2a53ddc2a994151405832cec403042ddbc5aa14b55922",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipfort-dev-rpath6.2.4/hipfort-dev-rpath6.2.4_0.4.0.60204-139~20.04_amd64.deb",
-        "version": "0.4.0.60204-139"
+        "name": "hipfort-devel-rpath",
+        "sha256": "de73fbb0e97dd28bed32f7be59842454047d92e94752f38e11a040d34ce839ed",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipfort-devel-rpath6.2.4-0.4.0.60204-139.el8.x86_64.rpm",
+        "version": "0.4.0.60204"
       }
     ],
-    "version": "0.4.0.60204-139"
+    "version": "0.4.0.60204"
   },
   "hipify-clang": {
     "deps": [
@@ -590,18 +762,18 @@
     "components": [
       {
         "name": "hipify-clang",
-        "sha256": "c44a9b9cf4ff80036184de95d5da2f83d262a929adc0592abe59d594b3dfb718",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipify-clang/hipify-clang_18.0.0.60204-139~20.04_amd64.deb",
-        "version": "18.0.0.60204-139"
+        "sha256": "1ff2731979cfdbf7858efbee39a22829dbb396c8bdd0d8cda23edde21e1aba1b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipify-clang-18.0.0.60204-139.el8.x86_64.rpm",
+        "version": "18.0.0.60204"
       },
       {
         "name": "hipify-clang-rpath",
-        "sha256": "6d1f63da70538395bbeabe438d52e893ded60977ce46ce317865760092c9b787",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipify-clang-rpath6.2.4/hipify-clang-rpath6.2.4_18.0.0.60204-139~20.04_amd64.deb",
-        "version": "18.0.0.60204-139"
+        "sha256": "5a58855557cc98e5ae3c3d38a5897cfcbdbf8ec46034fe3f6e11d3dcc7ad9781",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipify-clang-rpath6.2.4-18.0.0.60204-139.el8.x86_64.rpm",
+        "version": "18.0.0.60204"
       }
     ],
-    "version": "18.0.0.60204-139"
+    "version": "18.0.0.60204"
   },
   "hiprand": {
     "deps": [
@@ -610,30 +782,30 @@
     "components": [
       {
         "name": "hiprand",
-        "sha256": "ac320e7485af0f4c692439d813c3124a727423a014e86ffc98d1ba208ce0c570",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hiprand/hiprand_2.11.1.60204-139~20.04_amd64.deb",
-        "version": "2.11.1.60204-139"
+        "sha256": "4845423f319c18bd5a388bf974bee20766c6b03e85980ab332fd9fd19b5b4dba",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hiprand-2.11.1.60204-139.el8.x86_64.rpm",
+        "version": "2.11.1.60204"
       },
       {
-        "name": "hiprand-dev",
-        "sha256": "8b45b8b60b75a1750090064242f20aaa6f7bef182f2c74b64882168df5e3a230",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hiprand-dev/hiprand-dev_2.11.1.60204-139~20.04_amd64.deb",
-        "version": "2.11.1.60204-139"
+        "name": "hiprand-devel",
+        "sha256": "f9c7290095f90a90383c4bd9b9c5c433366e64e69ab343f9d4907ae169fa64ec",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hiprand-devel-2.11.1.60204-139.el8.x86_64.rpm",
+        "version": "2.11.1.60204"
       },
       {
-        "name": "hiprand-dev-rpath",
-        "sha256": "7040baaf1848aa807f9cc409ced9d3f649756df662e7b1e65817360bbb8180fe",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hiprand-dev-rpath6.2.4/hiprand-dev-rpath6.2.4_2.11.1.60204-139~20.04_amd64.deb",
-        "version": "2.11.1.60204-139"
+        "name": "hiprand-devel-rpath",
+        "sha256": "17879268deedcb404a1f278e3f577dc1f1b3c918c957b45c9d465246d377e50b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hiprand-devel-rpath6.2.4-2.11.1.60204-139.el8.x86_64.rpm",
+        "version": "2.11.1.60204"
       },
       {
         "name": "hiprand-rpath",
-        "sha256": "33f1ad0aa4fe1be832c116284b4df923b2948e4c67a8c22d46093f3d1c16da73",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hiprand-rpath6.2.4/hiprand-rpath6.2.4_2.11.1.60204-139~20.04_amd64.deb",
-        "version": "2.11.1.60204-139"
+        "sha256": "ca0acead3df4f0b4fd00447613afa80025dd1dce0fdf4288a7b7591b9286232e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hiprand-rpath6.2.4-2.11.1.60204-139.el8.x86_64.rpm",
+        "version": "2.11.1.60204"
       }
     ],
-    "version": "2.11.1.60204-139"
+    "version": "2.11.1.60204"
   },
   "hiprand-asan": {
     "deps": [
@@ -642,18 +814,46 @@
     "components": [
       {
         "name": "hiprand-asan",
-        "sha256": "70dd7485a1c955c5eb7d00a2fc6d6770ab3195a3a2104067076c89b65896accd",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hiprand-asan/hiprand-asan_2.11.1.60204-139~20.04_amd64.deb",
-        "version": "2.11.1.60204-139"
+        "sha256": "d4e6ece89a73e3783a5bbf66f372daa22c9b6094ec4ec0d5d4aacc09fa907010",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hiprand-asan-2.11.1.60204-139.el8.x86_64.rpm",
+        "version": "2.11.1.60204"
       },
       {
         "name": "hiprand-asan-rpath",
-        "sha256": "cd64234c34ccd1185ba7589f03cc72fdc45cb83afdac7f3dc7abc3dd49dfcfcf",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hiprand-asan-rpath6.2.4/hiprand-asan-rpath6.2.4_2.11.1.60204-139~20.04_amd64.deb",
-        "version": "2.11.1.60204-139"
+        "sha256": "0ccc8c5fd649c26461347b1ed543443e892906dd15bfa1d74a421b70e601434f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hiprand-asan-rpath6.2.4-2.11.1.60204-139.el8.x86_64.rpm",
+        "version": "2.11.1.60204"
       }
     ],
-    "version": "2.11.1.60204-139"
+    "version": "2.11.1.60204"
+  },
+  "hiprand-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hiprand-asan-rpath6.2.4-rpath",
+        "sha256": "14c12c8fef55467795d70b5fb9a76a2515b899cbd3ed0f81e84664d91b8946d6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hiprand-asan-rpath6.2.4-rpath6.2.4-2.11.1.60204-139.el8.x86_64.rpm",
+        "version": "2.11.1.60204"
+      }
+    ],
+    "version": "2.11.1.60204"
+  },
+  "hiprand-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hiprand-asan6.2.4-rpath",
+        "sha256": "696ba394f7e6f4d91fa7089b2f9791be0dc230c0e351768032711acbe2eae206",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hiprand-asan6.2.4-rpath6.2.4-2.11.1.60204-139.el8.x86_64.rpm",
+        "version": "2.11.1.60204"
+      }
+    ],
+    "version": "2.11.1.60204"
   },
   "hipsolver": {
     "deps": [
@@ -665,30 +865,30 @@
     "components": [
       {
         "name": "hipsolver",
-        "sha256": "565787df794d55226cee56489780118e52ebd11b5d5f6450bc2223fb30fffd2c",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipsolver/hipsolver_2.2.0.60204-139~20.04_amd64.deb",
-        "version": "2.2.0.60204-139"
+        "sha256": "7f98865a6956ddd07b5340617962c394055ac8ab79d2531d217e3be060918088",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsolver-2.2.0.60204-139.el8.x86_64.rpm",
+        "version": "2.2.0.60204"
       },
       {
-        "name": "hipsolver-dev",
-        "sha256": "a3b7ebdba6803c8d512025ea134bb813e6a1b4d74c5f03baa1e73168c0c74413",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipsolver-dev/hipsolver-dev_2.2.0.60204-139~20.04_amd64.deb",
-        "version": "2.2.0.60204-139"
+        "name": "hipsolver-devel",
+        "sha256": "237ea7b6be5d1ca1dd9a6fc365f1229a22fcb2b048b99cd49dee90c0dacaf954",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsolver-devel-2.2.0.60204-139.el8.x86_64.rpm",
+        "version": "2.2.0.60204"
       },
       {
-        "name": "hipsolver-dev-rpath",
-        "sha256": "eb0b1681a928af196f2f78a3682c006ab0c1773e1b63ece2385c4397e82ff640",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipsolver-dev-rpath6.2.4/hipsolver-dev-rpath6.2.4_2.2.0.60204-139~20.04_amd64.deb",
-        "version": "2.2.0.60204-139"
+        "name": "hipsolver-devel-rpath",
+        "sha256": "78e6af3d30afa4d4ae927f8140a676f7ffddd26886a6b11970b2a37dc7dc83f6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsolver-devel-rpath6.2.4-2.2.0.60204-139.el8.x86_64.rpm",
+        "version": "2.2.0.60204"
       },
       {
         "name": "hipsolver-rpath",
-        "sha256": "d2572f280028906b588972f480b18ea280120a6a9eee8a1fc659c7d1675238a2",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipsolver-rpath6.2.4/hipsolver-rpath6.2.4_2.2.0.60204-139~20.04_amd64.deb",
-        "version": "2.2.0.60204-139"
+        "sha256": "0e1887ff127047ca97c66121cbb2e7d119101e7cafefe9627681c12b25fd9b53",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsolver-rpath6.2.4-2.2.0.60204-139.el8.x86_64.rpm",
+        "version": "2.2.0.60204"
       }
     ],
-    "version": "2.2.0.60204-139"
+    "version": "2.2.0.60204"
   },
   "hipsolver-asan": {
     "deps": [
@@ -700,18 +900,46 @@
     "components": [
       {
         "name": "hipsolver-asan",
-        "sha256": "afc731d0104e9e03317aa1c4ec8d1622785236e03a806e292f7a2bf3131de967",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipsolver-asan/hipsolver-asan_2.2.0.60204-139~20.04_amd64.deb",
-        "version": "2.2.0.60204-139"
+        "sha256": "9186e8f6fc071c0f7fa05948de2d53acdba82f95e33b95cffee81dbf0a796a24",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsolver-asan-2.2.0.60204-139.el8.x86_64.rpm",
+        "version": "2.2.0.60204"
       },
       {
         "name": "hipsolver-asan-rpath",
-        "sha256": "87af48e337a22562d42f40d5a6d17262f05c1674e43961a31908f5d792d5108f",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipsolver-asan-rpath6.2.4/hipsolver-asan-rpath6.2.4_2.2.0.60204-139~20.04_amd64.deb",
-        "version": "2.2.0.60204-139"
+        "sha256": "34215d6651ab3159092b9e368687b866339da208277a8ebfe14e893069814648",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsolver-asan-rpath6.2.4-2.2.0.60204-139.el8.x86_64.rpm",
+        "version": "2.2.0.60204"
       }
     ],
-    "version": "2.2.0.60204-139"
+    "version": "2.2.0.60204"
+  },
+  "hipsolver-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hipsolver-asan-rpath6.2.4-rpath",
+        "sha256": "5e8c386d86b87bedf6fb9e71897e2d77421e9b8fc34accf6b5f36c28c0923b34",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsolver-asan-rpath6.2.4-rpath6.2.4-2.2.0.60204-139.el8.x86_64.rpm",
+        "version": "2.2.0.60204"
+      }
+    ],
+    "version": "2.2.0.60204"
+  },
+  "hipsolver-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hipsolver-asan6.2.4-rpath",
+        "sha256": "b51c4d6f266f9e4aea56e9bb87977d90ea09e8b104192a1236c58dbc20583c9b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsolver-asan6.2.4-rpath6.2.4-2.2.0.60204-139.el8.x86_64.rpm",
+        "version": "2.2.0.60204"
+      }
+    ],
+    "version": "2.2.0.60204"
   },
   "hipsparse": {
     "deps": [
@@ -721,30 +949,30 @@
     "components": [
       {
         "name": "hipsparse",
-        "sha256": "61728f4d246e1fa986b258882d0181cf259d4268a1b7059adb8de4149c049798",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipsparse/hipsparse_3.1.1.60204-139~20.04_amd64.deb",
-        "version": "3.1.1.60204-139"
+        "sha256": "3cc5bf2a26d74b1c6d786485fb2a93f638d299e83eba43c04c99a29b79dabc43",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsparse-3.1.1.60204-139.el8.x86_64.rpm",
+        "version": "3.1.1.60204"
       },
       {
-        "name": "hipsparse-dev",
-        "sha256": "88913be306315734773a8a3f4972ce05f60a1d267d0604cb10deade14e59f6d6",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipsparse-dev/hipsparse-dev_3.1.1.60204-139~20.04_amd64.deb",
-        "version": "3.1.1.60204-139"
+        "name": "hipsparse-devel",
+        "sha256": "47293e76396c5acd17c43e11f8dc7e3663ccde0b7e685178058cab4c333d6325",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsparse-devel-3.1.1.60204-139.el8.x86_64.rpm",
+        "version": "3.1.1.60204"
       },
       {
-        "name": "hipsparse-dev-rpath",
-        "sha256": "3e97ece0d621276b57a195e6053c074524d3468b0f7c35e33b5dcbeeae326680",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipsparse-dev-rpath6.2.4/hipsparse-dev-rpath6.2.4_3.1.1.60204-139~20.04_amd64.deb",
-        "version": "3.1.1.60204-139"
+        "name": "hipsparse-devel-rpath",
+        "sha256": "efae0d4bc5a0473d37f9b768fcc227ea4a38937f781331620a11ae5350f01714",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsparse-devel-rpath6.2.4-3.1.1.60204-139.el8.x86_64.rpm",
+        "version": "3.1.1.60204"
       },
       {
         "name": "hipsparse-rpath",
-        "sha256": "48030c74f796c85aaf8af3a7014448f2a60c294f5ad403e993e40924787ecfac",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipsparse-rpath6.2.4/hipsparse-rpath6.2.4_3.1.1.60204-139~20.04_amd64.deb",
-        "version": "3.1.1.60204-139"
+        "sha256": "22f24327f96d30bd4b621ffd9a4f4a6c6f6123d112061f6b1d953036e7367cda",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsparse-rpath6.2.4-3.1.1.60204-139.el8.x86_64.rpm",
+        "version": "3.1.1.60204"
       }
     ],
-    "version": "3.1.1.60204-139"
+    "version": "3.1.1.60204"
   },
   "hipsparse-asan": {
     "deps": [
@@ -754,18 +982,46 @@
     "components": [
       {
         "name": "hipsparse-asan",
-        "sha256": "6c2a8d55e1723860c2e987990629656f056bb157198d296b09d184284d5d697c",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipsparse-asan/hipsparse-asan_3.1.1.60204-139~20.04_amd64.deb",
-        "version": "3.1.1.60204-139"
+        "sha256": "94a538ff8a9bf537689ad8e1df98b683fcc5627ff0fcfeb7cb95a27c200db987",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsparse-asan-3.1.1.60204-139.el8.x86_64.rpm",
+        "version": "3.1.1.60204"
       },
       {
         "name": "hipsparse-asan-rpath",
-        "sha256": "27eec2cf3c7f2942cba5ce895ae71dd68493cba123c514a1d9d957a163056eaf",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipsparse-asan-rpath6.2.4/hipsparse-asan-rpath6.2.4_3.1.1.60204-139~20.04_amd64.deb",
-        "version": "3.1.1.60204-139"
+        "sha256": "d150b0540b76a806204ac98359ea3e3718a8007b2235a05339345fffb91f5001",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsparse-asan-rpath6.2.4-3.1.1.60204-139.el8.x86_64.rpm",
+        "version": "3.1.1.60204"
       }
     ],
-    "version": "3.1.1.60204-139"
+    "version": "3.1.1.60204"
+  },
+  "hipsparse-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hipsparse-asan-rpath6.2.4-rpath",
+        "sha256": "27b7e4642e07b9fdc428cc02fbb4ea482f455ce361662a80c8fc39b01cf701c1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsparse-asan-rpath6.2.4-rpath6.2.4-3.1.1.60204-139.el8.x86_64.rpm",
+        "version": "3.1.1.60204"
+      }
+    ],
+    "version": "3.1.1.60204"
+  },
+  "hipsparse-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hipsparse-asan6.2.4-rpath",
+        "sha256": "2e541c6b179cbe65b91e573aa067eb59337dd54e639d36d22d45eb0bbf9b9322",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsparse-asan6.2.4-rpath6.2.4-3.1.1.60204-139.el8.x86_64.rpm",
+        "version": "3.1.1.60204"
+      }
+    ],
+    "version": "3.1.1.60204"
   },
   "hipsparselt": {
     "deps": [
@@ -775,30 +1031,30 @@
     "components": [
       {
         "name": "hipsparselt",
-        "sha256": "29aa6ae7294088f9dc4a44dc7cb6f00e61fbd991565108cf92798c3edc404065",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipsparselt/hipsparselt_0.2.1.60204-139~20.04_amd64.deb",
-        "version": "0.2.1.60204-139"
+        "sha256": "b7e5dd85ce186d3bc3d36e72c29d5d0bb2c72a7d4648cf2e28037deda58ed13c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsparselt-0.2.1.60204-139.el8.x86_64.rpm",
+        "version": "0.2.1.60204"
       },
       {
-        "name": "hipsparselt-dev",
-        "sha256": "a3186196b154e2db811bba2c8592c8c6ba14a3215ad9e35cfb6b600735a2b688",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipsparselt-dev/hipsparselt-dev_0.2.1.60204-139~20.04_amd64.deb",
-        "version": "0.2.1.60204-139"
+        "name": "hipsparselt-devel",
+        "sha256": "8fe963e7d5087370ab4d7e77700956e4eef0ba115111a3dd514f499c02ddfd10",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsparselt-devel-0.2.1.60204-139.el8.x86_64.rpm",
+        "version": "0.2.1.60204"
       },
       {
-        "name": "hipsparselt-dev-rpath",
-        "sha256": "c67df7439f299ae60080121202d65e16b56f91ab9ff5856440e3f2ab48362665",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipsparselt-dev-rpath6.2.4/hipsparselt-dev-rpath6.2.4_0.2.1.60204-139~20.04_amd64.deb",
-        "version": "0.2.1.60204-139"
+        "name": "hipsparselt-devel-rpath",
+        "sha256": "42e5f4d28e34f7d1a94a54cbd0c05ad97eafeba07004dba030b669adc9989eec",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsparselt-devel-rpath6.2.4-0.2.1.60204-139.el8.x86_64.rpm",
+        "version": "0.2.1.60204"
       },
       {
         "name": "hipsparselt-rpath",
-        "sha256": "9b08a7125ed2d832b7f1af61f1a24e7e875c5df37603a92c3e3ee1732781be08",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipsparselt-rpath6.2.4/hipsparselt-rpath6.2.4_0.2.1.60204-139~20.04_amd64.deb",
-        "version": "0.2.1.60204-139"
+        "sha256": "2a60ef44e9f78f8bbb6c99d6e434842fdb923a2ebdfe3ac11cd30769e5db4dbb",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsparselt-rpath6.2.4-0.2.1.60204-139.el8.x86_64.rpm",
+        "version": "0.2.1.60204"
       }
     ],
-    "version": "0.2.1.60204-139"
+    "version": "0.2.1.60204"
   },
   "hipsparselt-asan": {
     "deps": [
@@ -808,18 +1064,46 @@
     "components": [
       {
         "name": "hipsparselt-asan",
-        "sha256": "161962bc77bf7713f983d94fa13d091c2af205111c67050b4d86ccf52d354830",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipsparselt-asan/hipsparselt-asan_0.2.1.60204-139~20.04_amd64.deb",
-        "version": "0.2.1.60204-139"
+        "sha256": "be666a42633b870df15ec97a5a299385b7bafe40db5e572c4599815cbc5a7e4f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsparselt-asan-0.2.1.60204-139.el8.x86_64.rpm",
+        "version": "0.2.1.60204"
       },
       {
         "name": "hipsparselt-asan-rpath",
-        "sha256": "d0fb086df6b04166343fe62a7fea69032e7d35809b0c4f1975388abf3ec7c017",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hipsparselt-asan-rpath6.2.4/hipsparselt-asan-rpath6.2.4_0.2.1.60204-139~20.04_amd64.deb",
-        "version": "0.2.1.60204-139"
+        "sha256": "2c33b302ebe8e961dd1db83d947da95788beaf252535829859dc0c2809c2af43",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsparselt-asan-rpath6.2.4-0.2.1.60204-139.el8.x86_64.rpm",
+        "version": "0.2.1.60204"
       }
     ],
-    "version": "0.2.1.60204-139"
+    "version": "0.2.1.60204"
+  },
+  "hipsparselt-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hipsparselt-asan-rpath6.2.4-rpath",
+        "sha256": "6188131673a9e20c7238d738aecf628755656c2e100d0a34c6687bf3f53b363a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsparselt-asan-rpath6.2.4-rpath6.2.4-0.2.1.60204-139.el8.x86_64.rpm",
+        "version": "0.2.1.60204"
+      }
+    ],
+    "version": "0.2.1.60204"
+  },
+  "hipsparselt-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hipsparselt-asan6.2.4-rpath",
+        "sha256": "3e640c12ceddaaefd0cc55aab5942755e1c2133353d84df9e5ce5244b2a37c7e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hipsparselt-asan6.2.4-rpath6.2.4-0.2.1.60204-139.el8.x86_64.rpm",
+        "version": "0.2.1.60204"
+      }
+    ],
+    "version": "0.2.1.60204"
   },
   "hiptensor": {
     "deps": [
@@ -828,30 +1112,30 @@
     "components": [
       {
         "name": "hiptensor",
-        "sha256": "bf91710901bb35a5127809ebd904661aae5220bc0dc36fc2a75291e0efc85a8d",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hiptensor/hiptensor_1.3.0.60204-139~20.04_amd64.deb",
-        "version": "1.3.0.60204-139"
+        "sha256": "33bd5fff7a6c665e68f179b2469cf601529a43234c33dcc8c45f70ed7dc498bf",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hiptensor-1.3.0.60204-139.el8.x86_64.rpm",
+        "version": "1.3.0.60204"
       },
       {
-        "name": "hiptensor-dev",
-        "sha256": "5042c02797d5f541e134c6f36c631f5418f66c45641d6a2e5fb17c09d55ae841",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hiptensor-dev/hiptensor-dev_1.3.0.60204-139~20.04_amd64.deb",
-        "version": "1.3.0.60204-139"
+        "name": "hiptensor-devel",
+        "sha256": "b2b647f53991d9bcf8fcb9f210bba78df943353f6676723d38e4187f7685f61e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hiptensor-devel-1.3.0.60204-139.el8.x86_64.rpm",
+        "version": "1.3.0.60204"
       },
       {
-        "name": "hiptensor-dev-rpath",
-        "sha256": "498f0108c62963ae725fafe04db83af7e8a991a7bc976bb5da0bccbfebc48ec9",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hiptensor-dev-rpath6.2.4/hiptensor-dev-rpath6.2.4_1.3.0.60204-139~20.04_amd64.deb",
-        "version": "1.3.0.60204-139"
+        "name": "hiptensor-devel-rpath",
+        "sha256": "ca1d0b7231f5eb704590241a7014feef6cf40e2c830a4f0e3a64797752e92f2c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hiptensor-devel-rpath6.2.4-1.3.0.60204-139.el8.x86_64.rpm",
+        "version": "1.3.0.60204"
       },
       {
         "name": "hiptensor-rpath",
-        "sha256": "44fc9180e713de15eb354928fb6e2eded933012b245a3cd64c66aa8e63d44aea",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hiptensor-rpath6.2.4/hiptensor-rpath6.2.4_1.3.0.60204-139~20.04_amd64.deb",
-        "version": "1.3.0.60204-139"
+        "sha256": "06d58ddc7aeff43de629fdee89e53933dfa8c97c6146da2f4405a06ac91de35f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hiptensor-rpath6.2.4-1.3.0.60204-139.el8.x86_64.rpm",
+        "version": "1.3.0.60204"
       }
     ],
-    "version": "1.3.0.60204-139"
+    "version": "1.3.0.60204"
   },
   "hiptensor-asan": {
     "deps": [
@@ -860,18 +1144,46 @@
     "components": [
       {
         "name": "hiptensor-asan",
-        "sha256": "76c23224994190d214bb577c988bff5f5f3f464eb38c2a480c4be5dcdebfbe36",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hiptensor-asan/hiptensor-asan_1.3.0.60204-139~20.04_amd64.deb",
-        "version": "1.3.0.60204-139"
+        "sha256": "f23c7e054a19d502e7c6a2f10f67daeb7ade5597f76273c0e92fcddd9f324495",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hiptensor-asan-1.3.0.60204-139.el8.x86_64.rpm",
+        "version": "1.3.0.60204"
       },
       {
         "name": "hiptensor-asan-rpath",
-        "sha256": "97bc7c96f8bba43ffb06dafacb3bd772d9c59ce6a4060030b3c89b51859d3493",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hiptensor-asan-rpath6.2.4/hiptensor-asan-rpath6.2.4_1.3.0.60204-139~20.04_amd64.deb",
-        "version": "1.3.0.60204-139"
+        "sha256": "28b7b9d4887e7ae563a14786623806713bddce37799f2a6220c1b46d21801d5b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hiptensor-asan-rpath6.2.4-1.3.0.60204-139.el8.x86_64.rpm",
+        "version": "1.3.0.60204"
       }
     ],
-    "version": "1.3.0.60204-139"
+    "version": "1.3.0.60204"
+  },
+  "hiptensor-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hiptensor-asan-rpath6.2.4-rpath",
+        "sha256": "2db0305e90cb041a531b4499c6522aa909e434048cff4ed3fd3b7800280baaa7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hiptensor-asan-rpath6.2.4-rpath6.2.4-1.3.0.60204-139.el8.x86_64.rpm",
+        "version": "1.3.0.60204"
+      }
+    ],
+    "version": "1.3.0.60204"
+  },
+  "hiptensor-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hiptensor-asan6.2.4-rpath",
+        "sha256": "469b270498c4917c4c857b9b54e525dc45e15d6351595184fd1f79dc5aefee07",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hiptensor-asan6.2.4-rpath6.2.4-1.3.0.60204-139.el8.x86_64.rpm",
+        "version": "1.3.0.60204"
+      }
+    ],
+    "version": "1.3.0.60204"
   },
   "hsa-amd-aqlprofile": {
     "deps": [
@@ -880,18 +1192,18 @@
     "components": [
       {
         "name": "hsa-amd-aqlprofile",
-        "sha256": "614ad0c01b7f18eaa9e8a33fb73b9d8445c8785841ed41b406e129101dea854d",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hsa-amd-aqlprofile/hsa-amd-aqlprofile_1.0.0.60204.60204-139~20.04_amd64.deb",
-        "version": "1.0.0.60204.60204-139"
+        "sha256": "5125a32aac0a8e0659f6e043bfa99db0a8e0bef9ba3c0fc6899f02d63ac20bc2",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hsa-amd-aqlprofile-1.0.0.60204.60204-139.el8.x86_64.rpm",
+        "version": "1.0.0.60204.60204"
       },
       {
         "name": "hsa-amd-aqlprofile-rpath",
-        "sha256": "f30691acea587a39c20e6340ca824eb33a1da66737bc3ede4bdcaaafbaf88776",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hsa-amd-aqlprofile-rpath6.2.4/hsa-amd-aqlprofile-rpath6.2.4_1.0.0.60204.60204-139~20.04_amd64.deb",
-        "version": "1.0.0.60204.60204-139"
+        "sha256": "87d0bd404853c414da4f9f7932591cf89628cdbc1ab5772bf63f4d9255157848",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hsa-amd-aqlprofile-rpath6.2.4-1.0.0.60204.60204-139.el8.x86_64.rpm",
+        "version": "1.0.0.60204.60204"
       }
     ],
-    "version": "1.0.0.60204.60204-139"
+    "version": "1.0.0.60204.60204"
   },
   "hsa-amd-aqlprofile-asan": {
     "deps": [
@@ -900,52 +1212,80 @@
     "components": [
       {
         "name": "hsa-amd-aqlprofile-asan",
-        "sha256": "71cdb722227b5c86dd87d51ea0c82b015e13f3360c19ed6d9ce01eb313433b0d",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hsa-amd-aqlprofile-asan/hsa-amd-aqlprofile-asan_1.0.0.60204.60204-139~20.04_amd64.deb",
-        "version": "1.0.0.60204.60204-139"
+        "sha256": "a13dd9ee02d607cb1b09b06a7143b3726928a1b3422e1b2b78a123e4f8324c1e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hsa-amd-aqlprofile-asan-1.0.0.60204.60204-139.el8.x86_64.rpm",
+        "version": "1.0.0.60204.60204"
       },
       {
         "name": "hsa-amd-aqlprofile-asan-rpath",
-        "sha256": "26ec332ba24bfb718f50cc1ef090f59768f4b381b2dc2a02d0eed06d78bbd948",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hsa-amd-aqlprofile-asan-rpath6.2.4/hsa-amd-aqlprofile-asan-rpath6.2.4_1.0.0.60204.60204-139~20.04_amd64.deb",
-        "version": "1.0.0.60204.60204-139"
+        "sha256": "209f0bfe619cade2f78a89ef0d684acb91f122fa5d243806797347a7b88e957f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hsa-amd-aqlprofile-asan-rpath6.2.4-1.0.0.60204.60204-139.el8.x86_64.rpm",
+        "version": "1.0.0.60204.60204"
       }
     ],
-    "version": "1.0.0.60204.60204-139"
+    "version": "1.0.0.60204.60204"
+  },
+  "hsa-amd-aqlprofile-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hsa-amd-aqlprofile-asan-rpath6.2.4-rpath",
+        "sha256": "fa8e1cccace043f2dd195cf6e67616caa5ea7e44437bf9a69c1b071c49285949",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hsa-amd-aqlprofile-asan-rpath6.2.4-rpath6.2.4-1.0.0.60204.60204-139.el8.x86_64.rpm",
+        "version": "1.0.0.60204.60204"
+      }
+    ],
+    "version": "1.0.0.60204.60204"
+  },
+  "hsa-amd-aqlprofile-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hsa-amd-aqlprofile-asan6.2.4-rpath",
+        "sha256": "1d2f87392353b94642ec1fe324d73e6bc0ac33e9d058ddeaaf085cf846a8cf11",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hsa-amd-aqlprofile-asan6.2.4-rpath6.2.4-1.0.0.60204.60204-139.el8.x86_64.rpm",
+        "version": "1.0.0.60204.60204"
+      }
+    ],
+    "version": "1.0.0.60204.60204"
   },
   "hsa-rocr": {
     "deps": [
-      "hsakmt-roct-dev",
+      "hsakmt-roct-devel",
       "rocm-core",
       "rocprofiler-register"
     ],
     "components": [
       {
         "name": "hsa-rocr",
-        "sha256": "59ab1cfd95f205871b6e6cc8a7e72c7fb3ce001917f9ceab3b649bb9c4c32aac",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hsa-rocr/hsa-rocr_1.14.0.60204-139~20.04_amd64.deb",
-        "version": "1.14.0.60204-139"
+        "sha256": "418cc2a9c816e6d4c43740a7ce04c5b22ee35adaf4e4605ee93bec6b7c9ccda4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hsa-rocr-1.14.0.60204-139.el8.x86_64.rpm",
+        "version": "1.14.0.60204"
       },
       {
-        "name": "hsa-rocr-dev",
-        "sha256": "b0f194cf08b120df6ad245e80a95035e23bf48ee285341ec9bd87987cb75aa62",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hsa-rocr-dev/hsa-rocr-dev_1.14.0.60204-139~20.04_amd64.deb",
-        "version": "1.14.0.60204-139"
+        "name": "hsa-rocr-devel",
+        "sha256": "aadbfb105b3b1d1f7722aff15269cda7fe149e0d37c2bb2f7d72b39aa4f145b0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hsa-rocr-devel-1.14.0.60204-139.el8.x86_64.rpm",
+        "version": "1.14.0.60204"
       },
       {
-        "name": "hsa-rocr-dev-rpath",
-        "sha256": "06de83216ef865f50f0db04827cdeb0f10f5f0ea086ccbdd491a1dddc44e7fdc",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hsa-rocr-dev-rpath6.2.4/hsa-rocr-dev-rpath6.2.4_1.14.0.60204-139~20.04_amd64.deb",
-        "version": "1.14.0.60204-139"
+        "name": "hsa-rocr-devel-rpath",
+        "sha256": "7dea7f8c92837ea0a0e8580e958581b83eaccb1eeea29242956ee22ec34ff7c6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hsa-rocr-devel-rpath6.2.4-1.14.0.60204-139.el8.x86_64.rpm",
+        "version": "1.14.0.60204"
       },
       {
         "name": "hsa-rocr-rpath",
-        "sha256": "564d1c0d92d4fadcb9f5fd989f9fc34c9208e538c309040b682ffe2fb824024e",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hsa-rocr-rpath6.2.4/hsa-rocr-rpath6.2.4_1.14.0.60204-139~20.04_amd64.deb",
-        "version": "1.14.0.60204-139"
+        "sha256": "49b7bfb8ecdb5dd3727ae9c3ab3ef9f288ef91ee638ef2192b4d9c5541013ba4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hsa-rocr-rpath6.2.4-1.14.0.60204-139.el8.x86_64.rpm",
+        "version": "1.14.0.60204"
       }
     ],
-    "version": "1.14.0.60204-139"
+    "version": "1.14.0.60204"
   },
   "hsa-rocr-asan": {
     "deps": [
@@ -954,18 +1294,46 @@
     "components": [
       {
         "name": "hsa-rocr-asan",
-        "sha256": "061ab30331d56cd49a04c461ea3ac88d5a12d6e8ba5f16c110b64fae623662b4",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hsa-rocr-asan/hsa-rocr-asan_1.14.0.60204-139~20.04_amd64.deb",
-        "version": "1.14.0.60204-139"
+        "sha256": "12b0a1cb4c691694864d0edccd13dbf3af6feb4c7b3ab59f7f8dea1c77766ec0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hsa-rocr-asan-1.14.0.60204-139.el8.x86_64.rpm",
+        "version": "1.14.0.60204"
       },
       {
         "name": "hsa-rocr-asan-rpath",
-        "sha256": "e8bd579d78c23e95c6dff21b909c5d7b2a5292bd55dc3748705e0783f01660eb",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hsa-rocr-asan-rpath6.2.4/hsa-rocr-asan-rpath6.2.4_1.14.0.60204-139~20.04_amd64.deb",
-        "version": "1.14.0.60204-139"
+        "sha256": "1dcb27ffc6102804c62d4d522eb59f07e1a1858af585fa81f042088a61f73001",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hsa-rocr-asan-rpath6.2.4-1.14.0.60204-139.el8.x86_64.rpm",
+        "version": "1.14.0.60204"
       }
     ],
-    "version": "1.14.0.60204-139"
+    "version": "1.14.0.60204"
+  },
+  "hsa-rocr-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hsa-rocr-asan-rpath6.2.4-rpath",
+        "sha256": "ce03863f65f7bb13bad3ba725aef7fe7bac39f283e9531784375085f7359fb55",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hsa-rocr-asan-rpath6.2.4-rpath6.2.4-1.14.0.60204-139.el8.x86_64.rpm",
+        "version": "1.14.0.60204"
+      }
+    ],
+    "version": "1.14.0.60204"
+  },
+  "hsa-rocr-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hsa-rocr-asan6.2.4-rpath",
+        "sha256": "f71738bafd6d94ff8a742f5aedff0421d5e73388a4e0c5d8519e12357402ee4d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hsa-rocr-asan6.2.4-rpath6.2.4-1.14.0.60204-139.el8.x86_64.rpm",
+        "version": "1.14.0.60204"
+      }
+    ],
+    "version": "1.14.0.60204"
   },
   "hsakmt-roct-asan": {
     "deps": [
@@ -974,43 +1342,71 @@
     "components": [
       {
         "name": "hsakmt-roct-asan",
-        "sha256": "656afc617c413166c050ab8864e3ad626f6b0a180d875e7e2de71d34036f2dfb",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hsakmt-roct-asan/hsakmt-roct-asan_20240607.5.7.60204-139~20.04_amd64.deb",
-        "version": "20240607.5.7.60204-139"
+        "sha256": "93ab909fcc4bb8497be348e0fb09a59bbf27470c0f4675a0b0c72f2994dc6dc8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hsakmt-roct-asan-20240607.5.7.60204-139.el8.x86_64.rpm",
+        "version": "20240607.5.7.60204"
       },
       {
         "name": "hsakmt-roct-asan-rpath",
-        "sha256": "d5ff467289f5d5aab89807d1bc04f879f38267cbcb56175d20a7f0ca8d05c3e0",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hsakmt-roct-asan-rpath6.2.4/hsakmt-roct-asan-rpath6.2.4_20240607.5.7.60204-139~20.04_amd64.deb",
-        "version": "20240607.5.7.60204-139"
+        "sha256": "b557c6f6c28c5368dc9ac3520703e93ed89bc2502e8cfceca60d545fe4ab5123",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hsakmt-roct-asan-rpath6.2.4-20240607.5.7.60204-139.el8.x86_64.rpm",
+        "version": "20240607.5.7.60204"
       }
     ],
-    "version": "20240607.5.7.60204-139"
+    "version": "20240607.5.7.60204"
   },
-  "hsakmt-roct-dev": {
+  "hsakmt-roct-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hsakmt-roct-asan-rpath6.2.4-rpath",
+        "sha256": "bb360c92f42928754d9aaa53fe165db652c60c1baeebad033c432f4142fa0b84",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hsakmt-roct-asan-rpath6.2.4-rpath6.2.4-20240607.5.7.60204-139.el8.x86_64.rpm",
+        "version": "20240607.5.7.60204"
+      }
+    ],
+    "version": "20240607.5.7.60204"
+  },
+  "hsakmt-roct-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "hsakmt-roct-asan6.2.4-rpath",
+        "sha256": "74e93edd246e8a5299f58017835ed94ef86f997173dba62fc5496e4def62fb92",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hsakmt-roct-asan6.2.4-rpath6.2.4-20240607.5.7.60204-139.el8.x86_64.rpm",
+        "version": "20240607.5.7.60204"
+      }
+    ],
+    "version": "20240607.5.7.60204"
+  },
+  "hsakmt-roct-devel": {
     "deps": [
       "rocm-core"
     ],
     "components": [
       {
-        "name": "hsakmt-roct-dev",
-        "sha256": "e57cb2e1104726cf0705a4b83c7440f50d91397134af39791a5691f43ad09b42",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hsakmt-roct-dev/hsakmt-roct-dev_20240607.5.7.60204-139~20.04_amd64.deb",
-        "version": "20240607.5.7.60204-139"
+        "name": "hsakmt-roct-devel",
+        "sha256": "d040f420cd669b17d493c8b61a9ade9374f5366951bab8e90ee33ff1c8dc0660",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hsakmt-roct-devel-20240607.5.7.60204-139.el8.x86_64.rpm",
+        "version": "20240607.5.7.60204"
       },
       {
-        "name": "hsakmt-roct-dev-rpath",
-        "sha256": "1f18c7a86b2a7cdb2e711e5f2d02e39e30aa2cd84cd82cc15eed1dbcf0e6ea3d",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/h/hsakmt-roct-dev-rpath6.2.4/hsakmt-roct-dev-rpath6.2.4_20240607.5.7.60204-139~20.04_amd64.deb",
-        "version": "20240607.5.7.60204-139"
+        "name": "hsakmt-roct-devel-rpath",
+        "sha256": "a43eb59257f392fc30fe5e4f4c8d062edd420c14f3f4884f46ba8a100bd02f74",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/hsakmt-roct-devel-rpath6.2.4-20240607.5.7.60204-139.el8.x86_64.rpm",
+        "version": "20240607.5.7.60204"
       }
     ],
-    "version": "20240607.5.7.60204-139"
+    "version": "20240607.5.7.60204"
   },
   "migraphx": {
     "deps": [
       "half",
-      "hip-dev",
+      "hip-devel",
       "hip-runtime-amd",
       "miopen-hip",
       "rocblas",
@@ -1019,35 +1415,35 @@
     "components": [
       {
         "name": "migraphx",
-        "sha256": "674a817970e301642744afb9a9b5006b606ef3ef96f32e6d378973f3a3ce63fd",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/migraphx/migraphx_2.10.0.60204-139~20.04_amd64.deb",
-        "version": "2.10.0.60204-139"
+        "sha256": "f66a16d03187e95ead1ff9eae37d2d1d33de7eb7b00ea87d113ce9afddd5b6bc",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/migraphx-2.10.0.60204-139.el8.x86_64.rpm",
+        "version": "2.10.0.60204"
       },
       {
-        "name": "migraphx-dev",
-        "sha256": "5d7bee3753c106404f3427f27d740b330ee376ab4ab14405f6df2a012519cbe8",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/migraphx-dev/migraphx-dev_2.10.0.60204-139~20.04_amd64.deb",
-        "version": "2.10.0.60204-139"
+        "name": "migraphx-devel",
+        "sha256": "23927ea9da3d11345e2ced5cdf7b3c7a4d3af15b009c82fbaf33da12e5ea9a58",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/migraphx-devel-2.10.0.60204-139.el8.x86_64.rpm",
+        "version": "2.10.0.60204"
       },
       {
-        "name": "migraphx-dev-rpath",
-        "sha256": "58c803373019f80b4d317e4f5fcca875c62504bdc6b089d0766bc06a76344549",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/migraphx-dev-rpath6.2.4/migraphx-dev-rpath6.2.4_2.10.0.60204-139~20.04_amd64.deb",
-        "version": "2.10.0.60204-139"
+        "name": "migraphx-devel-rpath",
+        "sha256": "f4b0caf0e2c904b39391bd71b2adddd1ca29074f4faf9b7381f0c2fb2d66e55e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/migraphx-devel-rpath6.2.4-2.10.0.60204-139.el8.x86_64.rpm",
+        "version": "2.10.0.60204"
       },
       {
         "name": "migraphx-rpath",
-        "sha256": "74cb2150eb3b5c501e13604072d7799da8e3258e3e0a4d651fef0c40597b0f20",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/migraphx-rpath6.2.4/migraphx-rpath6.2.4_2.10.0.60204-139~20.04_amd64.deb",
-        "version": "2.10.0.60204-139"
+        "sha256": "4d557d7055cabddbccad480dca06d5d8f68d1235fa678b8659b738e6a986e2d1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/migraphx-rpath6.2.4-2.10.0.60204-139.el8.x86_64.rpm",
+        "version": "2.10.0.60204"
       }
     ],
-    "version": "2.10.0.60204-139"
+    "version": "2.10.0.60204"
   },
   "migraphx-asan": {
     "deps": [
       "half",
-      "hip-dev",
+      "hip-devel",
       "hip-runtime-amd",
       "miopen-hip",
       "rocblas",
@@ -1056,18 +1452,46 @@
     "components": [
       {
         "name": "migraphx-asan",
-        "sha256": "a3ec97b94338b47b8a014e474248ed13187f0a05d86345988169b7b7d1bca9c5",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/migraphx-asan/migraphx-asan_2.10.0.60204-139~20.04_amd64.deb",
-        "version": "2.10.0.60204-139"
+        "sha256": "5902db0c089a94555dd6a6a22d139f5345e08daebf3978d0c41238f3846d9b01",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/migraphx-asan-2.10.0.60204-139.el8.x86_64.rpm",
+        "version": "2.10.0.60204"
       },
       {
         "name": "migraphx-asan-rpath",
-        "sha256": "1953220153959081d86e39d50b1694760bb3789e84114d6cf1523bcc015eda4f",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/migraphx-asan-rpath6.2.4/migraphx-asan-rpath6.2.4_2.10.0.60204-139~20.04_amd64.deb",
-        "version": "2.10.0.60204-139"
+        "sha256": "57d7761db433253d5041959d7e9d8a35174df0733643c196200035cc9bbac425",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/migraphx-asan-rpath6.2.4-2.10.0.60204-139.el8.x86_64.rpm",
+        "version": "2.10.0.60204"
       }
     ],
-    "version": "2.10.0.60204-139"
+    "version": "2.10.0.60204"
+  },
+  "migraphx-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "migraphx-asan-rpath6.2.4-rpath",
+        "sha256": "04d919a9cb3c365fc3d6fe3a9bb5bfa2bb4b31d71a657efc8d43f40ada1c925c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/migraphx-asan-rpath6.2.4-rpath6.2.4-2.10.0.60204-139.el8.x86_64.rpm",
+        "version": "2.10.0.60204"
+      }
+    ],
+    "version": "2.10.0.60204"
+  },
+  "migraphx-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "migraphx-asan6.2.4-rpath",
+        "sha256": "437399a817b2ad81e895fb3d46efac39a036ed3bd389efb9ec829601bdfb64d0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/migraphx-asan6.2.4-rpath6.2.4-2.10.0.60204-139.el8.x86_64.rpm",
+        "version": "2.10.0.60204"
+      }
+    ],
+    "version": "2.10.0.60204"
   },
   "miopen-hip": {
     "deps": [
@@ -1081,30 +1505,30 @@
     "components": [
       {
         "name": "miopen-hip",
-        "sha256": "e10d1e9292153b9e6ce0719ddeeb52eb00750be6a500974cc45b31f7e9bd4811",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/miopen-hip/miopen-hip_3.2.0.60204-139~20.04_amd64.deb",
-        "version": "3.2.0.60204-139"
+        "sha256": "ca54cd6e2e05117494c17b8e6160a412a3fc931a4e524f997e1a6e0943453636",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/miopen-hip-3.2.0.60204-139.el8.x86_64.rpm",
+        "version": "3.2.0.60204"
       },
       {
-        "name": "miopen-hip-dev",
-        "sha256": "886a77bb1c53199008accf536795634405efa4d0b22e04e772b16f7bbbfe07bc",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/miopen-hip-dev/miopen-hip-dev_3.2.0.60204-139~20.04_amd64.deb",
-        "version": "3.2.0.60204-139"
+        "name": "miopen-hip-devel",
+        "sha256": "3e368b3fa80fc0f5804c1b7888637190d5625ddcbf0ddc35d5f0e61791fd86c4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/miopen-hip-devel-3.2.0.60204-139.el8.x86_64.rpm",
+        "version": "3.2.0.60204"
       },
       {
-        "name": "miopen-hip-dev-rpath",
-        "sha256": "b11c594c6df12e96a1750f5b9845dc5a43da98ccb40f0dbafc8db3f7446b7db8",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/miopen-hip-dev-rpath6.2.4/miopen-hip-dev-rpath6.2.4_3.2.0.60204-139~20.04_amd64.deb",
-        "version": "3.2.0.60204-139"
+        "name": "miopen-hip-devel-rpath",
+        "sha256": "d86baf0a5fa815a78162fa3cd6d5fb512e0909be22af0205f54cce8993f263b0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/miopen-hip-devel-rpath6.2.4-3.2.0.60204-139.el8.x86_64.rpm",
+        "version": "3.2.0.60204"
       },
       {
         "name": "miopen-hip-rpath",
-        "sha256": "d8f103ba8a1396559212a977c5c50e235d4a3c1266246293763e3ebd7f1e784e",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/miopen-hip-rpath6.2.4/miopen-hip-rpath6.2.4_3.2.0.60204-139~20.04_amd64.deb",
-        "version": "3.2.0.60204-139"
+        "sha256": "b60cf25151f91fe54ed41bdd1a775807829ca0960442673fd2dc518af2a0072a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/miopen-hip-rpath6.2.4-3.2.0.60204-139.el8.x86_64.rpm",
+        "version": "3.2.0.60204"
       }
     ],
-    "version": "3.2.0.60204-139"
+    "version": "3.2.0.60204"
   },
   "miopen-hip-asan": {
     "deps": [
@@ -1119,18 +1543,48 @@
     "components": [
       {
         "name": "miopen-hip-asan",
-        "sha256": "c5edc613ea01dd3a80978a4f8c3b5c9517e676c2a3938d0d5e1eb30800d9fbea",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/miopen-hip-asan/miopen-hip-asan_3.2.0.60204-139~20.04_amd64.deb",
-        "version": "3.2.0.60204-139"
+        "sha256": "e1c7951e4039d291d272f5a9f2a030cdd080ec726b52a997e9b53e638d96b752",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/miopen-hip-asan-3.2.0.60204-139.el8.x86_64.rpm",
+        "version": "3.2.0.60204"
       },
       {
         "name": "miopen-hip-asan-rpath",
-        "sha256": "b606e4ceb5569bbb77cde67870e12681d735546492ad52ad204cfc4e6ea25ace",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/miopen-hip-asan-rpath6.2.4/miopen-hip-asan-rpath6.2.4_3.2.0.60204-139~20.04_amd64.deb",
-        "version": "3.2.0.60204-139"
+        "sha256": "52d370d4ee4271d6d46314ff89ad6c4e81e969ad444c7141be6243c37183148e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/miopen-hip-asan-rpath6.2.4-3.2.0.60204-139.el8.x86_64.rpm",
+        "version": "3.2.0.60204"
       }
     ],
-    "version": "3.2.0.60204-139"
+    "version": "3.2.0.60204"
+  },
+  "miopen-hip-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "hip-runtime-amd-asan-rpath6.2.4-rpath",
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "miopen-hip-asan-rpath6.2.4-rpath",
+        "sha256": "d50f685a62b5c73bb64a6a4cbd5377fceea63f27fa1fec00ff2e34fefff11ffa",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/miopen-hip-asan-rpath6.2.4-rpath6.2.4-3.2.0.60204-139.el8.x86_64.rpm",
+        "version": "3.2.0.60204"
+      }
+    ],
+    "version": "3.2.0.60204"
+  },
+  "miopen-hip-asan6.2.4-rpath": {
+    "deps": [
+      "hip-runtime-amd-asan6.2.4-rpath",
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "miopen-hip-asan6.2.4-rpath",
+        "sha256": "585fc56909ef54a0a37cf8f61386fce59d4e816a4913c163f98d16b0fbf28fea",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/miopen-hip-asan6.2.4-rpath6.2.4-3.2.0.60204-139.el8.x86_64.rpm",
+        "version": "3.2.0.60204"
+      }
+    ],
+    "version": "3.2.0.60204"
   },
   "miopen-hip-client": {
     "deps": [
@@ -1144,18 +1598,18 @@
     "components": [
       {
         "name": "miopen-hip-client",
-        "sha256": "2ececbc1872ea1afb8d7c89440bab1a951351cc6ffe68b0bd4f2feddb097f183",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/miopen-hip-client/miopen-hip-client_3.2.0.60204-139~20.04_amd64.deb",
-        "version": "3.2.0.60204-139"
+        "sha256": "054675cf0d76449800c5744c02cae9dcea5ea695d90682d0cd0fbf8ac51aea39",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/miopen-hip-client-3.2.0.60204-139.el8.x86_64.rpm",
+        "version": "3.2.0.60204"
       },
       {
         "name": "miopen-hip-client-rpath",
-        "sha256": "07184cd55f8b4adea39794d76b54ad63d427f1b94e03204317f3431f50ed98a6",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/miopen-hip-client-rpath6.2.4/miopen-hip-client-rpath6.2.4_3.2.0.60204-139~20.04_amd64.deb",
-        "version": "3.2.0.60204-139"
+        "sha256": "009db2c5c4a410596de2ec95e6ed1ea5581203df7195585d87af9c61e1edb37f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/miopen-hip-client-rpath6.2.4-3.2.0.60204-139.el8.x86_64.rpm",
+        "version": "3.2.0.60204"
       }
     ],
-    "version": "3.2.0.60204-139"
+    "version": "3.2.0.60204"
   },
   "miopen-hip-gfx1030kdb": {
     "deps": [
@@ -1169,18 +1623,18 @@
     "components": [
       {
         "name": "miopen-hip-gfx1030kdb",
-        "sha256": "2552fccadac411486d6834cdf29f8620a1ce6ab694adfa6ed22aa5a79c169648",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/miopen-hip-gfx1030kdb/miopen-hip-gfx1030kdb_3.2.0.60204-139~20.04_amd64.deb",
-        "version": "3.2.0.60204-139"
+        "sha256": "1534f20ec4e482e654060a8bce99fadf9c3de79983f779a803c8ebf66da3b2d5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/miopen-hip-gfx1030kdb-3.2.0.60204-139.el8.x86_64.rpm",
+        "version": "3.2.0.60204"
       },
       {
         "name": "miopen-hip-gfx1030kdb-rpath",
-        "sha256": "b1a23485004cdf15bb77f84e44b7e651fe9f92635a9bee4e848db971a2d72d5e",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/miopen-hip-gfx1030kdb-rpath6.2.4/miopen-hip-gfx1030kdb-rpath6.2.4_3.2.0.60204-139~20.04_amd64.deb",
-        "version": "3.2.0.60204-139"
+        "sha256": "630d13e1b4f854dc7509572121cabcd40acf75470656a834add3f60272b6f654",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/miopen-hip-gfx1030kdb-rpath6.2.4-3.2.0.60204-139.el8.x86_64.rpm",
+        "version": "3.2.0.60204"
       }
     ],
-    "version": "3.2.0.60204-139"
+    "version": "3.2.0.60204"
   },
   "miopen-hip-gfx900kdb": {
     "deps": [
@@ -1194,18 +1648,18 @@
     "components": [
       {
         "name": "miopen-hip-gfx900kdb",
-        "sha256": "b8f40a0c1033c15f4c45010add2ea03c7b6e1f4050ead668ae20a55b5fdf4c05",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/miopen-hip-gfx900kdb/miopen-hip-gfx900kdb_3.2.0.60204-139~20.04_amd64.deb",
-        "version": "3.2.0.60204-139"
+        "sha256": "476f5d15ce31796ce315270003af282319daa700dac59f6578280128ee41b94e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/miopen-hip-gfx900kdb-3.2.0.60204-139.el8.x86_64.rpm",
+        "version": "3.2.0.60204"
       },
       {
         "name": "miopen-hip-gfx900kdb-rpath",
-        "sha256": "8cd6b11bff78c9170c205726c885ebf0335e78b92277eb84e5f0d23087b1f9fb",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/miopen-hip-gfx900kdb-rpath6.2.4/miopen-hip-gfx900kdb-rpath6.2.4_3.2.0.60204-139~20.04_amd64.deb",
-        "version": "3.2.0.60204-139"
+        "sha256": "f04a1dcc9d7661835c5ebccfa58fa65baefed6ec3b8db82f5ac188c6ddb88f2f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/miopen-hip-gfx900kdb-rpath6.2.4-3.2.0.60204-139.el8.x86_64.rpm",
+        "version": "3.2.0.60204"
       }
     ],
-    "version": "3.2.0.60204-139"
+    "version": "3.2.0.60204"
   },
   "miopen-hip-gfx906kdb": {
     "deps": [
@@ -1219,18 +1673,18 @@
     "components": [
       {
         "name": "miopen-hip-gfx906kdb",
-        "sha256": "5d55ed270a12bb5ab1b1caf327d4d8c0560a16a01cc26f50dc60da38b511a6c9",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/miopen-hip-gfx906kdb/miopen-hip-gfx906kdb_3.2.0.60204-139~20.04_amd64.deb",
-        "version": "3.2.0.60204-139"
+        "sha256": "cbc8a689e86c8e3f74852abdf9147a290130496c48b4e830ce28b607e0639001",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/miopen-hip-gfx906kdb-3.2.0.60204-139.el8.x86_64.rpm",
+        "version": "3.2.0.60204"
       },
       {
         "name": "miopen-hip-gfx906kdb-rpath",
-        "sha256": "a4055c756bd4214743b6036f8ec4d8e434b9d33854204029626ee163b089a5fc",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/miopen-hip-gfx906kdb-rpath6.2.4/miopen-hip-gfx906kdb-rpath6.2.4_3.2.0.60204-139~20.04_amd64.deb",
-        "version": "3.2.0.60204-139"
+        "sha256": "9079912551dfff6d5f6c7b3191164d27acc7c5195d33aa5d018f62361009a18f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/miopen-hip-gfx906kdb-rpath6.2.4-3.2.0.60204-139.el8.x86_64.rpm",
+        "version": "3.2.0.60204"
       }
     ],
-    "version": "3.2.0.60204-139"
+    "version": "3.2.0.60204"
   },
   "miopen-hip-gfx908kdb": {
     "deps": [
@@ -1244,18 +1698,18 @@
     "components": [
       {
         "name": "miopen-hip-gfx908kdb",
-        "sha256": "d2afbcb9541fb7dfce49bf50996a53e32621992d75e9f064ac8faf647ce14283",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/miopen-hip-gfx908kdb/miopen-hip-gfx908kdb_3.2.0.60204-139~20.04_amd64.deb",
-        "version": "3.2.0.60204-139"
+        "sha256": "810766b55adb9cff474f9c12b0ea34c14fae83cde2c7e9b05a32c9b43810fc52",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/miopen-hip-gfx908kdb-3.2.0.60204-139.el8.x86_64.rpm",
+        "version": "3.2.0.60204"
       },
       {
         "name": "miopen-hip-gfx908kdb-rpath",
-        "sha256": "80b4bf944c45c14ddac5637c1678a787d47c52f779d6c17105df255b5870c9c6",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/miopen-hip-gfx908kdb-rpath6.2.4/miopen-hip-gfx908kdb-rpath6.2.4_3.2.0.60204-139~20.04_amd64.deb",
-        "version": "3.2.0.60204-139"
+        "sha256": "dde64bec5354b09967bf891726d4b46591a7620030b3c4d4a3e20d1adaeee335",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/miopen-hip-gfx908kdb-rpath6.2.4-3.2.0.60204-139.el8.x86_64.rpm",
+        "version": "3.2.0.60204"
       }
     ],
-    "version": "3.2.0.60204-139"
+    "version": "3.2.0.60204"
   },
   "miopen-hip-gfx90akdb": {
     "deps": [
@@ -1269,18 +1723,18 @@
     "components": [
       {
         "name": "miopen-hip-gfx90akdb",
-        "sha256": "890ac113a615d5a459caca76ea2b799014af0518b047850e64a4729219c16491",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/miopen-hip-gfx90akdb/miopen-hip-gfx90akdb_3.2.0.60204-139~20.04_amd64.deb",
-        "version": "3.2.0.60204-139"
+        "sha256": "d091cad75ebcf2114fe53b5fe07ce8d928126ceb4efff421fb77aa5869c87eb9",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/miopen-hip-gfx90akdb-3.2.0.60204-139.el8.x86_64.rpm",
+        "version": "3.2.0.60204"
       },
       {
         "name": "miopen-hip-gfx90akdb-rpath",
-        "sha256": "05bf13555812777ca911d2c2e67ebd9e39b4f55af4280aad1939b64312cf3f28",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/miopen-hip-gfx90akdb-rpath6.2.4/miopen-hip-gfx90akdb-rpath6.2.4_3.2.0.60204-139~20.04_amd64.deb",
-        "version": "3.2.0.60204-139"
+        "sha256": "944067f5e89c1dddcba309b927aba369a7070d3407f571c3aecac419f5541475",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/miopen-hip-gfx90akdb-rpath6.2.4-3.2.0.60204-139.el8.x86_64.rpm",
+        "version": "3.2.0.60204"
       }
     ],
-    "version": "3.2.0.60204-139"
+    "version": "3.2.0.60204"
   },
   "mivisionx": {
     "deps": [
@@ -1296,30 +1750,30 @@
     "components": [
       {
         "name": "mivisionx",
-        "sha256": "d70f0d2c3a48655be1e080b97d808374d52d859b1f4be8f0aec3bcf24df2f7b1",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/mivisionx/mivisionx_3.0.0.60204-139~20.04_amd64.deb",
-        "version": "3.0.0.60204-139"
+        "sha256": "ac6114a7c5c916680566a54a97e74d25f0601c613eff72a4cbbd6ea7c0ba95d1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/mivisionx-3.0.0.60204-139.x86_64.rpm",
+        "version": "3.0.0.60204"
       },
       {
-        "name": "mivisionx-dev",
-        "sha256": "9ec447d967e57d1e5f4c16ce4bd31b00cb9e62da4a4957ce6cbe77b72da1f656",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/mivisionx-dev/mivisionx-dev_3.0.0.60204-139~20.04_amd64.deb",
-        "version": "3.0.0.60204-139"
+        "name": "mivisionx-devel",
+        "sha256": "c40ceff60971f4def69dd6a651a70ac7824a368f43f040cc8823895b8674ee50",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/mivisionx-devel-3.0.0.60204-139.x86_64.rpm",
+        "version": "3.0.0.60204"
       },
       {
-        "name": "mivisionx-dev-rpath",
-        "sha256": "f65797c8dd59eadee70be1d227401d618deded8c92c01b37b82f099805d60015",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/mivisionx-dev-rpath6.2.4/mivisionx-dev-rpath6.2.4_3.0.0.60204-139~20.04_amd64.deb",
-        "version": "3.0.0.60204-139"
+        "name": "mivisionx-devel-rpath",
+        "sha256": "c0a1309ff47e3170b782a0ed8b040903356870f261643145430160291792dbf2",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/mivisionx-devel-rpath6.2.4-3.0.0.60204-139.x86_64.rpm",
+        "version": "3.0.0.60204"
       },
       {
         "name": "mivisionx-rpath",
-        "sha256": "1c92b45cc3a9aee258367b61c9f8b4cab02a8214c27285ce0fb77667cb8dc2b9",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/mivisionx-rpath6.2.4/mivisionx-rpath6.2.4_3.0.0.60204-139~20.04_amd64.deb",
-        "version": "3.0.0.60204-139"
+        "sha256": "33fd615362c429bea981d2e807d463827461bb16d573d549e467b3156375fc1c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/mivisionx-rpath6.2.4-3.0.0.60204-139.x86_64.rpm",
+        "version": "3.0.0.60204"
       }
     ],
-    "version": "3.0.0.60204-139"
+    "version": "3.0.0.60204"
   },
   "mivisionx-asan": {
     "deps": [
@@ -1335,18 +1789,46 @@
     "components": [
       {
         "name": "mivisionx-asan",
-        "sha256": "2c9b639043cbe29e12a5b7826fc8aecb6f743c95c0210b43585a01fd3ee938ee",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/mivisionx-asan/mivisionx-asan_3.0.0.60204-139~20.04_amd64.deb",
-        "version": "3.0.0.60204-139"
+        "sha256": "e57a9e7a05efd55f8f6ffa81d0d2bdccf2c1bf6c25764f7a49402e181d9b0e56",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/mivisionx-asan-3.0.0.60204-139.x86_64.rpm",
+        "version": "3.0.0.60204"
       },
       {
         "name": "mivisionx-asan-rpath",
-        "sha256": "2a1be855bb05315776cfbb48d533db3c5b90c1219b7a8f272163a4ff110b4cb0",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/mivisionx-asan-rpath6.2.4/mivisionx-asan-rpath6.2.4_3.0.0.60204-139~20.04_amd64.deb",
-        "version": "3.0.0.60204-139"
+        "sha256": "bd914b6b57c46341e971dbb41c6c2a1b56cd132cf645cd1ee55a9819b064256a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/mivisionx-asan-rpath6.2.4-3.0.0.60204-139.x86_64.rpm",
+        "version": "3.0.0.60204"
       }
     ],
-    "version": "3.0.0.60204-139"
+    "version": "3.0.0.60204"
+  },
+  "mivisionx-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "mivisionx-asan-rpath6.2.4-rpath",
+        "sha256": "35f390de30be5abd6962ee3c40660612f14cf8af8097fbd1da90b84faa943f37",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/mivisionx-asan-rpath6.2.4-rpath6.2.4-3.0.0.60204-139.x86_64.rpm",
+        "version": "3.0.0.60204"
+      }
+    ],
+    "version": "3.0.0.60204"
+  },
+  "mivisionx-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "mivisionx-asan6.2.4-rpath",
+        "sha256": "7a39ecd763c7df7acc1c4764ed86b1e45dd1f6b91d826f807a9b75d3ae06d056",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/mivisionx-asan6.2.4-rpath6.2.4-3.0.0.60204-139.x86_64.rpm",
+        "version": "3.0.0.60204"
+      }
+    ],
+    "version": "3.0.0.60204"
   },
   "mivisionx-test": {
     "deps": [
@@ -1356,18 +1838,18 @@
     "components": [
       {
         "name": "mivisionx-test",
-        "sha256": "19bdb274e534d67c91710ebb2b7ce040409c944229db645f5ab13b3eb0f8d842",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/mivisionx-test/mivisionx-test_3.0.0.60204-139~20.04_amd64.deb",
-        "version": "3.0.0.60204-139"
+        "sha256": "7bc5ed004405e7157ca09d778eb34cdd394b1df39c5c0422352e400789410c21",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/mivisionx-test-3.0.0.60204-139.x86_64.rpm",
+        "version": "3.0.0.60204"
       },
       {
         "name": "mivisionx-test-rpath",
-        "sha256": "ae7ea1c0e5c8d9309895d97acc3f562ba62376cc7586aec955ca0a272d717982",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/m/mivisionx-test-rpath6.2.4/mivisionx-test-rpath6.2.4_3.0.0.60204-139~20.04_amd64.deb",
-        "version": "3.0.0.60204-139"
+        "sha256": "c3b1dfa3bf3d1781ede4c2ee512c833c908773791b7166d0cb6375d07882c610",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/mivisionx-test-rpath6.2.4-3.0.0.60204-139.x86_64.rpm",
+        "version": "3.0.0.60204"
       }
     ],
-    "version": "3.0.0.60204-139"
+    "version": "3.0.0.60204"
   },
   "omniperf": {
     "deps": [
@@ -1376,40 +1858,36 @@
     "components": [
       {
         "name": "omniperf",
-        "sha256": "afcdaa18f2941f6c06842f84f37af899a3d9e9315bd62c8644bdc5a3c402d125",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/o/omniperf/omniperf_2.0.1.60204-139~20.04_amd64.deb",
-        "version": "2.0.1.60204-139"
+        "sha256": "603db68ba025a6de11a5cc8113f383efcc7f21e00fe726f674efb0ffcc99029b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/omniperf-2.0.1.60204-139.el8.x86_64.rpm",
+        "version": "2.0.1.60204"
       },
       {
         "name": "omniperf-rpath",
-        "sha256": "91b65902fbca0f97762e9f29df9004f22f9d4202315ab2e3d471bafff2110d70",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/o/omniperf-rpath6.2.4/omniperf-rpath6.2.4_2.0.1.60204-139~20.04_amd64.deb",
-        "version": "2.0.1.60204-139"
+        "sha256": "d711f51483b9242e227eb55b50bfd5c3f1de0c1ae78d31ca47b57af6fc27103d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/omniperf-rpath6.2.4-2.0.1.60204-139.el8.x86_64.rpm",
+        "version": "2.0.1.60204"
       }
     ],
-    "version": "2.0.1.60204-139"
+    "version": "2.0.1.60204"
   },
   "omnitrace": {
-    "deps": [
-      "rocm-smi-lib",
-      "rocprofiler",
-      "roctracer"
-    ],
+    "deps": [],
     "components": [
       {
         "name": "omnitrace",
-        "sha256": "13ab0e90f08cc64cd86dd813f80815a82fa7cd4fc9a9dec8da51ef203921584b",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/o/omnitrace/omnitrace_1.11.2.60204-139~20.04_amd64.deb",
-        "version": "1.11.2.60204-139"
+        "sha256": "bf4d52574903d1288360eb60f0a30d63e04854163a75f7677b720559040e5f03",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/omnitrace-1.11.2.60204-139.el8.x86_64.rpm",
+        "version": "1.11.2.60204"
       },
       {
         "name": "omnitrace-rpath",
-        "sha256": "45110eaea5a32be75abfb2439d822bf498a48df5645c99d6d9b693d5a31e2a63",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/o/omnitrace-rpath6.2.4/omnitrace-rpath6.2.4_1.11.2.60204-139~20.04_amd64.deb",
-        "version": "1.11.2.60204-139"
+        "sha256": "20844c1600c2c5109d17075cf916599bb5b5522c53aacd4080bbfea2fb2a869b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/omnitrace-rpath6.2.4-1.11.2.60204-139.el8.x86_64.rpm",
+        "version": "1.11.2.60204"
       }
     ],
-    "version": "1.11.2.60204-139"
+    "version": "1.11.2.60204"
   },
   "openmp-extras-asan": {
     "deps": [
@@ -1419,20 +1897,50 @@
     "components": [
       {
         "name": "openmp-extras-asan",
-        "sha256": "0fb361a9d1cabe202217ebf8e2f21d12541219caacfffa7cee5efac1177d3fce",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/o/openmp-extras-asan/openmp-extras-asan_18.62.0.60204-139~20.04_amd64.deb",
-        "version": "18.62.0.60204-139"
+        "sha256": "a2fa0aa4aa4ea4884de5abe12c6abbc46aa4c533d9ad0253cb737e69dc8d03f8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/openmp-extras-asan-18.62.0.60204-139.el8.x86_64.rpm",
+        "version": "18.62.0.60204"
       },
       {
         "name": "openmp-extras-asan-rpath",
-        "sha256": "1af6ded8ffb05dc5839d743fbb9d7d49fce29c40051160f7c5f0ab2b9a6e136b",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/o/openmp-extras-asan-rpath6.2.4/openmp-extras-asan-rpath6.2.4_18.62.0.60204-139~20.04_amd64.deb",
-        "version": "18.62.0.60204-139"
+        "sha256": "93908a54ff189ec5ffb16bfb0ff4a38718df689e663e51bbe981db8aa9e39876",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/openmp-extras-asan-rpath6.2.4-18.62.0.60204-139.el8.x86_64.rpm",
+        "version": "18.62.0.60204"
       }
     ],
-    "version": "18.62.0.60204-139"
+    "version": "18.62.0.60204"
   },
-  "openmp-extras-dev": {
+  "openmp-extras-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "hsa-rocr-asan-rpath6.2.4-rpath",
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "openmp-extras-asan-rpath6.2.4-rpath",
+        "sha256": "ad2cd768553d23a25267b5e4421dc7ec6cd8c2da98327ce02ef52105a1eb9d2a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/openmp-extras-asan-rpath6.2.4-rpath6.2.4-18.62.0.60204-139.el8.x86_64.rpm",
+        "version": "18.62.0.60204"
+      }
+    ],
+    "version": "18.62.0.60204"
+  },
+  "openmp-extras-asan6.2.4-rpath": {
+    "deps": [
+      "hsa-rocr-asan6.2.4-rpath",
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "openmp-extras-asan6.2.4-rpath",
+        "sha256": "c30255b7f90b4a85bb7530b3e380e81404f2633fb3ff14a3126754a60a7d260b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/openmp-extras-asan6.2.4-rpath6.2.4-18.62.0.60204-139.el8.x86_64.rpm",
+        "version": "18.62.0.60204"
+      }
+    ],
+    "version": "18.62.0.60204"
+  },
+  "openmp-extras-devel": {
     "deps": [
       "hsa-rocr",
       "openmp-extras-runtime",
@@ -1442,19 +1950,19 @@
     ],
     "components": [
       {
-        "name": "openmp-extras-dev",
-        "sha256": "4fbcc12b3100f4041b08ac22445bf9df74854bee0372cb733de7df270dec48cd",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/o/openmp-extras-dev/openmp-extras-dev_18.62.0.60204-139~20.04_amd64.deb",
-        "version": "18.62.0.60204-139"
+        "name": "openmp-extras-devel",
+        "sha256": "9bcbd0e2a1515b876560d60294c91a5093015ddd86ab13ee71260222ff0bd2cb",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/openmp-extras-devel-18.62.0.60204-139.el8.x86_64.rpm",
+        "version": "18.62.0.60204"
       },
       {
-        "name": "openmp-extras-dev-rpath",
-        "sha256": "c9326f5ac37ad818d38fed68ff4d0fdc16078d9b23e3535596ada9107c59ac98",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/o/openmp-extras-dev-rpath6.2.4/openmp-extras-dev-rpath6.2.4_18.62.0.60204-139~20.04_amd64.deb",
-        "version": "18.62.0.60204-139"
+        "name": "openmp-extras-devel-rpath",
+        "sha256": "1fd1f05cb00a63e1c9ca6b6694930fb373838cb4cae73adae2b74ad933c90688",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/openmp-extras-devel-rpath6.2.4-18.62.0.60204-139.el8.x86_64.rpm",
+        "version": "18.62.0.60204"
       }
     ],
-    "version": "18.62.0.60204-139"
+    "version": "18.62.0.60204"
   },
   "openmp-extras-runtime": {
     "deps": [
@@ -1464,18 +1972,18 @@
     "components": [
       {
         "name": "openmp-extras-runtime",
-        "sha256": "6606bf3e9855636ccac656703174d4f4153ddbd2081c8f24b5d6c379852e32f0",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/o/openmp-extras-runtime/openmp-extras-runtime_18.62.0.60204-139~20.04_amd64.deb",
-        "version": "18.62.0.60204-139"
+        "sha256": "664c0d4939ad2e06414f12bf253e7a95bba5fc6728db8fe6955290d12e598440",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/openmp-extras-runtime-18.62.0.60204-139.el8.x86_64.rpm",
+        "version": "18.62.0.60204"
       },
       {
         "name": "openmp-extras-runtime-rpath",
-        "sha256": "8a74f266b282338451ef339a07a64391210f7e2dc3656a31fd3260d573c4f460",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/o/openmp-extras-runtime-rpath6.2.4/openmp-extras-runtime-rpath6.2.4_18.62.0.60204-139~20.04_amd64.deb",
-        "version": "18.62.0.60204-139"
+        "sha256": "989f6c309d62ee510bfb16a84cd5b9661e150c463ab0f9ad0cab6d7da3a161bc",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/openmp-extras-runtime-rpath6.2.4-18.62.0.60204-139.el8.x86_64.rpm",
+        "version": "18.62.0.60204"
       }
     ],
-    "version": "18.62.0.60204-139"
+    "version": "18.62.0.60204"
   },
   "rccl": {
     "deps": [
@@ -1486,30 +1994,30 @@
     "components": [
       {
         "name": "rccl",
-        "sha256": "0987a33526cd6a87993d69cec3c88a70c288005fcf84bec50830795eaddf9af1",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rccl/rccl_2.20.5.60204-139~20.04_amd64.deb",
-        "version": "2.20.5.60204-139"
+        "sha256": "3f58d0e0bd6f0845146b1a7fcf6e8cbb6c71bd1888d812b067d74675d7ebdead",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rccl-2.20.5.60204-139.el8.x86_64.rpm",
+        "version": "2.20.5.60204"
       },
       {
-        "name": "rccl-dev",
-        "sha256": "8ca0d46892878d9e4833d5c664f8f82b307621d405d63a846b447cc68b44c773",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rccl-dev/rccl-dev_2.20.5.60204-139~20.04_amd64.deb",
-        "version": "2.20.5.60204-139"
+        "name": "rccl-devel",
+        "sha256": "a1a9117ad6c45239947a5bc465fdcfabd80ce7f22a6a4e6e69e56bfef459e886",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rccl-devel-2.20.5.60204-139.el8.x86_64.rpm",
+        "version": "2.20.5.60204"
       },
       {
-        "name": "rccl-dev-rpath",
-        "sha256": "aa6d95a3322202f34fa9e23493882bc15c8df5659cf842cd99fe2bb582ae9427",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rccl-dev-rpath6.2.4/rccl-dev-rpath6.2.4_2.20.5.60204-139~20.04_amd64.deb",
-        "version": "2.20.5.60204-139"
+        "name": "rccl-devel-rpath",
+        "sha256": "259e8cf4e2e4d8c637cb7b24e9466fba92d16a2cad0e58844c9f2c6b4b20ba00",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rccl-devel-rpath6.2.4-2.20.5.60204-139.el8.x86_64.rpm",
+        "version": "2.20.5.60204"
       },
       {
         "name": "rccl-rpath",
-        "sha256": "0dec68607afd4395c7c77c8c9c1086a5634f3c5a9ccc19e059c84fb08c89ea4e",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rccl-rpath6.2.4/rccl-rpath6.2.4_2.20.5.60204-139~20.04_amd64.deb",
-        "version": "2.20.5.60204-139"
+        "sha256": "4fc8f0907f909dce05a7ffdd5565f17af2d4ccd383751ee86a44970aa705309a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rccl-rpath6.2.4-2.20.5.60204-139.el8.x86_64.rpm",
+        "version": "2.20.5.60204"
       }
     ],
-    "version": "2.20.5.60204-139"
+    "version": "2.20.5.60204"
   },
   "rccl-asan": {
     "deps": [
@@ -1520,36 +2028,48 @@
     "components": [
       {
         "name": "rccl-asan",
-        "sha256": "e7325338d1a3e584da968283036c3447b75a7dc04b2fafb248a4293f257722a2",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rccl-asan/rccl-asan_2.20.5.60204-139~20.04_amd64.deb",
-        "version": "2.20.5.60204-139"
+        "sha256": "b96c0a1a8d3b62f74979e66b3a703ddde5861b12e54ebdf05c118432a748eb21",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rccl-asan-2.20.5.60204-139.el8.x86_64.rpm",
+        "version": "2.20.5.60204"
       },
       {
         "name": "rccl-asan-rpath",
-        "sha256": "e6143640fc6f83e64be00db2c06c13f12bb7cc10ceefe1a26acc7cfceba440ef",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rccl-asan-rpath6.2.4/rccl-asan-rpath6.2.4_2.20.5.60204-139~20.04_amd64.deb",
-        "version": "2.20.5.60204-139"
+        "sha256": "90bd8224e5711f3495ce6421425577fc6294d6e595f7b13b0c949c4bea26b404",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rccl-asan-rpath6.2.4-2.20.5.60204-139.el8.x86_64.rpm",
+        "version": "2.20.5.60204"
       }
     ],
-    "version": "2.20.5.60204-139"
+    "version": "2.20.5.60204"
   },
-  "rccl-rdma-sharp-plugins": {
-    "deps": [],
+  "rccl-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "hip-runtime-amd-asan-rpath6.2.4-rpath",
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
     "components": [
       {
-        "name": "rccl-rdma-sharp-plugins",
-        "sha256": "bb266f3e396412a17f592f25cbeec8b071b89208151698a2461c67e50f6c1534",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rccl-rdma-sharp-plugins/rccl-rdma-sharp-plugins_1.0.60204-139~20.04_amd64.deb",
-        "version": "1.0.60204-139"
-      },
-      {
-        "name": "rccl-rdma-sharp-plugins-rpath",
-        "sha256": "a9893b7f5bfdaee97f7923b2e4325baac5fb375bb311c64b138df02afea35439",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rccl-rdma-sharp-plugins-rpath6.2.4/rccl-rdma-sharp-plugins-rpath6.2.4_1.0.60204-139~20.04_amd64.deb",
-        "version": "1.0.60204-139"
+        "name": "rccl-asan-rpath6.2.4-rpath",
+        "sha256": "0f2a905df84fbf93aaeda4720a4875f6149b132532ad364e3bf91770e8c5ed94",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rccl-asan-rpath6.2.4-rpath6.2.4-2.20.5.60204-139.el8.x86_64.rpm",
+        "version": "2.20.5.60204"
       }
     ],
-    "version": "1.0.60204-139"
+    "version": "2.20.5.60204"
+  },
+  "rccl-asan6.2.4-rpath": {
+    "deps": [
+      "hip-runtime-amd-asan6.2.4-rpath",
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rccl-asan6.2.4-rpath",
+        "sha256": "025d83cb4b675c5dc2173958c0eb36745c66d86d8be05d80ba151f6d498a20a8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rccl-asan6.2.4-rpath6.2.4-2.20.5.60204-139.el8.x86_64.rpm",
+        "version": "2.20.5.60204"
+      }
+    ],
+    "version": "2.20.5.60204"
   },
   "rccl-unittests": {
     "deps": [
@@ -1558,18 +2078,18 @@
     "components": [
       {
         "name": "rccl-unittests",
-        "sha256": "96e1293bcde1487042a0a6a0c02446c8742917326a33f4c38bd11842e26ef714",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rccl-unittests/rccl-unittests_2.20.5.60204-139~20.04_amd64.deb",
-        "version": "2.20.5.60204-139"
+        "sha256": "312e88389ebba5e68b2fceccc5d23102e7b0a97f5f6509e656aec2c9d22ae314",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rccl-unittests-2.20.5.60204-139.el8.x86_64.rpm",
+        "version": "2.20.5.60204"
       },
       {
         "name": "rccl-unittests-rpath",
-        "sha256": "8d015d438c70ac8d6bb342144b5ba613f18bcb57505f67dff37349e370dcea59",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rccl-unittests-rpath6.2.4/rccl-unittests-rpath6.2.4_2.20.5.60204-139~20.04_amd64.deb",
-        "version": "2.20.5.60204-139"
+        "sha256": "a58b7954234bb6af035c486aec5d486cf9b7e8f6fade78515eb0dd3f44eb3562",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rccl-unittests-rpath6.2.4-2.20.5.60204-139.el8.x86_64.rpm",
+        "version": "2.20.5.60204"
       }
     ],
-    "version": "2.20.5.60204-139"
+    "version": "2.20.5.60204"
   },
   "rdc": {
     "deps": [
@@ -1578,18 +2098,18 @@
     "components": [
       {
         "name": "rdc",
-        "sha256": "3704ca9f46442513c284fd1f26d8a70591e052e5eb23e314158810658831941d",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rdc/rdc_0.3.0.60204-139~20.04_amd64.deb",
-        "version": "0.3.0.60204-139"
+        "sha256": "0db0cdb6bc5bfca50ed11b28d01c2dd3e5a2b7bc3f710fad333da9f3433eedee",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rdc-0.3.0.60204-139.el8.x86_64.rpm",
+        "version": "0.3.0.60204"
       },
       {
         "name": "rdc-rpath",
-        "sha256": "b44d25b29141c2ebae2828e21a855a14421972e2401bf2fbd1ace92f5d53230a",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rdc-rpath6.2.4/rdc-rpath6.2.4_0.3.0.60204-139~20.04_amd64.deb",
-        "version": "0.3.0.60204-139"
+        "sha256": "02c6ffe28e36bf9da25989c911fada24f7b86db0ccdae645db34677b7e04e4fd",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rdc-rpath6.2.4-0.3.0.60204-139.el8.x86_64.rpm",
+        "version": "0.3.0.60204"
       }
     ],
-    "version": "0.3.0.60204-139"
+    "version": "0.3.0.60204"
   },
   "rocal": {
     "deps": [
@@ -1600,30 +2120,30 @@
     "components": [
       {
         "name": "rocal",
-        "sha256": "0fb53574cba8688e95b9e9dd22b4c3ca25bbfa9941b3fc4cdab82fe99c0925bd",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocal/rocal_2.0.0.60204-139~20.04_amd64.deb",
-        "version": "2.0.0.60204-139"
+        "sha256": "b307554faa5922f4e9cc8093a1b344dc92c175c35bab37cced5f5bf6498d234d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocal-2.0.0.60204-139.x86_64.rpm",
+        "version": "2.0.0.60204"
       },
       {
-        "name": "rocal-dev",
-        "sha256": "a7bdb752f06f315bcafe5ec122e653889a5194a2e581e8bb9752244467e1b5a9",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocal-dev/rocal-dev_2.0.0.60204-139~20.04_amd64.deb",
-        "version": "2.0.0.60204-139"
+        "name": "rocal-devel",
+        "sha256": "0f66afe0afff12036c6346e640811d4a49110dde3ddf1273f4dad9e142053dc4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocal-devel-2.0.0.60204-139.x86_64.rpm",
+        "version": "2.0.0.60204"
       },
       {
-        "name": "rocal-dev-rpath",
-        "sha256": "88a2a1055e6aeeb23325c6d66316afa60b41c824d39c8467e3e9466d94fbfe90",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocal-dev-rpath6.2.4/rocal-dev-rpath6.2.4_2.0.0.60204-139~20.04_amd64.deb",
-        "version": "2.0.0.60204-139"
+        "name": "rocal-devel-rpath",
+        "sha256": "f1ffe03ac2d7aad957f8b38e32efbdb1143a7f6d8f98ad90df4f53b1a6188a49",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocal-devel-rpath6.2.4-2.0.0.60204-139.x86_64.rpm",
+        "version": "2.0.0.60204"
       },
       {
         "name": "rocal-rpath",
-        "sha256": "b3452ce3eb6edc759fb5a89e0b5a57fb84f91bc9b7873477fbcb22b018e35bac",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocal-rpath6.2.4/rocal-rpath6.2.4_2.0.0.60204-139~20.04_amd64.deb",
-        "version": "2.0.0.60204-139"
+        "sha256": "d5d8c6bc3702f371cf77c066cd03835e8aa3b1f3763d576d41ccb2b898993ff1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocal-rpath6.2.4-2.0.0.60204-139.x86_64.rpm",
+        "version": "2.0.0.60204"
       }
     ],
-    "version": "2.0.0.60204-139"
+    "version": "2.0.0.60204"
   },
   "rocal-test": {
     "deps": [
@@ -1632,18 +2152,18 @@
     "components": [
       {
         "name": "rocal-test",
-        "sha256": "38e6e73aaf2194e5256fd35a68099a6d7371f835bc470174d68d054dff654aa2",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocal-test/rocal-test_2.0.0.60204-139~20.04_amd64.deb",
-        "version": "2.0.0.60204-139"
+        "sha256": "10813e676cb9e8a5aa7af374f59786c5dbad211cc71a35a18028e5c17bb78840",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocal-test-2.0.0.60204-139.x86_64.rpm",
+        "version": "2.0.0.60204"
       },
       {
         "name": "rocal-test-rpath",
-        "sha256": "faf907f878a387dbd6ce3d3dd0811bdfcad808df62e8de0fd8fdc103f106d944",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocal-test-rpath6.2.4/rocal-test-rpath6.2.4_2.0.0.60204-139~20.04_amd64.deb",
-        "version": "2.0.0.60204-139"
+        "sha256": "1610b9d2ef083efdc632e06952dda84c417fe71e6a0049bf2c8d1f051be3f680",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocal-test-rpath6.2.4-2.0.0.60204-139.x86_64.rpm",
+        "version": "2.0.0.60204"
       }
     ],
-    "version": "2.0.0.60204-139"
+    "version": "2.0.0.60204"
   },
   "rocalution": {
     "deps": [
@@ -1656,30 +2176,30 @@
     "components": [
       {
         "name": "rocalution",
-        "sha256": "ed20a00472bab32325b12054206dd8255289c8b5acc60a60473f3c02c660efe1",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocalution/rocalution_3.2.1.60204-139~20.04_amd64.deb",
-        "version": "3.2.1.60204-139"
+        "sha256": "6627ad89164baf8026175780dc55ffe064759be42ff9a89c70ebea09120fca59",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocalution-3.2.1.60204-139.el8.x86_64.rpm",
+        "version": "3.2.1.60204"
       },
       {
-        "name": "rocalution-dev",
-        "sha256": "7206544e3ce7cf9de87b66057465820f2ebe05e07407b204f66f8ce5faf85b34",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocalution-dev/rocalution-dev_3.2.1.60204-139~20.04_amd64.deb",
-        "version": "3.2.1.60204-139"
+        "name": "rocalution-devel",
+        "sha256": "afbc2e650410f93abafb13dda04036c4448a221b0638fbef492985cdd240f2c8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocalution-devel-3.2.1.60204-139.el8.x86_64.rpm",
+        "version": "3.2.1.60204"
       },
       {
-        "name": "rocalution-dev-rpath",
-        "sha256": "bfdeaeb344a72dcfbd0564c01c9b3d37ffca155f6fd6af670db5d7289f7d9368",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocalution-dev-rpath6.2.4/rocalution-dev-rpath6.2.4_3.2.1.60204-139~20.04_amd64.deb",
-        "version": "3.2.1.60204-139"
+        "name": "rocalution-devel-rpath",
+        "sha256": "2cf917ca006eafdd0bae9bf6933479f22755a8d45a0a00c97772732e6e7aee99",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocalution-devel-rpath6.2.4-3.2.1.60204-139.el8.x86_64.rpm",
+        "version": "3.2.1.60204"
       },
       {
         "name": "rocalution-rpath",
-        "sha256": "ddcfc5935d782eddf36394057f4355d32283e56fb88fb6e0e28fbb279b48858c",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocalution-rpath6.2.4/rocalution-rpath6.2.4_3.2.1.60204-139~20.04_amd64.deb",
-        "version": "3.2.1.60204-139"
+        "sha256": "47826dd6874a888fa96760d9a4b96ad3b2ba4ab1bed8ff1efee9d301d30617ba",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocalution-rpath6.2.4-3.2.1.60204-139.el8.x86_64.rpm",
+        "version": "3.2.1.60204"
       }
     ],
-    "version": "3.2.1.60204-139"
+    "version": "3.2.1.60204"
   },
   "rocalution-asan": {
     "deps": [
@@ -1692,18 +2212,48 @@
     "components": [
       {
         "name": "rocalution-asan",
-        "sha256": "dade1fa64067b2de393fee5dba895ec99ff6039550cec725d3bf81935105895b",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocalution-asan/rocalution-asan_3.2.1.60204-139~20.04_amd64.deb",
-        "version": "3.2.1.60204-139"
+        "sha256": "0c44d55ca143836791c2b1c0f1b879fd0d17226d53fbc2118c36f26a56714c2e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocalution-asan-3.2.1.60204-139.el8.x86_64.rpm",
+        "version": "3.2.1.60204"
       },
       {
         "name": "rocalution-asan-rpath",
-        "sha256": "fae1e72d8a6dfe1afa2318509f1a208cc24b0bae425bca3c2d78a254c0dc08a7",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocalution-asan-rpath6.2.4/rocalution-asan-rpath6.2.4_3.2.1.60204-139~20.04_amd64.deb",
-        "version": "3.2.1.60204-139"
+        "sha256": "b8d653fecfddca3caa580cd518106db072e8eaac37b05ebcbf0074e66ff2b5b2",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocalution-asan-rpath6.2.4-3.2.1.60204-139.el8.x86_64.rpm",
+        "version": "3.2.1.60204"
       }
     ],
-    "version": "3.2.1.60204-139"
+    "version": "3.2.1.60204"
+  },
+  "rocalution-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "hip-runtime-amd-asan-rpath6.2.4-rpath",
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocalution-asan-rpath6.2.4-rpath",
+        "sha256": "ef0ee1871845cfd01e02f7c5f53a242d41962f68e2af7169ee0ee438fce34ce3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocalution-asan-rpath6.2.4-rpath6.2.4-3.2.1.60204-139.el8.x86_64.rpm",
+        "version": "3.2.1.60204"
+      }
+    ],
+    "version": "3.2.1.60204"
+  },
+  "rocalution-asan6.2.4-rpath": {
+    "deps": [
+      "hip-runtime-amd-asan6.2.4-rpath",
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocalution-asan6.2.4-rpath",
+        "sha256": "a94d11089e0b0417b93597f58896aed7b51e0aaa1952ecedac3315c190df9030",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocalution-asan6.2.4-rpath6.2.4-3.2.1.60204-139.el8.x86_64.rpm",
+        "version": "3.2.1.60204"
+      }
+    ],
+    "version": "3.2.1.60204"
   },
   "rocblas": {
     "deps": [
@@ -1713,30 +2263,30 @@
     "components": [
       {
         "name": "rocblas",
-        "sha256": "08d7db51d28402192047e1c240efb815311cf88e0e91c8b37d14b1677583bf8b",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocblas/rocblas_4.2.4.60204-139~20.04_amd64.deb",
-        "version": "4.2.4.60204-139"
+        "sha256": "49a727c730eeb8cd5a9f6db83596dfcdad655d2f36cb8d4ad4f155b6bfc526f3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocblas-4.2.4.60204-139.el8.x86_64.rpm",
+        "version": "4.2.4.60204"
       },
       {
-        "name": "rocblas-dev",
-        "sha256": "6f6865db610f6f4abadd862d4d8730c96d85084e6693e6a0b7eec7e7f675f6bb",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocblas-dev/rocblas-dev_4.2.4.60204-139~20.04_amd64.deb",
-        "version": "4.2.4.60204-139"
+        "name": "rocblas-devel",
+        "sha256": "e737aa91153a959cc6ec8ed257680b354664a5d293b034e7d345b0c97ac68228",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocblas-devel-4.2.4.60204-139.el8.x86_64.rpm",
+        "version": "4.2.4.60204"
       },
       {
-        "name": "rocblas-dev-rpath",
-        "sha256": "d54e357780bd5c6358bfc07b5be8869abb7e705690a9ff84a3ccdd0ae690b452",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocblas-dev-rpath6.2.4/rocblas-dev-rpath6.2.4_4.2.4.60204-139~20.04_amd64.deb",
-        "version": "4.2.4.60204-139"
+        "name": "rocblas-devel-rpath",
+        "sha256": "1edf4fbdab57587a499a32c188ae73f94ead6a63452c5c1ec60315898ac39b59",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocblas-devel-rpath6.2.4-4.2.4.60204-139.el8.x86_64.rpm",
+        "version": "4.2.4.60204"
       },
       {
         "name": "rocblas-rpath",
-        "sha256": "fc21ce9d0f559fe73985c2462c8c03f42fd0b57b1df309e130c864fea12bd456",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocblas-rpath6.2.4/rocblas-rpath6.2.4_4.2.4.60204-139~20.04_amd64.deb",
-        "version": "4.2.4.60204-139"
+        "sha256": "d183998c1ff5b182c4a1dba873f33e5cda324d8f41c78c38a7060d13d9d05b20",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocblas-rpath6.2.4-4.2.4.60204-139.el8.x86_64.rpm",
+        "version": "4.2.4.60204"
       }
     ],
-    "version": "4.2.4.60204-139"
+    "version": "4.2.4.60204"
   },
   "rocblas-asan": {
     "deps": [
@@ -1746,18 +2296,48 @@
     "components": [
       {
         "name": "rocblas-asan",
-        "sha256": "08dc46fe9dea6152b98e4ac19c7e882b43539a0b282584ff1017ca41cdbc1467",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocblas-asan/rocblas-asan_4.2.4.60204-139~20.04_amd64.deb",
-        "version": "4.2.4.60204-139"
+        "sha256": "d298dabeeaa4b380a5cc1c41508229bb4bff4ef7e025949eb5d263d4b82a3152",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocblas-asan-4.2.4.60204-139.el8.x86_64.rpm",
+        "version": "4.2.4.60204"
       },
       {
         "name": "rocblas-asan-rpath",
-        "sha256": "72755cedd7aabc0f591f00812fed547b94d05202a4bbd46891bb228fa4953167",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocblas-asan-rpath6.2.4/rocblas-asan-rpath6.2.4_4.2.4.60204-139~20.04_amd64.deb",
-        "version": "4.2.4.60204-139"
+        "sha256": "96af2510b6d14341e19fdfc8d1bd7dfe5e6b26a4cacfb50d1f34c832f02c2eb5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocblas-asan-rpath6.2.4-4.2.4.60204-139.el8.x86_64.rpm",
+        "version": "4.2.4.60204"
       }
     ],
-    "version": "4.2.4.60204-139"
+    "version": "4.2.4.60204"
+  },
+  "rocblas-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "hip-runtime-amd-asan-rpath6.2.4-rpath",
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocblas-asan-rpath6.2.4-rpath",
+        "sha256": "6797c076ba2e28b0331d59fcfb8f5fdd79a457ecb407cdbeefc4f48fae91a5f0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocblas-asan-rpath6.2.4-rpath6.2.4-4.2.4.60204-139.el8.x86_64.rpm",
+        "version": "4.2.4.60204"
+      }
+    ],
+    "version": "4.2.4.60204"
+  },
+  "rocblas-asan6.2.4-rpath": {
+    "deps": [
+      "hip-runtime-amd-asan6.2.4-rpath",
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocblas-asan6.2.4-rpath",
+        "sha256": "9573a4e5b9c471e97a28221775432a4a34287fa40b1599f7ecc56d997d6ae8b9",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocblas-asan6.2.4-rpath6.2.4-4.2.4.60204-139.el8.x86_64.rpm",
+        "version": "4.2.4.60204"
+      }
+    ],
+    "version": "4.2.4.60204"
   },
   "rocdecode": {
     "deps": [
@@ -1767,30 +2347,30 @@
     "components": [
       {
         "name": "rocdecode",
-        "sha256": "de3dc7258c5bd8f19e9bbdb3a24f04ddde62128327e2b3570df753a19b8ae683",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocdecode/rocdecode_0.6.0.60204-139~20.04_amd64.deb",
-        "version": "0.6.0.60204-139"
+        "sha256": "c512d7bc25132b1b6c8af6c0428b366f50bf2f0a227d438ea3e1d62390870429",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocdecode-0.6.0.60204-139.x86_64.rpm",
+        "version": "0.6.0.60204"
       },
       {
-        "name": "rocdecode-dev",
-        "sha256": "ffa5ef9eecda1820eecb6e5b6f267f8f706c63205f1ea37cf9b829e1cb317044",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocdecode-dev/rocdecode-dev_0.6.0.60204-139~20.04_amd64.deb",
-        "version": "0.6.0.60204-139"
+        "name": "rocdecode-devel",
+        "sha256": "81baeb53c9f071797594270f6ae8bc7cba44e1a8e057a96e7f3acccbf0da09fb",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocdecode-devel-0.6.0.60204-139.x86_64.rpm",
+        "version": "0.6.0.60204"
       },
       {
-        "name": "rocdecode-dev-rpath",
-        "sha256": "aa1a966bb557d5488bb8d5268d2c291ac8da7d1eee9ab3f57228877bd7a20501",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocdecode-dev-rpath6.2.4/rocdecode-dev-rpath6.2.4_0.6.0.60204-139~20.04_amd64.deb",
-        "version": "0.6.0.60204-139"
+        "name": "rocdecode-devel-rpath",
+        "sha256": "542defb8d511981701ab89b7e47a1c0e2a9edb1f02a01f3f95ec1cc83f166d60",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocdecode-devel-rpath6.2.4-0.6.0.60204-139.x86_64.rpm",
+        "version": "0.6.0.60204"
       },
       {
         "name": "rocdecode-rpath",
-        "sha256": "ecd7c38b6810e9c2ce8ed11683a641339ed5b3711afe775b79047f752b6c9c2e",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocdecode-rpath6.2.4/rocdecode-rpath6.2.4_0.6.0.60204-139~20.04_amd64.deb",
-        "version": "0.6.0.60204-139"
+        "sha256": "6f15c9bd78173fe9bb43ac4502a9f3a33adf5c531a9445fc5f2eb8dd1e4b34ca",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocdecode-rpath6.2.4-0.6.0.60204-139.x86_64.rpm",
+        "version": "0.6.0.60204"
       }
     ],
-    "version": "0.6.0.60204-139"
+    "version": "0.6.0.60204"
   },
   "rocdecode-test": {
     "deps": [
@@ -1800,18 +2380,18 @@
     "components": [
       {
         "name": "rocdecode-test",
-        "sha256": "965bf2908721948e3d1c79c2cd1a3049bead2b584b2c386b8239471cea6d83a1",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocdecode-test/rocdecode-test_0.6.0.60204-139~20.04_amd64.deb",
-        "version": "0.6.0.60204-139"
+        "sha256": "067c976b9d6968a3d6a687daee744e8e174e4a78aa8f387e1a9b713948edec26",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocdecode-test-0.6.0.60204-139.x86_64.rpm",
+        "version": "0.6.0.60204"
       },
       {
         "name": "rocdecode-test-rpath",
-        "sha256": "4844ee6928314492a4f062f6dc3313aac6f23b4cf6c6b01aae9d481c19ee846f",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocdecode-test-rpath6.2.4/rocdecode-test-rpath6.2.4_0.6.0.60204-139~20.04_amd64.deb",
-        "version": "0.6.0.60204-139"
+        "sha256": "bdc53b816e218a389a57d91a9ba3d0d0863e652aa06c10e3e6a8b42a318af394",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocdecode-test-rpath6.2.4-0.6.0.60204-139.x86_64.rpm",
+        "version": "0.6.0.60204"
       }
     ],
-    "version": "0.6.0.60204-139"
+    "version": "0.6.0.60204"
   },
   "rocfft": {
     "deps": [
@@ -1820,30 +2400,30 @@
     "components": [
       {
         "name": "rocfft",
-        "sha256": "1d43175d149a99ec643ba6f98fe0b5e0267dbc5f6340fa309adcd80d190aeca6",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocfft/rocfft_1.0.30.60204-139~20.04_amd64.deb",
-        "version": "1.0.30.60204-139"
+        "sha256": "aa1578b106fd8c8b9a04b27a26c96286075875fc3410df2e33d4ec7d52b38a5f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocfft-1.0.30.60204-139.el8.x86_64.rpm",
+        "version": "1.0.30.60204"
       },
       {
-        "name": "rocfft-dev",
-        "sha256": "730d53e821402124329382ee9289d3ab9dd495f932f08f1d906d6a34061f6418",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocfft-dev/rocfft-dev_1.0.30.60204-139~20.04_amd64.deb",
-        "version": "1.0.30.60204-139"
+        "name": "rocfft-devel",
+        "sha256": "4545d6463d8d8d692438e84000eb1d77c9fa11c2d3c08ec886bea4d7a92f6465",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocfft-devel-1.0.30.60204-139.el8.x86_64.rpm",
+        "version": "1.0.30.60204"
       },
       {
-        "name": "rocfft-dev-rpath",
-        "sha256": "18f128b792f1e7eff472dd345478dd7619b6ffb29cdecfcfe01824e470e5b33f",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocfft-dev-rpath6.2.4/rocfft-dev-rpath6.2.4_1.0.30.60204-139~20.04_amd64.deb",
-        "version": "1.0.30.60204-139"
+        "name": "rocfft-devel-rpath",
+        "sha256": "fa6c800a69531efe0e8cf14d0773ee9c8d11d7f5d6543447d1d060dc40838d9d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocfft-devel-rpath6.2.4-1.0.30.60204-139.el8.x86_64.rpm",
+        "version": "1.0.30.60204"
       },
       {
         "name": "rocfft-rpath",
-        "sha256": "34ba0a19c388a5f56a7ac3faa32dbc2f18944a9454037e199e11843cc7bbb37a",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocfft-rpath6.2.4/rocfft-rpath6.2.4_1.0.30.60204-139~20.04_amd64.deb",
-        "version": "1.0.30.60204-139"
+        "sha256": "639a054e0b041e026168734615c7ef7ac0a6c8a8791a74dec55eb0aa2f0f8c26",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocfft-rpath6.2.4-1.0.30.60204-139.el8.x86_64.rpm",
+        "version": "1.0.30.60204"
       }
     ],
-    "version": "1.0.30.60204-139"
+    "version": "1.0.30.60204"
   },
   "rocfft-asan": {
     "deps": [
@@ -1852,86 +2432,74 @@
     "components": [
       {
         "name": "rocfft-asan",
-        "sha256": "9ff8e254a95373d4f968e3be5207232b63752733a737f6d9684b9d9fdcf8adda",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocfft-asan/rocfft-asan_1.0.30.60204-139~20.04_amd64.deb",
-        "version": "1.0.30.60204-139"
+        "sha256": "a99292bd33af356a20701542844768034e0644661a12007a1ca2ed4aa6f164dc",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocfft-asan-1.0.30.60204-139.el8.x86_64.rpm",
+        "version": "1.0.30.60204"
       },
       {
         "name": "rocfft-asan-rpath",
-        "sha256": "9e4454f7b17ac9ba6846ec893bcb67c2c147f48155c8091a39e44668f76333c2",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocfft-asan-rpath6.2.4/rocfft-asan-rpath6.2.4_1.0.30.60204-139~20.04_amd64.deb",
-        "version": "1.0.30.60204-139"
+        "sha256": "fda6307000bf1858eba699f9c7e6f9bc6f2ca96314970c8c396c550c389a146d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocfft-asan-rpath6.2.4-1.0.30.60204-139.el8.x86_64.rpm",
+        "version": "1.0.30.60204"
       }
     ],
-    "version": "1.0.30.60204-139"
+    "version": "1.0.30.60204"
+  },
+  "rocfft-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocfft-asan-rpath6.2.4-rpath",
+        "sha256": "61d9a1f3f993812c98389a79c33e5d5972ea862343aaf84e9e8142ef7a25b27f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocfft-asan-rpath6.2.4-rpath6.2.4-1.0.30.60204-139.el8.x86_64.rpm",
+        "version": "1.0.30.60204"
+      }
+    ],
+    "version": "1.0.30.60204"
+  },
+  "rocfft-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocfft-asan6.2.4-rpath",
+        "sha256": "fbde2f3c528463d0b81dedea9d56e19b61623bc8c7224c062ef993dc6bb3a27b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocfft-asan6.2.4-rpath6.2.4-1.0.30.60204-139.el8.x86_64.rpm",
+        "version": "1.0.30.60204"
+      }
+    ],
+    "version": "1.0.30.60204"
   },
   "rocm": {
     "deps": [
-      "amd-smi-lib",
-      "comgr",
-      "hip-dev",
-      "hip-doc",
-      "hip-runtime-amd",
-      "hip-samples",
-      "hipcc",
-      "hipify-clang",
-      "hsa-amd-aqlprofile",
-      "hsa-rocr",
-      "hsakmt-roct-dev",
       "migraphx",
       "mivisionx",
-      "openmp-extras-dev",
-      "openmp-extras-runtime",
-      "rocm-cmake",
       "rocm-core",
-      "rocm-dbgapi",
-      "rocm-debug-agent",
       "rocm-developer-tools",
-      "rocm-device-libs",
-      "rocm-gdb",
-      "rocm-llvm",
       "rocm-ml-sdk",
-      "rocm-opencl",
-      "rocm-opencl-icd-loader",
       "rocm-opencl-sdk",
       "rocm-openmp-sdk",
-      "rocm-smi-lib",
       "rocm-utils",
-      "rocprofiler",
-      "rocprofiler-plugins",
-      "rocprofiler-register",
-      "rocprofiler-sdk",
-      "rocprofiler-sdk-roctx",
-      "roctracer",
       "rpp"
     ],
     "components": [
       {
         "name": "rocm",
-        "sha256": "f38aa2e0f5c85b7053c9c375dd9c262c33f3bc05f7942f8fb4e5ee33a6f1b593",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm/rocm_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
-      },
-      {
-        "name": "rocm-dev",
-        "sha256": "2641c11f73888d90a8b92546e0020c789f591e2cafd8b8ae7c0840c7ca9e81f3",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-dev/rocm-dev_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
-      },
-      {
-        "name": "rocm-dev-rpath",
-        "sha256": "884533ebf32dbd030becb571739da8bfd591e9eedea47136f286be51bf8ce233",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-dev-rpath6.2.4/rocm-dev-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "13e14aa4989816d45d3a1c9933f3b6e8fcac46efd01eccacc3a04a2c2cb105c9",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-rpath",
-        "sha256": "94baf77817b4f06d9a1b8533fe89a00705eb71676da81a58a2ebbfda19d926bd",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-rpath6.2.4/rocm-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "8c350cdb132650799c55bb6aeee688262ba34172bd798499151f6ca17224f38a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
   },
   "rocm-asan": {
     "deps": [
@@ -1947,18 +2515,58 @@
     "components": [
       {
         "name": "rocm-asan",
-        "sha256": "b26597103001135fb833fa53a8fe367fe5076e9e4fee2abd49dd7634e6691ead",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-asan/rocm-asan_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "df75120e29ecd7d49ce7fd5e114a1c3bd274d7bcd6d91b28f70a548e1ea78694",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-asan-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-asan-rpath",
-        "sha256": "ec5182dd62a0381c4c7959c08ae9d001b28ce6413cabeac5df0f2ebb69ed7ad8",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-asan-rpath6.2.4/rocm-asan-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "b558f348fb645f31abe7306953a21d2fdfca2c25de3cc9e0d49cd8be6a58a013",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-asan-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
+  },
+  "rocm-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "migraphx-asan-rpath6.2.4-rpath",
+      "mivisionx-asan-rpath6.2.4-rpath",
+      "rocm-core-asan-rpath6.2.4-rpath",
+      "rocm-developer-tools-asan-rpath6.2.4-rpath",
+      "rocm-language-runtime-asan-rpath6.2.4-rpath",
+      "rocm-ml-libraries-asan-rpath6.2.4-rpath",
+      "rocm-opencl-runtime-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-asan-rpath6.2.4-rpath",
+        "sha256": "a767a93703e772bd36f77746ef86adfd440673f24a30f44189077442063b40aa",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-asan-rpath6.2.4-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      }
+    ],
+    "version": "6.2.4.60204"
+  },
+  "rocm-asan6.2.4-rpath": {
+    "deps": [
+      "migraphx-asan6.2.4-rpath",
+      "mivisionx-asan6.2.4-rpath",
+      "rocm-core-asan6.2.4-rpath",
+      "rocm-developer-tools-asan6.2.4-rpath",
+      "rocm-language-runtime-asan6.2.4-rpath",
+      "rocm-ml-libraries-asan6.2.4-rpath",
+      "rocm-opencl-runtime-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-asan6.2.4-rpath",
+        "sha256": "284ecf69bafed4607386914ed01774c44bd276bf24660b5739807ac2b113afa6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-asan6.2.4-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      }
+    ],
+    "version": "6.2.4.60204"
   },
   "rocm-bandwidth-test": {
     "deps": [
@@ -1967,18 +2575,18 @@
     "components": [
       {
         "name": "rocm-bandwidth-test",
-        "sha256": "bef6c491fb4434e1f0c8c42a52b01e6f19687ba38535c74ca00f38f1c3d76e91",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-bandwidth-test/rocm-bandwidth-test_1.4.0.60204-139~20.04_amd64.deb",
-        "version": "1.4.0.60204-139"
+        "sha256": "d29d37af1f04d13d36ec68da8f2856dab6cd2bd15edaaaa8fc938b607f5e64ed",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-bandwidth-test-1.4.0.60204-139.el8.x86_64.rpm",
+        "version": "1.4.0.60204"
       },
       {
         "name": "rocm-bandwidth-test-rpath",
-        "sha256": "27168e5a86a1e14c3c23ca0b6288bacb76fc829a7708018225a9b26b607e1cdb",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-bandwidth-test-rpath6.2.4/rocm-bandwidth-test-rpath6.2.4_1.4.0.60204-139~20.04_amd64.deb",
-        "version": "1.4.0.60204-139"
+        "sha256": "9ff5e04f18cc7ca5614ff4fc55fa22e79c8218d1ab2ef0fee2a98ab30ede076d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-bandwidth-test-rpath6.2.4-1.4.0.60204-139.el8.x86_64.rpm",
+        "version": "1.4.0.60204"
       }
     ],
-    "version": "1.4.0.60204-139"
+    "version": "1.4.0.60204"
   },
   "rocm-cmake": {
     "deps": [
@@ -1987,36 +2595,36 @@
     "components": [
       {
         "name": "rocm-cmake",
-        "sha256": "986fa953c7509651e66094d4654b0dfa9c1cd5476f4369bc8b8326da30a7054b",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-cmake/rocm-cmake_0.13.0.60204-139~20.04_amd64.deb",
-        "version": "0.13.0.60204-139"
+        "sha256": "70314872210b5f14da3cf83371f38a84f615d3de371b5c6711596029d36a9308",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-cmake-0.13.0.60204-139.el8.x86_64.rpm",
+        "version": "0.13.0.60204"
       },
       {
         "name": "rocm-cmake-rpath",
-        "sha256": "2608775d437a07c98c40af518085e13595460bf04e16355b761fe3a36bb368b6",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-cmake-rpath6.2.4/rocm-cmake-rpath6.2.4_0.13.0.60204-139~20.04_amd64.deb",
-        "version": "0.13.0.60204-139"
+        "sha256": "e6da5c2f1838f8ca6b2bc7ea546eaa0cb6c8db7e9a92b39167a71b5e54898ed0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-cmake-rpath6.2.4-0.13.0.60204-139.el8.x86_64.rpm",
+        "version": "0.13.0.60204"
       }
     ],
-    "version": "0.13.0.60204-139"
+    "version": "0.13.0.60204"
   },
   "rocm-core": {
     "deps": [],
     "components": [
       {
         "name": "rocm-core",
-        "sha256": "5c9ea64b97dbacba9ce8f5ead9b64c97a0091337d06c9eb31980092054abcf05",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-core/rocm-core_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "43602f7659875902a805815961c075a788e1feb3a6e3faf23b5b7adb840b111f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-core-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-core-rpath",
-        "sha256": "8955bc64a241a4c1b7773ee6460ad052552e4c0a8ed86c9adc03997ac671fdf3",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-core-rpath6.2.4/rocm-core-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "6a201a3b4a4b683325c9e8a7cf9e6f63e1e8f6416e84069a6d20457fed756f1f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-core-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
   },
   "rocm-core-asan": {
     "deps": [
@@ -2025,58 +2633,114 @@
     "components": [
       {
         "name": "rocm-core-asan",
-        "sha256": "1dfd1bcaedfc92f72c8c0d08627295686c453ad6a856c6ae1ee676f8598941a7",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-core-asan/rocm-core-asan_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "ced89a71f95f9674f5f74ece87f4fb771ad02896efaafc1652e684b459530744",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-core-asan-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-core-asan-rpath",
-        "sha256": "5605ee6e8e5d7d0df604fb393ea8ccac625d3cd65f86391311a438f6b6023e7b",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-core-asan-rpath6.2.4/rocm-core-asan-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "cb9d1ed4eb63e02c747cbef8f719db293c19a908e82ec82980df1b5a622ac8cd",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-core-asan-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
+  },
+  "rocm-core-asan-rpath6.2.4-rpath": {
+    "deps": [],
+    "components": [
+      {
+        "name": "rocm-core-asan-rpath6.2.4-rpath",
+        "sha256": "07feb3337e0835349685ee8e2f7fb59eafbbca92e4e281de084fb38d66265764",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-core-asan-rpath6.2.4-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      }
+    ],
+    "version": "6.2.4.60204"
+  },
+  "rocm-core-asan6.2.4-rpath": {
+    "deps": [],
+    "components": [
+      {
+        "name": "rocm-core-asan6.2.4-rpath",
+        "sha256": "e1c3beaebeab6ab24f0477bca8712f0645c08f76cd09270f98dc16210b5f133e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-core-asan6.2.4-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      }
+    ],
+    "version": "6.2.4.60204"
   },
   "rocm-dbgapi": {
     "deps": [
+      "comgr",
       "rocm-core"
     ],
     "components": [
       {
         "name": "rocm-dbgapi",
-        "sha256": "090b6097216653cf9c9042161186d87d1f2e6798d0b711f59665cdce681b00c8",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-dbgapi/rocm-dbgapi_0.76.0.60204-139~20.04_amd64.deb",
-        "version": "0.76.0.60204-139"
+        "sha256": "5039d22006bc060e6fd62baa4107caf37b7168beb29d8f04c3a28c9271ae5f32",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-dbgapi-0.76.0.60204-139.el8.x86_64.rpm",
+        "version": "0.76.0.60204"
       },
       {
         "name": "rocm-dbgapi-rpath",
-        "sha256": "3004e28552f85adec054387fe9432141bd58b9d0c0a8ef0dedd02cc5bcfb6018",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-dbgapi-rpath6.2.4/rocm-dbgapi-rpath6.2.4_0.76.0.60204-139~20.04_amd64.deb",
-        "version": "0.76.0.60204-139"
+        "sha256": "2bced2ba53377e3d641785b76eb5837eadbdd66afa4670a098f40a67899bf8f9",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-dbgapi-rpath6.2.4-0.76.0.60204-139.el8.x86_64.rpm",
+        "version": "0.76.0.60204"
       }
     ],
-    "version": "0.76.0.60204-139"
+    "version": "0.76.0.60204"
   },
   "rocm-dbgapi-asan": {
     "deps": [
+      "comgr-asan",
       "rocm-core-asan"
     ],
     "components": [
       {
         "name": "rocm-dbgapi-asan",
-        "sha256": "fc283e31ccd54f301ab835430b970d58052d71592289b3502e968c18e1c32e19",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-dbgapi-asan/rocm-dbgapi-asan_0.76.0.60204-139~20.04_amd64.deb",
-        "version": "0.76.0.60204-139"
+        "sha256": "acadac5c7526245ae84ea0fcbb132148fd09de1379863611c4ae358ef1020f64",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-dbgapi-asan-0.76.0.60204-139.el8.x86_64.rpm",
+        "version": "0.76.0.60204"
       },
       {
         "name": "rocm-dbgapi-asan-rpath",
-        "sha256": "863bebd04749dfd42c64a8bcf8961bafb6810b91af04fe7284d8422623963c96",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-dbgapi-asan-rpath6.2.4/rocm-dbgapi-asan-rpath6.2.4_0.76.0.60204-139~20.04_amd64.deb",
-        "version": "0.76.0.60204-139"
+        "sha256": "a167a6ed1778bfd649b5530f75eac8c49fb5a7fb54977649e9330c4202d09452",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-dbgapi-asan-rpath6.2.4-0.76.0.60204-139.el8.x86_64.rpm",
+        "version": "0.76.0.60204"
       }
     ],
-    "version": "0.76.0.60204-139"
+    "version": "0.76.0.60204"
+  },
+  "rocm-dbgapi-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "comgr-asan-rpath6.2.4-rpath",
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-dbgapi-asan-rpath6.2.4-rpath",
+        "sha256": "e42ee2bbcf8b67f6b7077a3c1626261bb7276d20fb28aea3a7846f57c07c6651",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-dbgapi-asan-rpath6.2.4-rpath6.2.4-0.76.0.60204-139.el8.x86_64.rpm",
+        "version": "0.76.0.60204"
+      }
+    ],
+    "version": "0.76.0.60204"
+  },
+  "rocm-dbgapi-asan6.2.4-rpath": {
+    "deps": [
+      "comgr-asan6.2.4-rpath",
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-dbgapi-asan6.2.4-rpath",
+        "sha256": "c26d3315f97b6af7e3987431883a864c947088b9b5e5dc0da05bc7298a0517f9",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-dbgapi-asan6.2.4-rpath6.2.4-0.76.0.60204-139.el8.x86_64.rpm",
+        "version": "0.76.0.60204"
+      }
+    ],
+    "version": "0.76.0.60204"
   },
   "rocm-debug-agent": {
     "deps": [
@@ -2086,18 +2750,18 @@
     "components": [
       {
         "name": "rocm-debug-agent",
-        "sha256": "e9be49805360bf87f6c953e16f47b52dd900ee223babbb7e0123c7ea914a35e5",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-debug-agent/rocm-debug-agent_2.0.3.60204-139~20.04_amd64.deb",
-        "version": "2.0.3.60204-139"
+        "sha256": "fe4851a21459b980ae129cf9ae7aee040813a93a9927e38441b7177ec6f8d12d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-debug-agent-2.0.3.60204-139.el8.x86_64.rpm",
+        "version": "2.0.3.60204"
       },
       {
         "name": "rocm-debug-agent-rpath",
-        "sha256": "1a1c81e453001e99a7619360eb207e6bc869ee7431d18ec3aae585077cc23c47",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-debug-agent-rpath6.2.4/rocm-debug-agent-rpath6.2.4_2.0.3.60204-139~20.04_amd64.deb",
-        "version": "2.0.3.60204-139"
+        "sha256": "c94700cca7ed67bc9751bb0fd5cddbb74a319364bf78c800da42a33d2cd1902e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-debug-agent-rpath6.2.4-2.0.3.60204-139.el8.x86_64.rpm",
+        "version": "2.0.3.60204"
       }
     ],
-    "version": "2.0.3.60204-139"
+    "version": "2.0.3.60204"
   },
   "rocm-debug-agent-asan": {
     "deps": [
@@ -2107,18 +2771,97 @@
     "components": [
       {
         "name": "rocm-debug-agent-asan",
-        "sha256": "3485688bc7ae54cd318be6b64778edb320f9dfa722f948cb915a54fc71c8dce7",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-debug-agent-asan/rocm-debug-agent-asan_2.0.3.60204-139~20.04_amd64.deb",
-        "version": "2.0.3.60204-139"
+        "sha256": "121c3ad7ebf3e82e5331a7263b5479050cbed54617aaa1009db2adb22e9ce50c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-debug-agent-asan-2.0.3.60204-139.el8.x86_64.rpm",
+        "version": "2.0.3.60204"
       },
       {
         "name": "rocm-debug-agent-asan-rpath",
-        "sha256": "4176d90653e004a94759aeaaa9520c46c68264088df6e0ae3aee394d541609df",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-debug-agent-asan-rpath6.2.4/rocm-debug-agent-asan-rpath6.2.4_2.0.3.60204-139~20.04_amd64.deb",
-        "version": "2.0.3.60204-139"
+        "sha256": "683b66b2e25a0bb82754d013a5ab7de31ed91f32ecb07e99cd6ecb9ad8cd5ae1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-debug-agent-asan-rpath6.2.4-2.0.3.60204-139.el8.x86_64.rpm",
+        "version": "2.0.3.60204"
       }
     ],
-    "version": "2.0.3.60204-139"
+    "version": "2.0.3.60204"
+  },
+  "rocm-debug-agent-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath",
+      "rocm-dbgapi-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-debug-agent-asan-rpath6.2.4-rpath",
+        "sha256": "b914daf8b1642e3fe01cd293b5043c445e6ae8df9d5cb934196d3d55526c6a83",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-debug-agent-asan-rpath6.2.4-rpath6.2.4-2.0.3.60204-139.el8.x86_64.rpm",
+        "version": "2.0.3.60204"
+      }
+    ],
+    "version": "2.0.3.60204"
+  },
+  "rocm-debug-agent-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath",
+      "rocm-dbgapi-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-debug-agent-asan6.2.4-rpath",
+        "sha256": "0cf8a7a209fdd0455a921c31124345283223df2bab167e8d3b8653775d51ec54",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-debug-agent-asan6.2.4-rpath6.2.4-2.0.3.60204-139.el8.x86_64.rpm",
+        "version": "2.0.3.60204"
+      }
+    ],
+    "version": "2.0.3.60204"
+  },
+  "rocm-dev": {
+    "deps": [
+      "amd-smi-lib",
+      "comgr",
+      "hip-devel",
+      "hip-doc",
+      "hip-runtime-amd",
+      "hip-samples",
+      "hipcc",
+      "hipify-clang",
+      "hsa-amd-aqlprofile",
+      "hsa-rocr",
+      "hsakmt-roct-devel",
+      "openmp-extras-devel",
+      "openmp-extras-runtime",
+      "rocm-cmake",
+      "rocm-core",
+      "rocm-dbgapi",
+      "rocm-debug-agent",
+      "rocm-device-libs",
+      "rocm-gdb",
+      "rocm-llvm",
+      "rocm-opencl",
+      "rocm-opencl-icd-loader",
+      "rocm-smi-lib",
+      "rocm-utils",
+      "rocprofiler",
+      "rocprofiler-plugins",
+      "rocprofiler-register",
+      "rocprofiler-sdk",
+      "rocprofiler-sdk-roctx",
+      "roctracer"
+    ],
+    "components": [
+      {
+        "name": "rocm-dev",
+        "sha256": "73ea977c6f136a089d6768fe44e777808863997af40f9787bf573bb240f3794e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-dev-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      },
+      {
+        "name": "rocm-dev-rpath",
+        "sha256": "49af158fc27a44ae57e2c3169f2c9a0e97c2a87e2564236d7fe7b27c854937b2",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-dev-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      }
+    ],
+    "version": "6.2.4.60204"
   },
   "rocm-dev-asan": {
     "deps": [
@@ -2129,10 +2872,10 @@
       "hsa-rocr-asan",
       "hsakmt-roct-asan",
       "openmp-extras-asan",
-      "rocm",
       "rocm-core-asan",
       "rocm-dbgapi-asan",
       "rocm-debug-agent-asan",
+      "rocm-dev",
       "rocm-opencl-asan",
       "rocm-smi-lib-asan",
       "rocprofiler-asan",
@@ -2141,18 +2884,72 @@
     "components": [
       {
         "name": "rocm-dev-asan",
-        "sha256": "ca95d90b0ce245eba46fd0a065aa1d9fd483f459acc2d57002fdab7062b12d6e",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-dev-asan/rocm-dev-asan_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "5b5bff2580513b4b004f529e6a40b6b261bf9c9a64058e1bf7133dc4d6b4d675",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-dev-asan-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-dev-asan-rpath",
-        "sha256": "fcebb22b8c02a7f730c20a4b0505f029d027f026f59c51f26c2e858cfa6b047a",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-dev-asan-rpath6.2.4/rocm-dev-asan-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "9a28242ce5bff553964d8118e923cf454602d0a4fadb4f34732b1a783d0a3148",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-dev-asan-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
+  },
+  "rocm-dev-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "amd-smi-lib-asan-rpath6.2.4-rpath",
+      "comgr-asan-rpath6.2.4-rpath",
+      "hip-runtime-amd-asan-rpath6.2.4-rpath",
+      "hsa-amd-aqlprofile-asan-rpath6.2.4-rpath",
+      "hsa-rocr-asan-rpath6.2.4-rpath",
+      "hsakmt-roct-asan-rpath6.2.4-rpath",
+      "openmp-extras-asan-rpath6.2.4-rpath",
+      "rocm-core-asan-rpath6.2.4-rpath",
+      "rocm-dbgapi-asan-rpath6.2.4-rpath",
+      "rocm-debug-agent-asan-rpath6.2.4-rpath",
+      "rocm-opencl-asan-rpath6.2.4-rpath",
+      "rocm-smi-lib-asan-rpath6.2.4-rpath",
+      "rocprofiler-asan-rpath6.2.4-rpath",
+      "roctracer-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-dev-asan-rpath6.2.4-rpath",
+        "sha256": "358f8dfd5983258aae68d1f0e4448eab475ec01f3e8e00d6f0cb938a271e8803",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-dev-asan-rpath6.2.4-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      }
+    ],
+    "version": "6.2.4.60204"
+  },
+  "rocm-dev-asan6.2.4-rpath": {
+    "deps": [
+      "amd-smi-lib-asan6.2.4-rpath",
+      "comgr-asan6.2.4-rpath",
+      "hip-runtime-amd-asan6.2.4-rpath",
+      "hsa-amd-aqlprofile-asan6.2.4-rpath",
+      "hsa-rocr-asan6.2.4-rpath",
+      "hsakmt-roct-asan6.2.4-rpath",
+      "openmp-extras-asan6.2.4-rpath",
+      "rocm-core-asan6.2.4-rpath",
+      "rocm-dbgapi-asan6.2.4-rpath",
+      "rocm-debug-agent-asan6.2.4-rpath",
+      "rocm-opencl-asan6.2.4-rpath",
+      "rocm-smi-lib-asan6.2.4-rpath",
+      "rocprofiler-asan6.2.4-rpath",
+      "roctracer-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-dev-asan6.2.4-rpath",
+        "sha256": "c3d660bd03cc722a8ddd455651a4a99e694428876ad28312305824c0ae99c6b3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-dev-asan6.2.4-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      }
+    ],
+    "version": "6.2.4.60204"
   },
   "rocm-developer-tools": {
     "deps": [
@@ -2174,18 +2971,18 @@
     "components": [
       {
         "name": "rocm-developer-tools",
-        "sha256": "c3bdd2f3b1db0169b1156ecfdd25d413100d64b29dadf4fa70087a3457ee2fe7",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-developer-tools/rocm-developer-tools_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "677dc8ced64da3bd5bf204a46a27584258f1528396b5fd3fc50eb3e368f99af1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-developer-tools-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-developer-tools-rpath",
-        "sha256": "d8c959bf7e4dae4865d6d29c23f4476a0eb53c9e60656bc648885d82d5820608",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-developer-tools-rpath6.2.4/rocm-developer-tools-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "553865e6198adb93578254daff40a84b7ee241ed8f81059314c5781d833b4699",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-developer-tools-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
   },
   "rocm-developer-tools-asan": {
     "deps": [
@@ -2203,18 +3000,62 @@
     "components": [
       {
         "name": "rocm-developer-tools-asan",
-        "sha256": "604a765a565d73a36d9e42360e824508db38a535de0088ffda92af6154dd3808",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-developer-tools-asan/rocm-developer-tools-asan_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "9b4e00f432c2d7f528f2df1cb783963097bc617011e9e2d1992f3a51d8465774",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-developer-tools-asan-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-developer-tools-asan-rpath",
-        "sha256": "31d97376415fd2fff47feb2045c7c5c342dfa04b2081b048e84eca548fc322de",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-developer-tools-asan-rpath6.2.4/rocm-developer-tools-asan-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "2ce06604c2f0b30c49f684f31328b07a9630302e22afaa7305c49ea2c0ceafca",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-developer-tools-asan-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
+  },
+  "rocm-developer-tools-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "amd-smi-lib-asan-rpath6.2.4-rpath",
+      "hsa-amd-aqlprofile-asan-rpath6.2.4-rpath",
+      "rocm-core-asan-rpath6.2.4-rpath",
+      "rocm-dbgapi-asan-rpath6.2.4-rpath",
+      "rocm-debug-agent-asan-rpath6.2.4-rpath",
+      "rocm-language-runtime-asan-rpath6.2.4-rpath",
+      "rocm-smi-lib-asan-rpath6.2.4-rpath",
+      "rocprofiler-asan-rpath6.2.4-rpath",
+      "roctracer-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-developer-tools-asan-rpath6.2.4-rpath",
+        "sha256": "1b5e22b28586e76efb468bccb61c38cca767f43050961400afe446e544b9b25e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-developer-tools-asan-rpath6.2.4-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      }
+    ],
+    "version": "6.2.4.60204"
+  },
+  "rocm-developer-tools-asan6.2.4-rpath": {
+    "deps": [
+      "amd-smi-lib-asan6.2.4-rpath",
+      "hsa-amd-aqlprofile-asan6.2.4-rpath",
+      "rocm-core-asan6.2.4-rpath",
+      "rocm-dbgapi-asan6.2.4-rpath",
+      "rocm-debug-agent-asan6.2.4-rpath",
+      "rocm-language-runtime-asan6.2.4-rpath",
+      "rocm-smi-lib-asan6.2.4-rpath",
+      "rocprofiler-asan6.2.4-rpath",
+      "roctracer-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-developer-tools-asan6.2.4-rpath",
+        "sha256": "401e4b79dfb2a1a9cbefe92077f13b741c2ddf8951318e7454480c4725648c6f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-developer-tools-asan6.2.4-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      }
+    ],
+    "version": "6.2.4.60204"
   },
   "rocm-device-libs": {
     "deps": [
@@ -2223,39 +3064,38 @@
     "components": [
       {
         "name": "rocm-device-libs",
-        "sha256": "b29e708b2143255a233ed333fc45e9c0209d97823a8351ed955249d1cbbdab32",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-device-libs/rocm-device-libs_1.0.0.60204-139~20.04_amd64.deb",
-        "version": "1.0.0.60204-139"
+        "sha256": "bc63f28defc1e65572119c27a5209f0c53464e03ad8781b397f2f65085494645",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-device-libs-1.0.0.60204-139.el8.x86_64.rpm",
+        "version": "1.0.0.60204"
       },
       {
         "name": "rocm-device-libs-rpath",
-        "sha256": "0135528a18748254961b660ddf69fc3c7cff14b316a110d660ece7f4ed9c2302",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-device-libs-rpath6.2.4/rocm-device-libs-rpath6.2.4_1.0.0.60204-139~20.04_amd64.deb",
-        "version": "1.0.0.60204-139"
+        "sha256": "8a14cb5d329abba0ea8c9c03b1946945a0ddf094e803d849395f0c60e5ee4fa8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-device-libs-rpath6.2.4-1.0.0.60204-139.el8.x86_64.rpm",
+        "version": "1.0.0.60204"
       }
     ],
-    "version": "1.0.0.60204-139"
+    "version": "1.0.0.60204"
   },
   "rocm-gdb": {
     "deps": [
-      "rocm-core",
-      "rocm-dbgapi"
+      "rocm-core"
     ],
     "components": [
       {
         "name": "rocm-gdb",
-        "sha256": "30229137c81ae23f221149b57282dd5c6869df9820d385d30f555fcd3314b56f",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-gdb/rocm-gdb_14.2.60204-139~20.04_amd64.deb",
-        "version": "14.2.60204-139"
+        "sha256": "1069312bfce8b0d91fc8c9f3f8566a6302e3ea337e6533cb22c405549fd6db82",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-gdb-14.2.60204-139.el8.x86_64.rpm",
+        "version": "14.2.60204"
       },
       {
         "name": "rocm-gdb-rpath",
-        "sha256": "bdfba5a3bfa9569d267e9c42671eb36ca09db6d5270a25d1146989820f5f82bc",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-gdb-rpath6.2.4/rocm-gdb-rpath6.2.4_14.2.60204-139~20.04_amd64.deb",
-        "version": "14.2.60204-139"
+        "sha256": "53635c6533d7d0cc10852dcfedecfdcea48f3fde69478217e138f4ca84ab956d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-gdb-rpath6.2.4-14.2.60204-139.el8.x86_64.rpm",
+        "version": "14.2.60204"
       }
     ],
-    "version": "14.2.60204-139"
+    "version": "14.2.60204"
   },
   "rocm-hip-libraries": {
     "deps": [
@@ -2281,18 +3121,18 @@
     "components": [
       {
         "name": "rocm-hip-libraries",
-        "sha256": "7bc772766be3b997f06478ed952ac5123a93e3baa94de54b3e4324686ba2bc03",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-hip-libraries/rocm-hip-libraries_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "f8a7ea7113159bcbb58fef89d26b1db1955267f92f602ea9eb79e22f7c20cbd5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-hip-libraries-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-hip-libraries-rpath",
-        "sha256": "ac0c2cd7fc8cf3f0d4904efad7a203eed9da538566503592b0bbe59a5919bd3a",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-hip-libraries-rpath6.2.4/rocm-hip-libraries-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "6710ce747ae85275686a287abdaba5ea4fdd4532b36ed94418c121a5027a6046",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-hip-libraries-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
   },
   "rocm-hip-libraries-asan": {
     "deps": [
@@ -2319,29 +3159,91 @@
     "components": [
       {
         "name": "rocm-hip-libraries-asan",
-        "sha256": "bc028730a449650278203792eda0d2f79ab155db352e34ea08333b9111959fcc",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-hip-libraries-asan/rocm-hip-libraries-asan_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "14e28a57115ca9444894c00648b6544ffcbdc613341af20ac76894ff2bb9c10d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-hip-libraries-asan-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-hip-libraries-asan-rpath",
-        "sha256": "cb3a3ae933415e3f49d9436201acdc84ce941be205deb61f964f18ff58d85608",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-hip-libraries-asan-rpath6.2.4/rocm-hip-libraries-asan-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "e149e15ff92e275acab7592bcdc66b03c5294953950a1f01640b8b6a769da4f1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-hip-libraries-asan-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
+  },
+  "rocm-hip-libraries-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "hipblas-asan-rpath6.2.4-rpath",
+      "hipblaslt-asan-rpath6.2.4-rpath",
+      "hipfft-asan-rpath6.2.4-rpath",
+      "hiprand-asan-rpath6.2.4-rpath",
+      "hipsolver-asan-rpath6.2.4-rpath",
+      "hipsparse-asan-rpath6.2.4-rpath",
+      "hipsparselt-asan-rpath6.2.4-rpath",
+      "hiptensor-asan-rpath6.2.4-rpath",
+      "rccl-asan-rpath6.2.4-rpath",
+      "rocalution-asan-rpath6.2.4-rpath",
+      "rocblas-asan-rpath6.2.4-rpath",
+      "rocfft-asan-rpath6.2.4-rpath",
+      "rocm-core-asan-rpath6.2.4-rpath",
+      "rocm-hip-runtime-asan-rpath6.2.4-rpath",
+      "rocm-smi-lib-asan-rpath6.2.4-rpath",
+      "rocrand-asan-rpath6.2.4-rpath",
+      "rocsolver-asan-rpath6.2.4-rpath",
+      "rocsparse-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-hip-libraries-asan-rpath6.2.4-rpath",
+        "sha256": "12a7c35134c9e43b1e4dfbd3cfd4aad92c7097e6528301736df51ff92e7bb6ee",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-hip-libraries-asan-rpath6.2.4-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      }
+    ],
+    "version": "6.2.4.60204"
+  },
+  "rocm-hip-libraries-asan6.2.4-rpath": {
+    "deps": [
+      "hipblas-asan6.2.4-rpath",
+      "hipblaslt-asan6.2.4-rpath",
+      "hipfft-asan6.2.4-rpath",
+      "hiprand-asan6.2.4-rpath",
+      "hipsolver-asan6.2.4-rpath",
+      "hipsparse-asan6.2.4-rpath",
+      "hipsparselt-asan6.2.4-rpath",
+      "hiptensor-asan6.2.4-rpath",
+      "rccl-asan6.2.4-rpath",
+      "rocalution-asan6.2.4-rpath",
+      "rocblas-asan6.2.4-rpath",
+      "rocfft-asan6.2.4-rpath",
+      "rocm-core-asan6.2.4-rpath",
+      "rocm-hip-runtime-asan6.2.4-rpath",
+      "rocm-smi-lib-asan6.2.4-rpath",
+      "rocrand-asan6.2.4-rpath",
+      "rocsolver-asan6.2.4-rpath",
+      "rocsparse-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-hip-libraries-asan6.2.4-rpath",
+        "sha256": "3ebf5a1e805e9d22930c8b81264061f73d2781def3384472031ac84dbd7dc3c6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-hip-libraries-asan6.2.4-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      }
+    ],
+    "version": "6.2.4.60204"
   },
   "rocm-hip-runtime": {
     "deps": [
-      "hip-dev",
+      "hip-devel",
       "hip-doc",
       "hip-runtime-amd",
       "hip-samples",
       "hipcc",
       "hipify-clang",
       "hsa-rocr",
-      "hsakmt-roct-dev",
+      "hsakmt-roct-devel",
       "rocm-cmake",
       "rocm-core",
       "rocm-device-libs",
@@ -2352,30 +3254,30 @@
     "components": [
       {
         "name": "rocm-hip-runtime",
-        "sha256": "2ced4fef595a4f63797c9d096a9171a9e7f2d29c8f396339d987cbce70804fe1",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-hip-runtime/rocm-hip-runtime_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "bfd25a4d3894fc4a2bd7779636bfbcda510d62e3a646c48495d9cfe8ce0cec22",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-hip-runtime-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
-        "name": "rocm-hip-runtime-dev",
-        "sha256": "4694d15e0f3e904993c582526fa68547bdfe436ed07a61a96773351742169fb6",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-hip-runtime-dev/rocm-hip-runtime-dev_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "name": "rocm-hip-runtime-devel",
+        "sha256": "f21e7df8ce4d4131f90a7711dd30e5bd69fb27e984320ec2281b130867d712dd",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-hip-runtime-devel-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
-        "name": "rocm-hip-runtime-dev-rpath",
-        "sha256": "92033a88d16d3874a5413d6ccf45fe501d887e99ce4055c3d1590fc1dc36843a",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-hip-runtime-dev-rpath6.2.4/rocm-hip-runtime-dev-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "name": "rocm-hip-runtime-devel-rpath",
+        "sha256": "8868283438249ba3f736607ae34c080b8dde1d1bd94a253019363cb03442c36c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-hip-runtime-devel-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-hip-runtime-rpath",
-        "sha256": "04bdce2fc7a3570557dc07a322d2d1202b2c2d4f768ad89ea7586f60059dab9a",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-hip-runtime-rpath6.2.4/rocm-hip-runtime-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "24dc9e7c3e0aa891588e0807d2fd62c90e43ed16561497a7a141a1305d187da3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-hip-runtime-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
   },
   "rocm-hip-runtime-asan": {
     "deps": [
@@ -2387,27 +3289,59 @@
     "components": [
       {
         "name": "rocm-hip-runtime-asan",
-        "sha256": "32744c9a72497a3f7bd99c1790bcf960fb0312240de66c50b9bdb4480fd449f0",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-hip-runtime-asan/rocm-hip-runtime-asan_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "93fe5a33e75b67f23404b4053ce06bdb37b928a96a89f5e5ac4d81602ec51c09",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-hip-runtime-asan-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-hip-runtime-asan-rpath",
-        "sha256": "cd28116948f1ca409d9f8db47c2e7e7ebcb77004ffdee8647be4f7dc0a62da5b",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-hip-runtime-asan-rpath6.2.4/rocm-hip-runtime-asan-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "fc07bdb6d5115dd7a8cbddfb5b7b43b5e426a54f6b7aaecdb84675a21c75316a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-hip-runtime-asan-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
+  },
+  "rocm-hip-runtime-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "hip-runtime-amd-asan-rpath6.2.4-rpath",
+      "rocm-core-asan-rpath6.2.4-rpath",
+      "rocm-language-runtime-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-hip-runtime-asan-rpath6.2.4-rpath",
+        "sha256": "8f45a2a5ec0b7cfe50e35012429fde170da839b888e53fb54d599ff9080742dd",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-hip-runtime-asan-rpath6.2.4-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      }
+    ],
+    "version": "6.2.4.60204"
+  },
+  "rocm-hip-runtime-asan6.2.4-rpath": {
+    "deps": [
+      "hip-runtime-amd-asan6.2.4-rpath",
+      "rocm-core-asan6.2.4-rpath",
+      "rocm-language-runtime-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-hip-runtime-asan6.2.4-rpath",
+        "sha256": "44f62debb5fca5d14a662a26a57a39b7e7a292385910f58fe0531dbfb4725aa8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-hip-runtime-asan6.2.4-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      }
+    ],
+    "version": "6.2.4.60204"
   },
   "rocm-hip-sdk": {
     "deps": [
-      "composablekernel-dev",
+      "composablekernel-devel",
       "hipblas",
       "hipblaslt",
-      "hipcub-dev",
+      "hipcub-devel",
       "hipfft",
-      "hipfort-dev",
+      "hipfort-devel",
       "hiprand",
       "hipsolver",
       "hipsparse",
@@ -2420,28 +3354,28 @@
       "rocm-core",
       "rocm-hip-libraries",
       "rocm-hip-runtime",
-      "rocprim-dev",
+      "rocprim-devel",
       "rocrand",
       "rocsolver",
       "rocsparse",
-      "rocthrust-dev",
-      "rocwmma-dev"
+      "rocthrust-devel",
+      "rocwmma-devel"
     ],
     "components": [
       {
         "name": "rocm-hip-sdk",
-        "sha256": "60c7cce85998dd889fa3699ba566f8158518786370cc4bae65935035ebbec5d8",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-hip-sdk/rocm-hip-sdk_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "c3b42fb8240078333b9a856664f225895ea4f9248c498239bafc23ae9933b30f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-hip-sdk-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-hip-sdk-rpath",
-        "sha256": "8151f97bfd130a969cec5754a6e37a7fe64d6a0d412e776ecaaa89c85311bda3",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-hip-sdk-rpath6.2.4/rocm-hip-sdk-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "469fed37c507d030d3a5dd5ac6cbe76dbaccf4636c3e168fd2f0220923727ca8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-hip-sdk-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
   },
   "rocm-khronos-cts": {
     "deps": [
@@ -2451,18 +3385,18 @@
     "components": [
       {
         "name": "rocm-khronos-cts",
-        "sha256": "f4c6e8e8f5884bb6f0ea8c4c4cf363c4d31ddd830b0a5ddf838a5c946e4f2ee9",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-khronos-cts/rocm-khronos-cts_3.0.0.60204-139~20.04_amd64.deb",
-        "version": "3.0.0.60204-139"
+        "sha256": "a9cf64952454e4b8966bc5c9c83b293b3d1fc6236c9ed7037c8e1040f8334639",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-khronos-cts-3.0.0.60204-139.el8.x86_64.rpm",
+        "version": "3.0.0.60204"
       },
       {
         "name": "rocm-khronos-cts-rpath",
-        "sha256": "a89ac432208ff629c5f7b2dca50b8ff59864188111d52218ec98ff43d182710f",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-khronos-cts-rpath6.2.4/rocm-khronos-cts-rpath6.2.4_3.0.0.60204-139~20.04_amd64.deb",
-        "version": "3.0.0.60204-139"
+        "sha256": "17f3f41e4cf2010561c032c46d8eccec024187728851326701511d5015afe687",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-khronos-cts-rpath6.2.4-3.0.0.60204-139.el8.x86_64.rpm",
+        "version": "3.0.0.60204"
       }
     ],
-    "version": "3.0.0.60204-139"
+    "version": "3.0.0.60204"
   },
   "rocm-language-runtime": {
     "deps": [
@@ -2474,18 +3408,18 @@
     "components": [
       {
         "name": "rocm-language-runtime",
-        "sha256": "25f081390b869e7fc07f547155fd02e8c7fe66b7dda29021eb6c993f383bd2bb",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-language-runtime/rocm-language-runtime_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "25d0f68758c6de30af89c2d5e3996cf2f59c43b7c5c4b815550100dd669101d6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-language-runtime-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-language-runtime-rpath",
-        "sha256": "5addb7ec8515334ca63f2f704d2655ceeefaf6c2cb8f002dcc49d450c6ee9833",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-language-runtime-rpath6.2.4/rocm-language-runtime-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "e7386f5b9bbcdf121cef92f7f96fd1daff627c3aa420916fa11c5102c0507182",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-language-runtime-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
   },
   "rocm-language-runtime-asan": {
     "deps": [
@@ -2499,26 +3433,62 @@
     "components": [
       {
         "name": "rocm-language-runtime-asan",
-        "sha256": "488d614dfaeab9f3705e7c2a5a12b0e519c6872897e4e3e763fe30e6ddabcaf1",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-language-runtime-asan/rocm-language-runtime-asan_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "b2196723b5eb364c81aacb26d11756b05e3a87279833220ba4576bd736411649",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-language-runtime-asan-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-language-runtime-asan-rpath",
-        "sha256": "c6f434e9de73d1c5b81f377a612fe2ecfdba936def6eb6099943633e5dea7b72",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-language-runtime-asan-rpath6.2.4/rocm-language-runtime-asan-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "a3d05454370b69f347a573773a8683b013c361c927636fadb26c33f777fb2a7d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-language-runtime-asan-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
+  },
+  "rocm-language-runtime-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "comgr-asan-rpath6.2.4-rpath",
+      "hsa-rocr-asan-rpath6.2.4-rpath",
+      "hsakmt-roct-asan-rpath6.2.4-rpath",
+      "openmp-extras-asan-rpath6.2.4-rpath",
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-language-runtime-asan-rpath6.2.4-rpath",
+        "sha256": "9829f3092c6d5024729ea3fb73f5c3f50c82ae904743a6fae0861d7ce486b8b0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-language-runtime-asan-rpath6.2.4-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      }
+    ],
+    "version": "6.2.4.60204"
+  },
+  "rocm-language-runtime-asan6.2.4-rpath": {
+    "deps": [
+      "comgr-asan6.2.4-rpath",
+      "hsa-rocr-asan6.2.4-rpath",
+      "hsakmt-roct-asan6.2.4-rpath",
+      "openmp-extras-asan6.2.4-rpath",
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-language-runtime-asan6.2.4-rpath",
+        "sha256": "af4a6171d504bbb49860d813703b2259ed58d52d6dbe4546aa5ab45e72a1e7c2",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-language-runtime-asan6.2.4-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      }
+    ],
+    "version": "6.2.4.60204"
   },
   "rocm-libs": {
     "deps": [
-      "composablekernel-dev",
+      "composablekernel-devel",
       "half",
       "hipblas",
       "hipblaslt",
-      "hipcub-dev",
+      "hipcub-devel",
       "hipfft",
       "hiprand",
       "hipsolver",
@@ -2531,28 +3501,28 @@
       "rocblas",
       "rocfft",
       "rocm-core",
-      "rocprim-dev",
+      "rocprim-devel",
       "rocrand",
       "rocsolver",
       "rocsparse",
-      "rocthrust-dev",
-      "rocwmma-dev"
+      "rocthrust-devel",
+      "rocwmma-devel"
     ],
     "components": [
       {
         "name": "rocm-libs",
-        "sha256": "75e7ce8caf45411f4273f54adfc0de84c2b7613fb90c4297065647842852f1f1",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-libs/rocm-libs_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "d6cca772fccd4f4e36721648e29d688efaacce475501cef67b8586f8e73c39b7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-libs-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-libs-rpath",
-        "sha256": "24a069b1247155dec954b22f12da6863c0987cdda2f26c94fb92874fbd2c5ae5",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-libs-rpath6.2.4/rocm-libs-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "b76e3d52924f9f769200ce4d76cc23e0d435b32be7ab9fc2392d293aec606c8a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-libs-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
   },
   "rocm-llvm": {
     "deps": [
@@ -2561,30 +3531,30 @@
     "components": [
       {
         "name": "rocm-llvm",
-        "sha256": "a5669384ef20353202cb2013224587d0214d43a575d4b53520408b0927170353",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-llvm/rocm-llvm_18.0.0.24392.60204-139~20.04_amd64.deb",
-        "version": "18.0.0.24392.60204-139"
+        "sha256": "a961588b94aea4c246b4f9222c614adb5415160dd1cc905e420b277ca6449e17",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-llvm-18.0.0.24392.60204-139.el8.x86_64.rpm",
+        "version": "18.0.0.24392.60204"
       },
       {
-        "name": "rocm-llvm-dev",
-        "sha256": "7c1ed14a36e0fb97e9ae82b7f5143737eb07aabfdc909d6b9fd0f09491fa7593",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-llvm-dev/rocm-llvm-dev_18.0.0.24392.60204-139~20.04_amd64.deb",
-        "version": "18.0.0.24392.60204-139"
+        "name": "rocm-llvm-devel",
+        "sha256": "265cfbfa81044b985afd4667b31972cfafa7cedcfc91de94220776e577e49be5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-llvm-devel-18.0.0.24392.60204-139.el8.x86_64.rpm",
+        "version": "18.0.0.24392.60204"
       },
       {
-        "name": "rocm-llvm-dev-rpath",
-        "sha256": "a0e5d3ded97252b8bf913b24ff1acbf53f76248a636ba82a5be40d0252ae7a5c",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-llvm-dev-rpath6.2.4/rocm-llvm-dev-rpath6.2.4_18.0.0.24392.60204-139~20.04_amd64.deb",
-        "version": "18.0.0.24392.60204-139"
+        "name": "rocm-llvm-devel-rpath",
+        "sha256": "b209a1f1859c8e7418fa6174d04851d004771dd9dd385b3a545a145b81a4b475",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-llvm-devel-rpath6.2.4-18.0.0.24392.60204-139.el8.x86_64.rpm",
+        "version": "18.0.0.24392.60204"
       },
       {
         "name": "rocm-llvm-rpath",
-        "sha256": "a7440f3e2ae5f442fc48fae91c527e6d685606ecb96f1c7bfbe1f2f100861e8e",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-llvm-rpath6.2.4/rocm-llvm-rpath6.2.4_18.0.0.24392.60204-139~20.04_amd64.deb",
-        "version": "18.0.0.24392.60204-139"
+        "sha256": "8f5836c346fd372d3cf5eb534bf99fcf05b48a40d1df7e9978d86eeaff41c0fb",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-llvm-rpath6.2.4-18.0.0.24392.60204-139.el8.x86_64.rpm",
+        "version": "18.0.0.24392.60204"
       }
     ],
-    "version": "18.0.0.24392.60204-139"
+    "version": "18.0.0.24392.60204"
   },
   "rocm-llvm-docs": {
     "deps": [
@@ -2593,18 +3563,18 @@
     "components": [
       {
         "name": "rocm-llvm-docs",
-        "sha256": "c290cac6953c119826502d853ace506ee3bbbc193685e35eb0754891a1940d05",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-llvm-docs/rocm-llvm-docs_18.0.0.24392.60204-139~20.04_amd64.deb",
-        "version": "18.0.0.24392.60204-139"
+        "sha256": "7c5ea15e69d7412612545f8cbfffba73094e9ee641618c71c197be0ce56dcf67",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-llvm-docs-18.0.0.24392.60204-139.el8.x86_64.rpm",
+        "version": "18.0.0.24392.60204"
       },
       {
         "name": "rocm-llvm-docs-rpath",
-        "sha256": "29bec456d617cb94e7459f4309b1040ff2acd1aed3d598c1e585fa4fa699ccb8",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-llvm-docs-rpath6.2.4/rocm-llvm-docs-rpath6.2.4_18.0.0.24392.60204-139~20.04_amd64.deb",
-        "version": "18.0.0.24392.60204-139"
+        "sha256": "642b242ffde3b6a6742c58122bc744a3f0d12dbfcf23e8080a6b6955b2db987b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-llvm-docs-rpath6.2.4-18.0.0.24392.60204-139.el8.x86_64.rpm",
+        "version": "18.0.0.24392.60204"
       }
     ],
-    "version": "18.0.0.24392.60204-139"
+    "version": "18.0.0.24392.60204"
   },
   "rocm-ml-libraries": {
     "deps": [
@@ -2617,18 +3587,18 @@
     "components": [
       {
         "name": "rocm-ml-libraries",
-        "sha256": "c9cef768c754b6a7895967c93bc1ef0968a6f03ac12bdf2678119be5ab6aefa6",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-ml-libraries/rocm-ml-libraries_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "7ded9ab4a317f3f57b0d285cf9a8e0d2fb1f398d4071c58fdb14ccbc6bee0939",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-ml-libraries-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-ml-libraries-rpath",
-        "sha256": "179eb6d251099eca96b3bd78d616149180f5442ff3f2608bfd8ca4cbf6bdfb91",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-ml-libraries-rpath6.2.4/rocm-ml-libraries-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "8503153050f4e286d49915ff362a06bb426133483ac4a4446230bfb1217a2242",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-ml-libraries-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
   },
   "rocm-ml-libraries-asan": {
     "deps": [
@@ -2640,18 +3610,50 @@
     "components": [
       {
         "name": "rocm-ml-libraries-asan",
-        "sha256": "030a4632b34ce627bb39316e531644a3a67f3bec5526f880789151b6c9cf0255",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-ml-libraries-asan/rocm-ml-libraries-asan_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "4fcdde972439d7c1a7ae04d81a6eedeb42cca7ab2996a219599dc0e48fc4ac3f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-ml-libraries-asan-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-ml-libraries-asan-rpath",
-        "sha256": "4cdab9f6d88c43e87ac7b61c3d261f4e48868e2938548ae11057ba1c35ed1250",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-ml-libraries-asan-rpath6.2.4/rocm-ml-libraries-asan-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "c30b62ec514574d610e208377d3b126d695e3c7d241d70046b691ebea578833e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-ml-libraries-asan-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
+  },
+  "rocm-ml-libraries-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "miopen-hip-asan-rpath6.2.4-rpath",
+      "rocm-core-asan-rpath6.2.4-rpath",
+      "rocm-hip-libraries-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-ml-libraries-asan-rpath6.2.4-rpath",
+        "sha256": "b2246ec45deeed64c6f5bf5f1cac42a31f8baee3c1dd5fa13a10224cdae9610c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-ml-libraries-asan-rpath6.2.4-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      }
+    ],
+    "version": "6.2.4.60204"
+  },
+  "rocm-ml-libraries-asan6.2.4-rpath": {
+    "deps": [
+      "miopen-hip-asan6.2.4-rpath",
+      "rocm-core-asan6.2.4-rpath",
+      "rocm-hip-libraries-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-ml-libraries-asan6.2.4-rpath",
+        "sha256": "7bcb3f80cf474c16628b8d8efd15f26af7ed814b66e99a938768225655160207",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-ml-libraries-asan6.2.4-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      }
+    ],
+    "version": "6.2.4.60204"
   },
   "rocm-ml-sdk": {
     "deps": [
@@ -2663,18 +3665,18 @@
     "components": [
       {
         "name": "rocm-ml-sdk",
-        "sha256": "cd85a37a4225e34e5aa98ea285dbc8a9a17693a7854505aaffdb67d6ec25da23",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-ml-sdk/rocm-ml-sdk_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "18820096c106e5f7899281833464006feee45c1d0594977e1a7decc7682ee345",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-ml-sdk-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-ml-sdk-rpath",
-        "sha256": "92e895f3b0fc2ed818e5df0734c0f88c86353597d0326d3a4827a4d86c579b9a",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-ml-sdk-rpath6.2.4/rocm-ml-sdk-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "07de9b83162139c6f231bfd87caeaa39c21ec2bc7ecba69da1138d32f8b55673",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-ml-sdk-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
   },
   "rocm-ml-sdk-asan": {
     "deps": [
@@ -2685,36 +3687,66 @@
     "components": [
       {
         "name": "rocm-ml-sdk-asan",
-        "sha256": "3302732b6f85d68081bf9da7af8c93f84e3d9f864e205c930bd31b56ec518714",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-ml-sdk-asan/rocm-ml-sdk-asan_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "d4a479369647420a1d3771d0faae355b9908cd00257361e2b08dd8a66626b294",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-ml-sdk-asan-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-ml-sdk-asan-rpath",
-        "sha256": "ad101002377edef4415d0cf06b1f9d7ee217a82cab76a7ee1006b09733a29f06",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-ml-sdk-asan-rpath6.2.4/rocm-ml-sdk-asan-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "10ab2e859d48cdd8f695f9d3c86ab5a0b73b9ee2e3203a56734d368f9fe9687d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-ml-sdk-asan-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
+  },
+  "rocm-ml-sdk-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath",
+      "rocm-ml-libraries-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-ml-sdk-asan-rpath6.2.4-rpath",
+        "sha256": "01d376965e0d4bb0b6c2cf1a5bda7368491bb24550f78cb6c9039782c8f50e6e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-ml-sdk-asan-rpath6.2.4-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      }
+    ],
+    "version": "6.2.4.60204"
+  },
+  "rocm-ml-sdk-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath",
+      "rocm-ml-libraries-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-ml-sdk-asan6.2.4-rpath",
+        "sha256": "f9a1106cbbd1bbe0122ddb43e3ae8e09b2c7e013b823c0c2ba87958f52ae1d63",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-ml-sdk-asan6.2.4-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      }
+    ],
+    "version": "6.2.4.60204"
   },
   "rocm-ocltst": {
     "deps": [],
     "components": [
       {
         "name": "rocm-ocltst",
-        "sha256": "cb2596403196a5d1bcea3c0b3f9d1b4e976fb1fc96a62ca5a8cd0deb8f32e63c",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-ocltst/rocm-ocltst_2.0.0.60204-139~20.04_amd64.deb",
-        "version": "2.0.0.60204-139"
+        "sha256": "ddbea5591ba50c5ecce2ea7f2ced628e0d69ef430a2097f5ac09fde2fdbff243",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-ocltst-2.0.0.60204-139.el8.x86_64.rpm",
+        "version": "2.0.0.60204"
       },
       {
         "name": "rocm-ocltst-rpath",
-        "sha256": "b06aab47da149d2f75510cf62152ea6c30b4458242bbebf56030c6d6a3b215b8",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-ocltst-rpath6.2.4/rocm-ocltst-rpath6.2.4_2.0.0.60204-139~20.04_amd64.deb",
-        "version": "2.0.0.60204-139"
+        "sha256": "583591356be12d62db3b7be3510bb2da647bc908c75ec8e24a1cc147a09d27af",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-ocltst-rpath6.2.4-2.0.0.60204-139.el8.x86_64.rpm",
+        "version": "2.0.0.60204"
       }
     ],
-    "version": "2.0.0.60204-139"
+    "version": "2.0.0.60204"
   },
   "rocm-opencl": {
     "deps": [
@@ -2725,30 +3757,30 @@
     "components": [
       {
         "name": "rocm-opencl",
-        "sha256": "54306cb4c3c1df033f6dc6a1c4c4c8f71601e6ab5dbaf1787645ed1f673b0972",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-opencl/rocm-opencl_2.0.0.60204-139~20.04_amd64.deb",
-        "version": "2.0.0.60204-139"
+        "sha256": "9aa18b0dfbafbea5d35c82617850f8b5b83c9e2f86c9e0886e67bb25e854837d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-opencl-2.0.0.60204-139.el8.x86_64.rpm",
+        "version": "2.0.0.60204"
       },
       {
-        "name": "rocm-opencl-dev",
-        "sha256": "139e9d61ee751fc6f71a0d44b30cad416d9fb7ea8c776e425ac6849ff4a394c6",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-opencl-dev/rocm-opencl-dev_2.0.0.60204-139~20.04_amd64.deb",
-        "version": "2.0.0.60204-139"
+        "name": "rocm-opencl-devel",
+        "sha256": "29b77123d52ad1abf3f57895de53c8886fc84b37056d17c998f2a9824bea38de",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-opencl-devel-2.0.0.60204-139.el8.x86_64.rpm",
+        "version": "2.0.0.60204"
       },
       {
-        "name": "rocm-opencl-dev-rpath",
-        "sha256": "d89b1f4c0322d766c44f5357da9c618f0055278994761902496c18230421a3ae",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-opencl-dev-rpath6.2.4/rocm-opencl-dev-rpath6.2.4_2.0.0.60204-139~20.04_amd64.deb",
-        "version": "2.0.0.60204-139"
+        "name": "rocm-opencl-devel-rpath",
+        "sha256": "1e95376545971a5b2b03c9c5011f710bdaef21a03da6feabf20fae844d48512b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-opencl-devel-rpath6.2.4-2.0.0.60204-139.el8.x86_64.rpm",
+        "version": "2.0.0.60204"
       },
       {
         "name": "rocm-opencl-rpath",
-        "sha256": "3aa1b859e71438f86c883e170f5e995295615da587ff4b9125cf9fa5933adc32",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-opencl-rpath6.2.4/rocm-opencl-rpath6.2.4_2.0.0.60204-139~20.04_amd64.deb",
-        "version": "2.0.0.60204-139"
+        "sha256": "e84a538c6fc64d3b877dbe935b186ab3f826d3ff63e0b4e633db5997d040b301",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-opencl-rpath6.2.4-2.0.0.60204-139.el8.x86_64.rpm",
+        "version": "2.0.0.60204"
       }
     ],
-    "version": "2.0.0.60204-139"
+    "version": "2.0.0.60204"
   },
   "rocm-opencl-asan": {
     "deps": [
@@ -2759,18 +3791,50 @@
     "components": [
       {
         "name": "rocm-opencl-asan",
-        "sha256": "e95d0782dcad29ca7d3506d9ba0bfb2757139577ed32cb67a3ac91b4a44ffa25",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-opencl-asan/rocm-opencl-asan_2.0.0.60204-139~20.04_amd64.deb",
-        "version": "2.0.0.60204-139"
+        "sha256": "707d0ec491d7a795ed4915f16dbc47b340925131e437fd1b49558cb8efe4e36e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-opencl-asan-2.0.0.60204-139.el8.x86_64.rpm",
+        "version": "2.0.0.60204"
       },
       {
         "name": "rocm-opencl-asan-rpath",
-        "sha256": "218ec3c31c6dd132a675f57ab3c296bdf8f2711663b2e6995aeee669d4b3d9b8",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-opencl-asan-rpath6.2.4/rocm-opencl-asan-rpath6.2.4_2.0.0.60204-139~20.04_amd64.deb",
-        "version": "2.0.0.60204-139"
+        "sha256": "c1e017cf5108ddfafe518e5d1a8e7af9f3d568c2194fc6089d2a38e0c3099052",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-opencl-asan-rpath6.2.4-2.0.0.60204-139.el8.x86_64.rpm",
+        "version": "2.0.0.60204"
       }
     ],
-    "version": "2.0.0.60204-139"
+    "version": "2.0.0.60204"
+  },
+  "rocm-opencl-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "comgr-asan-rpath6.2.4-rpath",
+      "hsa-rocr-asan-rpath6.2.4-rpath",
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-opencl-asan-rpath6.2.4-rpath",
+        "sha256": "b436ac2050a3ec6ef0e427d86cef0d49d1f005a43e9770c18c250d2108ad71ed",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-opencl-asan-rpath6.2.4-rpath6.2.4-2.0.0.60204-139.el8.x86_64.rpm",
+        "version": "2.0.0.60204"
+      }
+    ],
+    "version": "2.0.0.60204"
+  },
+  "rocm-opencl-asan6.2.4-rpath": {
+    "deps": [
+      "comgr-asan6.2.4-rpath",
+      "hsa-rocr-asan6.2.4-rpath",
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-opencl-asan6.2.4-rpath",
+        "sha256": "0a11cc5deefead7ca6f519b985a3740a0ae6a5216b84d13a6d0af209ed2a1156",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-opencl-asan6.2.4-rpath6.2.4-2.0.0.60204-139.el8.x86_64.rpm",
+        "version": "2.0.0.60204"
+      }
+    ],
+    "version": "2.0.0.60204"
   },
   "rocm-opencl-icd-loader": {
     "deps": [
@@ -2779,18 +3843,18 @@
     "components": [
       {
         "name": "rocm-opencl-icd-loader",
-        "sha256": "dda8cef1b581f5c75435910acbee3d5c4179ab3a9038e0ee80ded002d4802a9e",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-opencl-icd-loader/rocm-opencl-icd-loader_1.2.60204-139~20.04_amd64.deb",
-        "version": "1.2.60204-139"
+        "sha256": "437325787bd95baf8e8556dbbe27d8dda3c23832c0d47e9221f2fd56acce7d3e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-opencl-icd-loader-1.2.60204-139.el8.x86_64.rpm",
+        "version": "1.2.60204"
       },
       {
         "name": "rocm-opencl-icd-loader-rpath",
-        "sha256": "40e764fb75ada32a1d322eef25abac60690eb1c4e2049642511b801d63596ecc",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-opencl-icd-loader-rpath6.2.4/rocm-opencl-icd-loader-rpath6.2.4_1.2.60204-139~20.04_amd64.deb",
-        "version": "1.2.60204-139"
+        "sha256": "4bc33ee94d61c1e710e43d8c1596d3c4e11371ba845f9665b9a51d1de025753a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-opencl-icd-loader-rpath6.2.4-1.2.60204-139.el8.x86_64.rpm",
+        "version": "1.2.60204"
       }
     ],
-    "version": "1.2.60204-139"
+    "version": "1.2.60204"
   },
   "rocm-opencl-runtime": {
     "deps": [
@@ -2802,18 +3866,18 @@
     "components": [
       {
         "name": "rocm-opencl-runtime",
-        "sha256": "82ac3df462af36cf472f0418ddd07d4b76a37504da55c3a48bcdf9da74355005",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-opencl-runtime/rocm-opencl-runtime_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "9bb61d0cafd4a3d6421ef5a49f03a86118c0331828ffa0999429468950b193dc",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-opencl-runtime-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-opencl-runtime-rpath",
-        "sha256": "8e7e82f22eba0c272e2e0262ce69ade6af30cef875b752756d064db73e7d11b9",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-opencl-runtime-rpath6.2.4/rocm-opencl-runtime-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "544e26291fe901f5efc1b76816eae7bca44cbcad57e54aaaa20f8e93022f0257",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-opencl-runtime-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
   },
   "rocm-opencl-runtime-asan": {
     "deps": [
@@ -2825,23 +3889,55 @@
     "components": [
       {
         "name": "rocm-opencl-runtime-asan",
-        "sha256": "8db6f7c876897dd728bddb01d389d427ab7cc96321239f445dda2c9273c3dcd2",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-opencl-runtime-asan/rocm-opencl-runtime-asan_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "af35c31bcfb168189e56317c8988a57d965117fab9c31e94a592a09580dd64b4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-opencl-runtime-asan-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-opencl-runtime-asan-rpath",
-        "sha256": "85d4ce29c1bb7298c74790a16e1966c5ed303e24073852ba2728a15187946eca",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-opencl-runtime-asan-rpath6.2.4/rocm-opencl-runtime-asan-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "0ab8f60df2621740cc56589b4543504a92e25ef895688dbb58cc0a1ca4270f8f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-opencl-runtime-asan-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
+  },
+  "rocm-opencl-runtime-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath",
+      "rocm-language-runtime-asan-rpath6.2.4-rpath",
+      "rocm-opencl-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-opencl-runtime-asan-rpath6.2.4-rpath",
+        "sha256": "22f9f645eaeed8062359d6cddbc973c86f4c945f59443988b1161768682d37c5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-opencl-runtime-asan-rpath6.2.4-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      }
+    ],
+    "version": "6.2.4.60204"
+  },
+  "rocm-opencl-runtime-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath",
+      "rocm-language-runtime-asan6.2.4-rpath",
+      "rocm-opencl-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-opencl-runtime-asan6.2.4-rpath",
+        "sha256": "86593488fd8105e987630151bfbd9781ed84eff25cfaaae8f7b6618dcdf0d79c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-opencl-runtime-asan6.2.4-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
+      }
+    ],
+    "version": "6.2.4.60204"
   },
   "rocm-opencl-sdk": {
     "deps": [
       "hsa-rocr",
-      "hsakmt-roct-dev",
+      "hsakmt-roct-devel",
       "rocm-core",
       "rocm-opencl",
       "rocm-opencl-runtime"
@@ -2849,24 +3945,24 @@
     "components": [
       {
         "name": "rocm-opencl-sdk",
-        "sha256": "ff6b2b31e279d806a27f174e77e623cbc3431fe57826e50431ea67cf943d2e1a",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-opencl-sdk/rocm-opencl-sdk_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "884624e65a28a64851b0e27709b12cd0b914296c10c2f280617b0fc1270e0311",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-opencl-sdk-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-opencl-sdk-rpath",
-        "sha256": "cdbd401de460ffd4ab860bbf2ecaf795498d9e014d204a8152c8f3fc907e69da",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-opencl-sdk-rpath6.2.4/rocm-opencl-sdk-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "a052664992a98bd3f5f12f1c6b6385273115347b97eeb0308eae094bcabc0049",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-opencl-sdk-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
   },
   "rocm-openmp-sdk": {
     "deps": [
       "hsa-rocr",
-      "hsakmt-roct-dev",
-      "openmp-extras-dev",
+      "hsakmt-roct-devel",
+      "openmp-extras-devel",
       "rocm-core",
       "rocm-device-libs",
       "rocm-language-runtime",
@@ -2875,18 +3971,18 @@
     "components": [
       {
         "name": "rocm-openmp-sdk",
-        "sha256": "cf3c6684cd3e5288bf212c6dceffff728aba83c1716a73d01138ee63432e1d4a",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-openmp-sdk/rocm-openmp-sdk_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "3ae28a9045893521ae201b6e6789778c1652fdf3f5a9a5fe446160a8405bd1d4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-openmp-sdk-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-openmp-sdk-rpath",
-        "sha256": "d79970d690597514b65a4c6ae3c2ef600e04b4af0ead61d3a553110662a71610",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-openmp-sdk-rpath6.2.4/rocm-openmp-sdk-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "66155068a94e0008b3216e017fc16c4c01e5adb879ecb3e663af0dfbe9c902f6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-openmp-sdk-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
   },
   "rocm-smi-lib": {
     "deps": [
@@ -2895,18 +3991,18 @@
     "components": [
       {
         "name": "rocm-smi-lib",
-        "sha256": "ac461e2e6e958b63c3a4653d836343eddd0c998fc1a2a4f2986c47b4bd765f52",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-smi-lib/rocm-smi-lib_7.3.0.60204-139~20.04_amd64.deb",
-        "version": "7.3.0.60204-139"
+        "sha256": "09b54929bd7fc620768c3add5cb9e5cba0ffb387dd140ba43e1510c51e4c5734",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-smi-lib-7.3.0.60204-139.el8.x86_64.rpm",
+        "version": "7.3.0.60204"
       },
       {
         "name": "rocm-smi-lib-rpath",
-        "sha256": "43a592dc87b63269869ec9ba6d35a9991990c53ddda353f26bf89b71e1585f9c",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-smi-lib-rpath6.2.4/rocm-smi-lib-rpath6.2.4_7.3.0.60204-139~20.04_amd64.deb",
-        "version": "7.3.0.60204-139"
+        "sha256": "06b56bd2b6d164bc73b2e29b8bbed3705ee68f0efbe9d6e072ed6fb9a17db28b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-smi-lib-rpath6.2.4-7.3.0.60204-139.el8.x86_64.rpm",
+        "version": "7.3.0.60204"
       }
     ],
-    "version": "7.3.0.60204-139"
+    "version": "7.3.0.60204"
   },
   "rocm-smi-lib-asan": {
     "deps": [
@@ -2915,18 +4011,46 @@
     "components": [
       {
         "name": "rocm-smi-lib-asan",
-        "sha256": "72131d9a491d262cdab86a01d46bfdc5ea472572d6c7b85bc1ab24c101d6c979",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-smi-lib-asan/rocm-smi-lib-asan_7.3.0.60204-139~20.04_amd64.deb",
-        "version": "7.3.0.60204-139"
+        "sha256": "b7f4284c0fd4ed2f9502f56c851af48bfbf9dcf1082c6c122268d8d7a4d0bcd0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-smi-lib-asan-7.3.0.60204-139.el8.x86_64.rpm",
+        "version": "7.3.0.60204"
       },
       {
         "name": "rocm-smi-lib-asan-rpath",
-        "sha256": "bf9b765f964c2d84eb742aca7c9d5863d756075ed34ef0a81830ec2d8b7eb034",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-smi-lib-asan-rpath6.2.4/rocm-smi-lib-asan-rpath6.2.4_7.3.0.60204-139~20.04_amd64.deb",
-        "version": "7.3.0.60204-139"
+        "sha256": "9ed5507152daa47a26bc7704c2c0ce0175c7f1084990156ffe2720e22ddfd20d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-smi-lib-asan-rpath6.2.4-7.3.0.60204-139.el8.x86_64.rpm",
+        "version": "7.3.0.60204"
       }
     ],
-    "version": "7.3.0.60204-139"
+    "version": "7.3.0.60204"
+  },
+  "rocm-smi-lib-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-smi-lib-asan-rpath6.2.4-rpath",
+        "sha256": "b220fc92f34645dd48477c861520c4a7cee557eb42a5332b07326727748312d1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-smi-lib-asan-rpath6.2.4-rpath6.2.4-7.3.0.60204-139.el8.x86_64.rpm",
+        "version": "7.3.0.60204"
+      }
+    ],
+    "version": "7.3.0.60204"
+  },
+  "rocm-smi-lib-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocm-smi-lib-asan6.2.4-rpath",
+        "sha256": "867da67529efeb5a65cc5dcddbb0eab2ae10bd54dddcecd0a92a6c9487b9648a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-smi-lib-asan6.2.4-rpath6.2.4-7.3.0.60204-139.el8.x86_64.rpm",
+        "version": "7.3.0.60204"
+      }
+    ],
+    "version": "7.3.0.60204"
   },
   "rocm-utils": {
     "deps": [
@@ -2937,18 +4061,18 @@
     "components": [
       {
         "name": "rocm-utils",
-        "sha256": "fa8538275dd1d68b87830eb1e232d14e9e88685e6d9ec1f05c8c30a6f551cdc2",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-utils/rocm-utils_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "ed714deee8415e422256bd830514d5e514cd9eedd758593abeffb5b1dc84c916",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-utils-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       },
       {
         "name": "rocm-utils-rpath",
-        "sha256": "dde83a5523b14b136ab5bf45ade5312a25e8aa4f63fdafd2fc704bb1b89c0289",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-utils-rpath6.2.4/rocm-utils-rpath6.2.4_6.2.4.60204-139~20.04_amd64.deb",
-        "version": "6.2.4.60204-139"
+        "sha256": "6091a6c4dad893ff201ee8ef8b6751062c90e02246051d30de88ecefb4e55fca",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-utils-rpath6.2.4-6.2.4.60204-139.el8.x86_64.rpm",
+        "version": "6.2.4.60204"
       }
     ],
-    "version": "6.2.4.60204-139"
+    "version": "6.2.4.60204"
   },
   "rocm-validation-suite": {
     "deps": [
@@ -2962,18 +4086,18 @@
     "components": [
       {
         "name": "rocm-validation-suite",
-        "sha256": "3faf05e7c6d5bb71bb4198b998cd0d5c3421e21ee8ff401ff585bf12dc9bc5f9",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-validation-suite/rocm-validation-suite_1.0.60204.60204-139~20.04_amd64.deb",
-        "version": "1.0.60204.60204-139"
+        "sha256": "1deb6982527fb1c616a792bf29a39b7c1c6d63c80e6d93eb096a545ea204cbc7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-validation-suite-1.0.60204.60204-139.el8.x86_64.rpm",
+        "version": "1.0.60204.60204"
       },
       {
         "name": "rocm-validation-suite-rpath",
-        "sha256": "40a8c1b8ebf1967078ed31ae975c54e230ff62c90541b97322ed0d1fda893b13",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocm-validation-suite-rpath6.2.4/rocm-validation-suite-rpath6.2.4_1.0.60204.60204-139~20.04_amd64.deb",
-        "version": "1.0.60204.60204-139"
+        "sha256": "d5643f9f0b983eaff92347214aaf6c51b450f2cd3d2b223eeea5e3e976d117bb",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocm-validation-suite-rpath6.2.4-1.0.60204.60204-139.el8.x86_64.rpm",
+        "version": "1.0.60204.60204"
       }
     ],
-    "version": "1.0.60204.60204-139"
+    "version": "1.0.60204.60204"
   },
   "rocminfo": {
     "deps": [
@@ -2983,39 +4107,39 @@
     "components": [
       {
         "name": "rocminfo",
-        "sha256": "2a8836ded82885fa85197f617ad46fac86f2968d94c6db19c162c7d16dd8f7bd",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocminfo/rocminfo_1.0.0.60204-139~20.04_amd64.deb",
-        "version": "1.0.0.60204-139"
+        "sha256": "a5f132af07de74010d91334b54ea383e28903b6e279c6f383d5ae48868ed8f5b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocminfo-1.0.0.60204-139.el8.x86_64.rpm",
+        "version": "1.0.0.60204"
       },
       {
         "name": "rocminfo-rpath",
-        "sha256": "b5415496733a26bde8ff23f866189fab3e85220fe79736c8c964cbbe4b312775",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocminfo-rpath6.2.4/rocminfo-rpath6.2.4_1.0.0.60204-139~20.04_amd64.deb",
-        "version": "1.0.0.60204-139"
+        "sha256": "792691f1a9259bcac472c803090d732bb81cc8ac0358bc6e8722864376ef322d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocminfo-rpath6.2.4-1.0.0.60204-139.el8.x86_64.rpm",
+        "version": "1.0.0.60204"
       }
     ],
-    "version": "1.0.0.60204-139"
+    "version": "1.0.0.60204"
   },
-  "rocprim-dev": {
+  "rocprim-devel": {
     "deps": [
       "hip-runtime-amd",
       "rocm-core"
     ],
     "components": [
       {
-        "name": "rocprim-dev",
-        "sha256": "1e253ab970ecb1aa34a992ec6d7239ae69e5a0b7f6d9e0624525e8752c99d13a",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocprim-dev/rocprim-dev_3.2.2.60204-139~20.04_amd64.deb",
-        "version": "3.2.2.60204-139"
+        "name": "rocprim-devel",
+        "sha256": "467d281bc79e3e6505b4f07075a7107b5729f0e9dbd815c4259d9914761414f8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocprim-devel-3.2.2.60204-139.el8.x86_64.rpm",
+        "version": "3.2.2.60204"
       },
       {
-        "name": "rocprim-dev-rpath",
-        "sha256": "9c6dc87019b8554992fab54ff57cc7543a1d59bdcee2cf4c9549eb64dfc430db",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocprim-dev-rpath6.2.4/rocprim-dev-rpath6.2.4_3.2.2.60204-139~20.04_amd64.deb",
-        "version": "3.2.2.60204-139"
+        "name": "rocprim-devel-rpath",
+        "sha256": "5c334294a85e1f7aa0386c48fbe45812a7e525cd8238e7de344338cf64b8793b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocprim-devel-rpath6.2.4-3.2.2.60204-139.el8.x86_64.rpm",
+        "version": "3.2.2.60204"
       }
     ],
-    "version": "3.2.2.60204-139"
+    "version": "3.2.2.60204"
   },
   "rocprofiler": {
     "deps": [
@@ -3026,30 +4150,30 @@
     "components": [
       {
         "name": "rocprofiler",
-        "sha256": "9924fd9175cdc741a5ca12e249c2dfcf1228eb7aeb9e3f94ddef09d519e4048a",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocprofiler/rocprofiler_2.0.60204.60204-139~20.04_amd64.deb",
-        "version": "2.0.60204.60204-139"
+        "sha256": "3cd51ed4cce5d9f51bb4afb30255b0ea95317e1a2d1590231af20aef3ccf8909",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocprofiler-2.0.60204.60204-139.el8.x86_64.rpm",
+        "version": "2.0.60204.60204"
       },
       {
-        "name": "rocprofiler-dev",
-        "sha256": "c793df62a59a89512674d3ea309b68b76ba52a5c2c6c41e8d87f8485f47a4f56",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocprofiler-dev/rocprofiler-dev_2.0.60204.60204-139~20.04_amd64.deb",
-        "version": "2.0.60204.60204-139"
+        "name": "rocprofiler-devel",
+        "sha256": "a20b7a988850f68a9c13bfe8a2c99ac8629f356db6040c156ec01b16d05668c0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocprofiler-devel-2.0.60204.60204-139.el8.x86_64.rpm",
+        "version": "2.0.60204.60204"
       },
       {
-        "name": "rocprofiler-dev-rpath",
-        "sha256": "d68d69f986cd24bc48d158b7bf5399f821b3addf99f75473db0826e2a1c8b840",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocprofiler-dev-rpath6.2.4/rocprofiler-dev-rpath6.2.4_2.0.60204.60204-139~20.04_amd64.deb",
-        "version": "2.0.60204.60204-139"
+        "name": "rocprofiler-devel-rpath",
+        "sha256": "043c35eabe59f6de755b42da6fb8b3ec63834bf0641d10bee570c9502c0d2380",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocprofiler-devel-rpath6.2.4-2.0.60204.60204-139.el8.x86_64.rpm",
+        "version": "2.0.60204.60204"
       },
       {
         "name": "rocprofiler-rpath",
-        "sha256": "634102896e274fc75cb89715f9eeaf008c5c9c58e88b82a413c46cc747a87152",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocprofiler-rpath6.2.4/rocprofiler-rpath6.2.4_2.0.60204.60204-139~20.04_amd64.deb",
-        "version": "2.0.60204.60204-139"
+        "sha256": "4a3ace29a6b1a703ae3a6395d18566ca1aa5bbaf4d8f7829f290944eb3f0613a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocprofiler-rpath6.2.4-2.0.60204.60204-139.el8.x86_64.rpm",
+        "version": "2.0.60204.60204"
       }
     ],
-    "version": "2.0.60204.60204-139"
+    "version": "2.0.60204.60204"
   },
   "rocprofiler-asan": {
     "deps": [
@@ -3059,18 +4183,48 @@
     "components": [
       {
         "name": "rocprofiler-asan",
-        "sha256": "6ec5cd6b957aa76db5e811c36527c63bc5ccd003f35016650cb239385bed33d6",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocprofiler-asan/rocprofiler-asan_2.0.60204.60204-139~20.04_amd64.deb",
-        "version": "2.0.60204.60204-139"
+        "sha256": "d4073afcc600507ed82f4f679c7a64895f1c53a7f4750e4101bd3824c79f06f7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocprofiler-asan-2.0.60204.60204-139.el8.x86_64.rpm",
+        "version": "2.0.60204.60204"
       },
       {
         "name": "rocprofiler-asan-rpath",
-        "sha256": "1586015a3c81e56ab3d9d4c4c66560382a2b9a6f9c6dafd856f9e88f517cc256",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocprofiler-asan-rpath6.2.4/rocprofiler-asan-rpath6.2.4_2.0.60204.60204-139~20.04_amd64.deb",
-        "version": "2.0.60204.60204-139"
+        "sha256": "1ea5ff10943fe1f4447f282db1e8dcd28d31d211dc6aa59f101d43402c6e80b8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocprofiler-asan-rpath6.2.4-2.0.60204.60204-139.el8.x86_64.rpm",
+        "version": "2.0.60204.60204"
       }
     ],
-    "version": "2.0.60204.60204-139"
+    "version": "2.0.60204.60204"
+  },
+  "rocprofiler-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "hsa-rocr-asan-rpath6.2.4-rpath",
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocprofiler-asan-rpath6.2.4-rpath",
+        "sha256": "1bad3412363a20a449228293a1de8a3e320239b6d279b308246c19e5b3232a93",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocprofiler-asan-rpath6.2.4-rpath6.2.4-2.0.60204.60204-139.el8.x86_64.rpm",
+        "version": "2.0.60204.60204"
+      }
+    ],
+    "version": "2.0.60204.60204"
+  },
+  "rocprofiler-asan6.2.4-rpath": {
+    "deps": [
+      "hsa-rocr-asan6.2.4-rpath",
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocprofiler-asan6.2.4-rpath",
+        "sha256": "ccfabaec517e12c8b742b4d183e01ba209121664ef2b5b5c043ce9e6e8fa7d06",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocprofiler-asan6.2.4-rpath6.2.4-2.0.60204.60204-139.el8.x86_64.rpm",
+        "version": "2.0.60204.60204"
+      }
+    ],
+    "version": "2.0.60204.60204"
   },
   "rocprofiler-docs": {
     "deps": [
@@ -3081,18 +4235,18 @@
     "components": [
       {
         "name": "rocprofiler-docs",
-        "sha256": "da7ea374ce5fd6c542ff90d3f1077f9c3ec9fcf1a9602b4eeafd55dd5029dda6",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocprofiler-docs/rocprofiler-docs_2.0.60204.60204-139~20.04_amd64.deb",
-        "version": "2.0.60204.60204-139"
+        "sha256": "4da1989cc1fd036bd66a15a274af1bd00ac2df38057b62a71d92582113155382",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocprofiler-docs-2.0.60204.60204-139.el8.x86_64.rpm",
+        "version": "2.0.60204.60204"
       },
       {
         "name": "rocprofiler-docs-rpath",
-        "sha256": "b3035ee82726ba36a250cffd818bf838234cb491b50fcd89102f4c77a1cf562a",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocprofiler-docs-rpath6.2.4/rocprofiler-docs-rpath6.2.4_2.0.60204.60204-139~20.04_amd64.deb",
-        "version": "2.0.60204.60204-139"
+        "sha256": "d3f949243a3e8743660fbb8bd57f907a8c1797f92b6576970156f86c272e78c4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocprofiler-docs-rpath6.2.4-2.0.60204.60204-139.el8.x86_64.rpm",
+        "version": "2.0.60204.60204"
       }
     ],
-    "version": "2.0.60204.60204-139"
+    "version": "2.0.60204.60204"
   },
   "rocprofiler-plugins": {
     "deps": [
@@ -3103,18 +4257,18 @@
     "components": [
       {
         "name": "rocprofiler-plugins",
-        "sha256": "6b7d12e47d960b336dd1352e5315bde8afcf0ec6cf33ce85be0dd3fd80920b60",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocprofiler-plugins/rocprofiler-plugins_2.0.60204.60204-139~20.04_amd64.deb",
-        "version": "2.0.60204.60204-139"
+        "sha256": "a1d609d5750d6640ec87cb2907be6b0a1ceffaeb5fba6afd664b88f9968db547",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocprofiler-plugins-2.0.60204.60204-139.el8.x86_64.rpm",
+        "version": "2.0.60204.60204"
       },
       {
         "name": "rocprofiler-plugins-rpath",
-        "sha256": "0a236e5f7f219a890c2c641bec0f18c76c15f4ba5c878dddafa2230454ebf218",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocprofiler-plugins-rpath6.2.4/rocprofiler-plugins-rpath6.2.4_2.0.60204.60204-139~20.04_amd64.deb",
-        "version": "2.0.60204.60204-139"
+        "sha256": "54af46899fb844bdbf3e878b5a1169c2be7ac1a2073b101387793749144a7995",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocprofiler-plugins-rpath6.2.4-2.0.60204.60204-139.el8.x86_64.rpm",
+        "version": "2.0.60204.60204"
       }
     ],
-    "version": "2.0.60204.60204-139"
+    "version": "2.0.60204.60204"
   },
   "rocprofiler-register": {
     "deps": [
@@ -3123,18 +4277,18 @@
     "components": [
       {
         "name": "rocprofiler-register",
-        "sha256": "b1f10baea3f192a054f09545a51da11bf656cfdbd900848e11fac765add0432d",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocprofiler-register/rocprofiler-register_0.4.0.60204-139~20.04_amd64.deb",
-        "version": "0.4.0.60204-139"
+        "sha256": "172ac302c51cc2381cca6f242a5e6ac213c57a34d70e4893765f873a7524dd24",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocprofiler-register-0.4.0.60204-139.el8.x86_64.rpm",
+        "version": "0.4.0.60204"
       },
       {
         "name": "rocprofiler-register-rpath",
-        "sha256": "56907f1226d48aca70cb578aa893f87f08b5a9f6dcdf4a53fa924ea57c450b5d",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocprofiler-register-rpath6.2.4/rocprofiler-register-rpath6.2.4_0.4.0.60204-139~20.04_amd64.deb",
-        "version": "0.4.0.60204-139"
+        "sha256": "4e31bbc77e87c65c51a07ed07e7538b74b6e432574e76ef38dd2aa7e9af01491",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocprofiler-register-rpath6.2.4-0.4.0.60204-139.el8.x86_64.rpm",
+        "version": "0.4.0.60204"
       }
     ],
-    "version": "0.4.0.60204-139"
+    "version": "0.4.0.60204"
   },
   "rocprofiler-sdk": {
     "deps": [
@@ -3143,18 +4297,18 @@
     "components": [
       {
         "name": "rocprofiler-sdk",
-        "sha256": "229ee90e8828e32707cc8abc3c34e6257b6f345d114b680b05459d7eaffb2143",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocprofiler-sdk/rocprofiler-sdk_0.4.0-139~20.04_amd64.deb",
-        "version": "0.4.0-139"
+        "sha256": "92313a469a33f482e973b66f54c8ed904c0f4a71db59abd28459eb58cdc31ffe",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocprofiler-sdk-0.4.0-139.el8.x86_64.rpm",
+        "version": "0.4.0"
       },
       {
         "name": "rocprofiler-sdk-rpath",
-        "sha256": "6f0f4321f512278f26597fb619d0a6f73357b09661e82a51e850fb1123129e9b",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocprofiler-sdk-rpath6.2.4/rocprofiler-sdk-rpath6.2.4_0.4.0-139~20.04_amd64.deb",
-        "version": "0.4.0-139"
+        "sha256": "370347a7f1c66990900a988474d9b98b502d2348a92f64e467f2eeb2e1aefa62",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocprofiler-sdk-rpath6.2.4-0.4.0-139.el8.x86_64.rpm",
+        "version": "0.4.0"
       }
     ],
-    "version": "0.4.0-139"
+    "version": "0.4.0"
   },
   "rocprofiler-sdk-roctx": {
     "deps": [
@@ -3163,18 +4317,18 @@
     "components": [
       {
         "name": "rocprofiler-sdk-roctx",
-        "sha256": "bed72e526bbc7b3cc387509d70eed0d8ce27f017adc70e58eb1ccefdbc00b1fe",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocprofiler-sdk-roctx/rocprofiler-sdk-roctx_0.4.0-139~20.04_amd64.deb",
-        "version": "0.4.0-139"
+        "sha256": "cc42c4fbe362caeaa9da533f7ee6fb02023060e8082ad0cf51375732c713c3a7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocprofiler-sdk-roctx-0.4.0-139.el8.x86_64.rpm",
+        "version": "0.4.0"
       },
       {
         "name": "rocprofiler-sdk-roctx-rpath",
-        "sha256": "9c809bdc1227c566cba90cd97c34ebdd09d21283bfa604c16761c380bc83ed11",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocprofiler-sdk-roctx-rpath6.2.4/rocprofiler-sdk-roctx-rpath6.2.4_0.4.0-139~20.04_amd64.deb",
-        "version": "0.4.0-139"
+        "sha256": "66e76daef091fc5505988761d4d85d33e8b3cdf86eef380390489a9b5a92ea2d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocprofiler-sdk-roctx-rpath6.2.4-0.4.0-139.el8.x86_64.rpm",
+        "version": "0.4.0"
       }
     ],
-    "version": "0.4.0-139"
+    "version": "0.4.0"
   },
   "rocrand": {
     "deps": [
@@ -3183,30 +4337,30 @@
     "components": [
       {
         "name": "rocrand",
-        "sha256": "f658ac957afaf982371c3e7e1ed7ed4fe10fc2c6383b1fc1459412bbfe0edb6d",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocrand/rocrand_3.1.1.60204-139~20.04_amd64.deb",
-        "version": "3.1.1.60204-139"
+        "sha256": "a52741b5a35a61e93664647299c18a297543d8b485e3c0d60b7b98ad097bd11d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocrand-3.1.1.60204-139.el8.x86_64.rpm",
+        "version": "3.1.1.60204"
       },
       {
-        "name": "rocrand-dev",
-        "sha256": "047f4d5b2d49b51e9da48827fef37a52a0c53951483eb6158b3cc177176536af",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocrand-dev/rocrand-dev_3.1.1.60204-139~20.04_amd64.deb",
-        "version": "3.1.1.60204-139"
+        "name": "rocrand-devel",
+        "sha256": "4b790b2efa1c1f88f797974dc6fc9dff408f23314dd77b2d1aa1c82fcaca553d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocrand-devel-3.1.1.60204-139.el8.x86_64.rpm",
+        "version": "3.1.1.60204"
       },
       {
-        "name": "rocrand-dev-rpath",
-        "sha256": "448cee79ea167177bbd68b23397bf5c72ece16d9cce8411609cca64f2c20f3f8",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocrand-dev-rpath6.2.4/rocrand-dev-rpath6.2.4_3.1.1.60204-139~20.04_amd64.deb",
-        "version": "3.1.1.60204-139"
+        "name": "rocrand-devel-rpath",
+        "sha256": "c996369799950b8768088b8437692c54db42195ed9cc73dc9bbce05ecba66d92",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocrand-devel-rpath6.2.4-3.1.1.60204-139.el8.x86_64.rpm",
+        "version": "3.1.1.60204"
       },
       {
         "name": "rocrand-rpath",
-        "sha256": "dc436de76a735957a50b5d10c28a047e3c5b2a93c45aac1bb1b0d1f30a656f4d",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocrand-rpath6.2.4/rocrand-rpath6.2.4_3.1.1.60204-139~20.04_amd64.deb",
-        "version": "3.1.1.60204-139"
+        "sha256": "b1d1fb9ade059f8195ff53d0ec09756da6a315d7d5818ac50f717e28d536d2be",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocrand-rpath6.2.4-3.1.1.60204-139.el8.x86_64.rpm",
+        "version": "3.1.1.60204"
       }
     ],
-    "version": "3.1.1.60204-139"
+    "version": "3.1.1.60204"
   },
   "rocrand-asan": {
     "deps": [
@@ -3215,18 +4369,46 @@
     "components": [
       {
         "name": "rocrand-asan",
-        "sha256": "3c7821593df3e27127ac6fdf60180249ad29465dc57e5ddc18fb7eb520459670",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocrand-asan/rocrand-asan_3.1.1.60204-139~20.04_amd64.deb",
-        "version": "3.1.1.60204-139"
+        "sha256": "0cafb4a286b47b766285a6e0e1e3f47fc659758ee3e620ecdc5d2dedc6d53914",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocrand-asan-3.1.1.60204-139.el8.x86_64.rpm",
+        "version": "3.1.1.60204"
       },
       {
         "name": "rocrand-asan-rpath",
-        "sha256": "9cf5502cab69b5e80c02d24f530426a5b7b21e9d1b4b95a1f7a0b32ce8884928",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocrand-asan-rpath6.2.4/rocrand-asan-rpath6.2.4_3.1.1.60204-139~20.04_amd64.deb",
-        "version": "3.1.1.60204-139"
+        "sha256": "1bdd1cce37e9b168e3e74f50eae9bda20804c8d4347324d06d3fbfc73364f5fa",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocrand-asan-rpath6.2.4-3.1.1.60204-139.el8.x86_64.rpm",
+        "version": "3.1.1.60204"
       }
     ],
-    "version": "3.1.1.60204-139"
+    "version": "3.1.1.60204"
+  },
+  "rocrand-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocrand-asan-rpath6.2.4-rpath",
+        "sha256": "ad5e5d9cc41b96e6c48763d513b072bacc74f899b64daf244603db08657827bf",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocrand-asan-rpath6.2.4-rpath6.2.4-3.1.1.60204-139.el8.x86_64.rpm",
+        "version": "3.1.1.60204"
+      }
+    ],
+    "version": "3.1.1.60204"
+  },
+  "rocrand-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocrand-asan6.2.4-rpath",
+        "sha256": "c672f9cf62a02d2363db630ec95b4515e8b8c49b78f3d2867220757a4255a41c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocrand-asan6.2.4-rpath6.2.4-3.1.1.60204-139.el8.x86_64.rpm",
+        "version": "3.1.1.60204"
+      }
+    ],
+    "version": "3.1.1.60204"
   },
   "rocsolver": {
     "deps": [
@@ -3237,30 +4419,30 @@
     "components": [
       {
         "name": "rocsolver",
-        "sha256": "426e0d64e1000211c4bfdbea8e809cb360ec6a70fbe386ceb54d24496cc62aae",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocsolver/rocsolver_3.26.2.60204-139~20.04_amd64.deb",
-        "version": "3.26.2.60204-139"
+        "sha256": "e29068ae8848e1547f7ca9ec06d57cce1350a0ff6061de79f8945ecb3268a445",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocsolver-3.26.2.60204-139.el8.x86_64.rpm",
+        "version": "3.26.2.60204"
       },
       {
-        "name": "rocsolver-dev",
-        "sha256": "3ec76630dc067ce176e6e530f33d6933c7b07a971dbe5264ba82e5fd6920d666",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocsolver-dev/rocsolver-dev_3.26.2.60204-139~20.04_amd64.deb",
-        "version": "3.26.2.60204-139"
+        "name": "rocsolver-devel",
+        "sha256": "d1a6a9529ad551a145e380c93e4f23ba7bae6fa5590b34c36a1883ee48ee2eca",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocsolver-devel-3.26.2.60204-139.el8.x86_64.rpm",
+        "version": "3.26.2.60204"
       },
       {
-        "name": "rocsolver-dev-rpath",
-        "sha256": "b1e930fabb93ff65ba9e3414216573f2a77e08f43cf137a5fe9d9c6c35c639c4",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocsolver-dev-rpath6.2.4/rocsolver-dev-rpath6.2.4_3.26.2.60204-139~20.04_amd64.deb",
-        "version": "3.26.2.60204-139"
+        "name": "rocsolver-devel-rpath",
+        "sha256": "be21f668365542554ee135eef1f145702ac531ef348874a2571fabae7987e5d7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocsolver-devel-rpath6.2.4-3.26.2.60204-139.el8.x86_64.rpm",
+        "version": "3.26.2.60204"
       },
       {
         "name": "rocsolver-rpath",
-        "sha256": "4a63ff62d6d5cc474920b3af4c31b904a85cd1da507cbd4a9caa50d9ca550290",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocsolver-rpath6.2.4/rocsolver-rpath6.2.4_3.26.2.60204-139~20.04_amd64.deb",
-        "version": "3.26.2.60204-139"
+        "sha256": "4e8265d36f2d9b091da0993055680a93a2d05b38e1f4481477be8c15e56228d3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocsolver-rpath6.2.4-3.26.2.60204-139.el8.x86_64.rpm",
+        "version": "3.26.2.60204"
       }
     ],
-    "version": "3.26.2.60204-139"
+    "version": "3.26.2.60204"
   },
   "rocsolver-asan": {
     "deps": [
@@ -3271,18 +4453,46 @@
     "components": [
       {
         "name": "rocsolver-asan",
-        "sha256": "fba159889dbd257d0afb2df9fd7ddbafbc848e38ec2c741f93e380eb3fab2913",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocsolver-asan/rocsolver-asan_3.26.2.60204-139~20.04_amd64.deb",
-        "version": "3.26.2.60204-139"
+        "sha256": "c64a22e082256d954d34c7bd659175658b0c8ca1ae4c2b3f60ad3c2f27c28bf9",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocsolver-asan-3.26.2.60204-139.el8.x86_64.rpm",
+        "version": "3.26.2.60204"
       },
       {
         "name": "rocsolver-asan-rpath",
-        "sha256": "a5c8fa890811186b2b8c6160d175ab39af9664a5a83c3e3eb15a202b4618a9c6",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocsolver-asan-rpath6.2.4/rocsolver-asan-rpath6.2.4_3.26.2.60204-139~20.04_amd64.deb",
-        "version": "3.26.2.60204-139"
+        "sha256": "37b497f5bc1ece67f5e3acaa4d67e8f4d32f5c0d2b0003ca8b7925d3fb98ed9a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocsolver-asan-rpath6.2.4-3.26.2.60204-139.el8.x86_64.rpm",
+        "version": "3.26.2.60204"
       }
     ],
-    "version": "3.26.2.60204-139"
+    "version": "3.26.2.60204"
+  },
+  "rocsolver-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocsolver-asan-rpath6.2.4-rpath",
+        "sha256": "103d4e8aff3eda4a449305647ed75fc5f4a185a35e5403938bed6ad751607d45",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocsolver-asan-rpath6.2.4-rpath6.2.4-3.26.2.60204-139.el8.x86_64.rpm",
+        "version": "3.26.2.60204"
+      }
+    ],
+    "version": "3.26.2.60204"
+  },
+  "rocsolver-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocsolver-asan6.2.4-rpath",
+        "sha256": "a1070c1213da58d496ee35cfc675e01ae0110486a1eddaf6663d00de9c3d7eeb",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocsolver-asan6.2.4-rpath6.2.4-3.26.2.60204-139.el8.x86_64.rpm",
+        "version": "3.26.2.60204"
+      }
+    ],
+    "version": "3.26.2.60204"
   },
   "rocsparse": {
     "deps": [
@@ -3292,30 +4502,30 @@
     "components": [
       {
         "name": "rocsparse",
-        "sha256": "acaf4c0900984b4e70cdd162f8cb853434b10da7b5e9a65b424055dddd59bfb2",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocsparse/rocsparse_3.2.1.60204-139~20.04_amd64.deb",
-        "version": "3.2.1.60204-139"
+        "sha256": "e93b4875dd0f0c02dffe53d57caa65b8909d66872b7e414735a197fdece1b768",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocsparse-3.2.1.60204-139.el8.x86_64.rpm",
+        "version": "3.2.1.60204"
       },
       {
-        "name": "rocsparse-dev",
-        "sha256": "6458330f565220d950f5fe570710243bf7d82a0660c182ab0c4f8f4ffc208373",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocsparse-dev/rocsparse-dev_3.2.1.60204-139~20.04_amd64.deb",
-        "version": "3.2.1.60204-139"
+        "name": "rocsparse-devel",
+        "sha256": "05467fb6182e6ba2d012a14ba3f54d00fbee46d63dcca859da6e9d8b0bd10cef",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocsparse-devel-3.2.1.60204-139.el8.x86_64.rpm",
+        "version": "3.2.1.60204"
       },
       {
-        "name": "rocsparse-dev-rpath",
-        "sha256": "8a6c9dbd6a2718ff0f5996e9feac3082d5eed71230c955b1be837d50f5101ce0",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocsparse-dev-rpath6.2.4/rocsparse-dev-rpath6.2.4_3.2.1.60204-139~20.04_amd64.deb",
-        "version": "3.2.1.60204-139"
+        "name": "rocsparse-devel-rpath",
+        "sha256": "4a7863c6fe17ca365a11144e317ebe4b014cb7a5b89b000aa2d82a1b6aaab138",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocsparse-devel-rpath6.2.4-3.2.1.60204-139.el8.x86_64.rpm",
+        "version": "3.2.1.60204"
       },
       {
         "name": "rocsparse-rpath",
-        "sha256": "673cbd12da53c479312314c21bb2c6b77edb6e70d16b2a1cae17c27a1bd3ba6b",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocsparse-rpath6.2.4/rocsparse-rpath6.2.4_3.2.1.60204-139~20.04_amd64.deb",
-        "version": "3.2.1.60204-139"
+        "sha256": "a3c7dcd5e3455cce89c5d4411e3ac72b7ce2116a9b83ca55f717dd9856fb1cc0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocsparse-rpath6.2.4-3.2.1.60204-139.el8.x86_64.rpm",
+        "version": "3.2.1.60204"
       }
     ],
-    "version": "3.2.1.60204-139"
+    "version": "3.2.1.60204"
   },
   "rocsparse-asan": {
     "deps": [
@@ -3325,39 +4535,69 @@
     "components": [
       {
         "name": "rocsparse-asan",
-        "sha256": "5dfae88999355f7b7b91181365c123287bb0ab5de38fad281dab3b4269c9d34c",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocsparse-asan/rocsparse-asan_3.2.1.60204-139~20.04_amd64.deb",
-        "version": "3.2.1.60204-139"
+        "sha256": "66f113964bf5f0dfdf4ac222ee4bbff7d238880d952c093dbed1bb3495cd6486",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocsparse-asan-3.2.1.60204-139.el8.x86_64.rpm",
+        "version": "3.2.1.60204"
       },
       {
         "name": "rocsparse-asan-rpath",
-        "sha256": "56c57a9f2c503a9a740f95ac7ad7387e8a6c216a40f384fce75b4d6c599ab83d",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocsparse-asan-rpath6.2.4/rocsparse-asan-rpath6.2.4_3.2.1.60204-139~20.04_amd64.deb",
-        "version": "3.2.1.60204-139"
+        "sha256": "40bd02ba40935e0d0d1d5a454705c3590c83fe0fbba97eb2f99a71a04260067f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocsparse-asan-rpath6.2.4-3.2.1.60204-139.el8.x86_64.rpm",
+        "version": "3.2.1.60204"
       }
     ],
-    "version": "3.2.1.60204-139"
+    "version": "3.2.1.60204"
   },
-  "rocthrust-dev": {
+  "rocsparse-asan-rpath6.2.4-rpath": {
     "deps": [
-      "rocm-core",
-      "rocprim-dev"
+      "hip-runtime-amd-asan-rpath6.2.4-rpath",
+      "rocm-core-asan-rpath6.2.4-rpath"
     ],
     "components": [
       {
-        "name": "rocthrust-dev",
-        "sha256": "58bd9cd846c321ee8e659e6ae319a935f19680f98c9f4280e0a6fd5e14084114",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocthrust-dev/rocthrust-dev_3.1.1.60204-139~20.04_amd64.deb",
-        "version": "3.1.1.60204-139"
-      },
-      {
-        "name": "rocthrust-dev-rpath",
-        "sha256": "c31202e6a6b3c2e5bdd6109312f001b6eb01a2cdfe958a31fa30c3006d89161a",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocthrust-dev-rpath6.2.4/rocthrust-dev-rpath6.2.4_3.1.1.60204-139~20.04_amd64.deb",
-        "version": "3.1.1.60204-139"
+        "name": "rocsparse-asan-rpath6.2.4-rpath",
+        "sha256": "04c049594901ef3dfb83be06c94251d917aadabcabe24a762683647f5ffee66d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocsparse-asan-rpath6.2.4-rpath6.2.4-3.2.1.60204-139.el8.x86_64.rpm",
+        "version": "3.2.1.60204"
       }
     ],
-    "version": "3.1.1.60204-139"
+    "version": "3.2.1.60204"
+  },
+  "rocsparse-asan6.2.4-rpath": {
+    "deps": [
+      "hip-runtime-amd-asan6.2.4-rpath",
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rocsparse-asan6.2.4-rpath",
+        "sha256": "4f2e0685dff306fa138d58daf13f95caae03d51c5272bba3b8da7d6181bca253",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocsparse-asan6.2.4-rpath6.2.4-3.2.1.60204-139.el8.x86_64.rpm",
+        "version": "3.2.1.60204"
+      }
+    ],
+    "version": "3.2.1.60204"
+  },
+  "rocthrust-devel": {
+    "deps": [
+      "rocm-core",
+      "rocprim-devel"
+    ],
+    "components": [
+      {
+        "name": "rocthrust-devel",
+        "sha256": "5ed9cfa2465036fc21d276aa268c4179458e837e61806a1839f20d19550bc0f6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocthrust-devel-3.1.1.60204-139.el8.x86_64.rpm",
+        "version": "3.1.1.60204"
+      },
+      {
+        "name": "rocthrust-devel-rpath",
+        "sha256": "8be22aa0f6eba9e3014c6fd08d6dccc0ff95de1f1ed9fa6bf2dd698128c24af9",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocthrust-devel-rpath6.2.4-3.1.1.60204-139.el8.x86_64.rpm",
+        "version": "3.1.1.60204"
+      }
+    ],
+    "version": "3.1.1.60204"
   },
   "roctracer": {
     "deps": [
@@ -3366,30 +4606,30 @@
     "components": [
       {
         "name": "roctracer",
-        "sha256": "f14047ad5f2410c4041b34ed3dd962de65c9abe657320ee8fc98fd0c2420189e",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/roctracer/roctracer_4.1.60204.60204-139~20.04_amd64.deb",
-        "version": "4.1.60204.60204-139"
+        "sha256": "a26def3efe36515dadd6c0d083906ca75645e90148b6697ed41cc0d4d6f2abc0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/roctracer-4.1.60204.60204-139.el8.x86_64.rpm",
+        "version": "4.1.60204.60204"
       },
       {
-        "name": "roctracer-dev",
-        "sha256": "adcaf5eceb989cdce385502973167cda95788a00d2b1d36bf9cc8d5c95b2326d",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/roctracer-dev/roctracer-dev_4.1.60204.60204-139~20.04_amd64.deb",
-        "version": "4.1.60204.60204-139"
+        "name": "roctracer-devel",
+        "sha256": "4692176fc59b7570bd252539369d2ec1e1e908dfd8a899b0d65fda518cd90501",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/roctracer-devel-4.1.60204.60204-139.el8.x86_64.rpm",
+        "version": "4.1.60204.60204"
       },
       {
-        "name": "roctracer-dev-rpath",
-        "sha256": "f931d20088c1a4d713f1327e25d3bd765c836895896f5bca5d72133a76f7615e",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/roctracer-dev-rpath6.2.4/roctracer-dev-rpath6.2.4_4.1.60204.60204-139~20.04_amd64.deb",
-        "version": "4.1.60204.60204-139"
+        "name": "roctracer-devel-rpath",
+        "sha256": "2fa19b2e4af3da1ca262a65680932d22d504341e8b4c21db186fb8fd0a806961",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/roctracer-devel-rpath6.2.4-4.1.60204.60204-139.el8.x86_64.rpm",
+        "version": "4.1.60204.60204"
       },
       {
         "name": "roctracer-rpath",
-        "sha256": "cf3619c646bf4f132500bcda75ac12d70996f5fdabd7e74e3877b6cf21270d32",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/roctracer-rpath6.2.4/roctracer-rpath6.2.4_4.1.60204.60204-139~20.04_amd64.deb",
-        "version": "4.1.60204.60204-139"
+        "sha256": "178d784008fdac40487b4089a79e65df4fbf53d385044f19c79ec928bf5403be",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/roctracer-rpath6.2.4-4.1.60204.60204-139.el8.x86_64.rpm",
+        "version": "4.1.60204.60204"
       }
     ],
-    "version": "4.1.60204.60204-139"
+    "version": "4.1.60204.60204"
   },
   "roctracer-asan": {
     "deps": [
@@ -3398,38 +4638,66 @@
     "components": [
       {
         "name": "roctracer-asan",
-        "sha256": "8272b1f2fa9efc51607909bd52fe066dc284a5e0d0f6467a227a8411f4fffaae",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/roctracer-asan/roctracer-asan_4.1.60204.60204-139~20.04_amd64.deb",
-        "version": "4.1.60204.60204-139"
+        "sha256": "5e51e2bb5c9a6bfcb4395611239ef84ee04607decdcb6932af6baf9f1f46fa1f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/roctracer-asan-4.1.60204.60204-139.el8.x86_64.rpm",
+        "version": "4.1.60204.60204"
       },
       {
         "name": "roctracer-asan-rpath",
-        "sha256": "166d89243e8ebae49ddc41af6ad45903bd9a90e54f154cd37a523a99bd9f51e7",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/roctracer-asan-rpath6.2.4/roctracer-asan-rpath6.2.4_4.1.60204.60204-139~20.04_amd64.deb",
-        "version": "4.1.60204.60204-139"
+        "sha256": "e1fb40cb8f37464426ca86d0a4e91b8436b70ea641c6ac7e999bd1eb9cde0636",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/roctracer-asan-rpath6.2.4-4.1.60204.60204-139.el8.x86_64.rpm",
+        "version": "4.1.60204.60204"
       }
     ],
-    "version": "4.1.60204.60204-139"
+    "version": "4.1.60204.60204"
   },
-  "rocwmma-dev": {
+  "roctracer-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "roctracer-asan-rpath6.2.4-rpath",
+        "sha256": "6d74d73fc29ac0b1eabcca243aab834dcdbb4bb33748d541c6c4c1586b9e0769",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/roctracer-asan-rpath6.2.4-rpath6.2.4-4.1.60204.60204-139.el8.x86_64.rpm",
+        "version": "4.1.60204.60204"
+      }
+    ],
+    "version": "4.1.60204.60204"
+  },
+  "roctracer-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "roctracer-asan6.2.4-rpath",
+        "sha256": "e7575e84cbdab99c2e95f5fea1b3c7b0432136868c5d82a8583aed67aad7119d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/roctracer-asan6.2.4-rpath6.2.4-4.1.60204.60204-139.el8.x86_64.rpm",
+        "version": "4.1.60204.60204"
+      }
+    ],
+    "version": "4.1.60204.60204"
+  },
+  "rocwmma-devel": {
     "deps": [
       "rocm-core"
     ],
     "components": [
       {
-        "name": "rocwmma-dev",
-        "sha256": "942913d1c051e735f58bca17fbabb8a5c9fe4ff798ff482c056de25ee3280a51",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocwmma-dev/rocwmma-dev_1.5.0.60204-139~20.04_amd64.deb",
-        "version": "1.5.0.60204-139"
+        "name": "rocwmma-devel",
+        "sha256": "d4b7b7c01c7b4dfd41fe2919bad9f48235b5fb28481f6e32ffbb92e62a8a2f9b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocwmma-devel-1.5.0.60204-139.el8.x86_64.rpm",
+        "version": "1.5.0.60204"
       },
       {
-        "name": "rocwmma-dev-rpath",
-        "sha256": "e1a2badd20cafcc82181101968d9937e64b7a14dd8f2c30e38acc0730dc8350c",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rocwmma-dev-rpath6.2.4/rocwmma-dev-rpath6.2.4_1.5.0.60204-139~20.04_amd64.deb",
-        "version": "1.5.0.60204-139"
+        "name": "rocwmma-devel-rpath",
+        "sha256": "d7bc7813bded00da4619c91f40c69266fc6449d8f810723139feb86012e9f32f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rocwmma-devel-rpath6.2.4-1.5.0.60204-139.el8.x86_64.rpm",
+        "version": "1.5.0.60204"
       }
     ],
-    "version": "1.5.0.60204-139"
+    "version": "1.5.0.60204"
   },
   "rpp": {
     "deps": [
@@ -3439,30 +4707,30 @@
     "components": [
       {
         "name": "rpp",
-        "sha256": "2c5d72d286c1851519ef0d9554183d57a4e134b83ddb6a25bf4ad44cd4b6a682",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rpp/rpp_1.8.0.60204-139~20.04_amd64.deb",
-        "version": "1.8.0.60204-139"
+        "sha256": "66516a9f62b1a6f4a9210766ad9ca1ea60e23bada1e6fce7f046ed4bea20795c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rpp-1.8.0.60204-139.el8.x86_64.rpm",
+        "version": "1.8.0.60204"
       },
       {
-        "name": "rpp-dev",
-        "sha256": "9e98a6d3a4ccf61d605e455d63e810d15fd1a506f542e9b1a2468b149987d465",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rpp-dev/rpp-dev_1.8.0.60204-139~20.04_amd64.deb",
-        "version": "1.8.0.60204-139"
+        "name": "rpp-devel",
+        "sha256": "ea7cc7cbd2217c3ebaa42c7250a0224a1453153752e28780f32d234f9f4233b0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rpp-devel-1.8.0.60204-139.el8.x86_64.rpm",
+        "version": "1.8.0.60204"
       },
       {
-        "name": "rpp-dev-rpath",
-        "sha256": "5f82016bed71418a743534d1cd1d689e00afef6a6c34b72ecfa55cb07a331817",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rpp-dev-rpath6.2.4/rpp-dev-rpath6.2.4_1.8.0.60204-139~20.04_amd64.deb",
-        "version": "1.8.0.60204-139"
+        "name": "rpp-devel-rpath",
+        "sha256": "1e44d860f2cdc0649410cba53d7d3755734040873e713afa3ff35b33e484787d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rpp-devel-rpath6.2.4-1.8.0.60204-139.el8.x86_64.rpm",
+        "version": "1.8.0.60204"
       },
       {
         "name": "rpp-rpath",
-        "sha256": "af3e20eff2e175f291895b0f7c6e72a8a972a4420af4314fe81d71e991df9e2d",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rpp-rpath6.2.4/rpp-rpath6.2.4_1.8.0.60204-139~20.04_amd64.deb",
-        "version": "1.8.0.60204-139"
+        "sha256": "a4179b65037668d2da0b2c4dda1436ae224697009cd35e38a5b9f6d8bb6638b1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rpp-rpath6.2.4-1.8.0.60204-139.el8.x86_64.rpm",
+        "version": "1.8.0.60204"
       }
     ],
-    "version": "1.8.0.60204-139"
+    "version": "1.8.0.60204"
   },
   "rpp-asan": {
     "deps": [
@@ -3471,18 +4739,46 @@
     "components": [
       {
         "name": "rpp-asan",
-        "sha256": "b17dc024bd59123e6437874d4be5c471ad0a49989d851a005de747b025f3b661",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rpp-asan/rpp-asan_1.8.0.60204-139~20.04_amd64.deb",
-        "version": "1.8.0.60204-139"
+        "sha256": "4afe4c0b54d47e54f8f97555d330b3b8abddffbf30eb046381c9f7068904757d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rpp-asan-1.8.0.60204-139.el8.x86_64.rpm",
+        "version": "1.8.0.60204"
       },
       {
         "name": "rpp-asan-rpath",
-        "sha256": "d9f9fd448502c4dac370eddc8fe1493ab6d6b29d10e17fa9c1c7822c6984b2aa",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rpp-asan-rpath6.2.4/rpp-asan-rpath6.2.4_1.8.0.60204-139~20.04_amd64.deb",
-        "version": "1.8.0.60204-139"
+        "sha256": "de74b32e4bdaf21b3d4296ddff1c31a0268829aafc6797136183e4574a34df22",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rpp-asan-rpath6.2.4-1.8.0.60204-139.el8.x86_64.rpm",
+        "version": "1.8.0.60204"
       }
     ],
-    "version": "1.8.0.60204-139"
+    "version": "1.8.0.60204"
+  },
+  "rpp-asan-rpath6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan-rpath6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rpp-asan-rpath6.2.4-rpath",
+        "sha256": "070b61336ea7e5d4c859580f2124eaf94b11d20cea4cd8c0000bdd2e46af536a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rpp-asan-rpath6.2.4-rpath6.2.4-1.8.0.60204-139.el8.x86_64.rpm",
+        "version": "1.8.0.60204"
+      }
+    ],
+    "version": "1.8.0.60204"
+  },
+  "rpp-asan6.2.4-rpath": {
+    "deps": [
+      "rocm-core-asan6.2.4-rpath"
+    ],
+    "components": [
+      {
+        "name": "rpp-asan6.2.4-rpath",
+        "sha256": "fc4927d2cacf8cd0b9112375f94d3f2fa3f408d738681653f48f4c8e8bc9e5f4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rpp-asan6.2.4-rpath6.2.4-1.8.0.60204-139.el8.x86_64.rpm",
+        "version": "1.8.0.60204"
+      }
+    ],
+    "version": "1.8.0.60204"
   },
   "rpp-test": {
     "deps": [
@@ -3491,17 +4787,17 @@
     "components": [
       {
         "name": "rpp-test",
-        "sha256": "061663ee3ef3150d3e634526fde402f5b708e9ff2d240e4b99a47fd227729683",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rpp-test/rpp-test_1.8.0.60204-139~20.04_amd64.deb",
-        "version": "1.8.0.60204-139"
+        "sha256": "ac0b79b6b5906d14a2481b7ea1c37322ab229567626bbd9d20de059ba3756eb3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rpp-test-1.8.0.60204-139.el8.x86_64.rpm",
+        "version": "1.8.0.60204"
       },
       {
         "name": "rpp-test-rpath",
-        "sha256": "1cf7872cc2044f49a60ca25f99af7daf84227b8a239e053eb50f6492d32199a0",
-        "url": "https://repo.radeon.com/rocm/apt/6.2.4/pool/main/r/rpp-test-rpath6.2.4/rpp-test-rpath6.2.4_1.8.0.60204-139~20.04_amd64.deb",
-        "version": "1.8.0.60204-139"
+        "sha256": "04fde833ce62cbc14660bd53f1e177bd1e351f08b1876063058e47cb2ac16163",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.2.4/main/rpp-test-rpath6.2.4-1.8.0.60204-139.el8.x86_64.rpm",
+        "version": "1.8.0.60204"
       }
     ],
-    "version": "1.8.0.60204-139"
+    "version": "1.8.0.60204"
   }
 }

--- a/pkgs/rocm-packages/rocm-6.3.4-metadata.json
+++ b/pkgs/rocm-packages/rocm-6.3.4-metadata.json
@@ -6,18 +6,38 @@
     "components": [
       {
         "name": "amd-smi-lib",
-        "sha256": "b003b543db37afeb5d42f31d98cf4d40c4015f274f2adb341daec8d3194a90dd",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/a/amd-smi-lib/amd-smi-lib_25.1.0.60304-76~20.04_amd64.deb",
-        "version": "25.1.0.60304-76"
+        "sha256": "1c964cc09802b8e5a1c4a2002eecb3ba7704b23926bc33a4f83453b8b5906a0e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/amd-smi-lib-25.1.0.60304-76.el8.x86_64.rpm",
+        "version": "25.1.0.60304"
       },
       {
         "name": "amd-smi-lib-rpath",
-        "sha256": "55c5651c6ebb418795a9e51edd24dd98e3d27ac0c6252629cffdae0cfb875816",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/a/amd-smi-lib-rpath6.3.4/amd-smi-lib-rpath6.3.4_25.1.0.60304-76~20.04_amd64.deb",
-        "version": "25.1.0.60304-76"
+        "sha256": "ffdb2c34aa474a87127e043d00618c5bec3a8e747a899d42e63276f852b02191",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/amd-smi-lib-rpath6.3.4-25.1.0.60304-76.el8.x86_64.rpm",
+        "version": "25.1.0.60304"
       }
     ],
-    "version": "25.1.0.60304-76"
+    "version": "25.1.0.60304"
+  },
+  "amd-smi-lib-asan": {
+    "deps": [
+      "rocm-core-asan"
+    ],
+    "components": [
+      {
+        "name": "amd-smi-lib-asan",
+        "sha256": "6a02836ae984dedffd22fa4454f6478784176294550ec9d57827d373a2be49d7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/amd-smi-lib-asan-25.1.0.60304-76.el8.x86_64.rpm",
+        "version": "25.1.0.60304"
+      },
+      {
+        "name": "amd-smi-lib-asan-rpath",
+        "sha256": "37347d2d2fec8b5f35865141ba5b01b81f10f4c935ba086d437a88ad5852173b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/amd-smi-lib-asan-rpath6.3.4-25.1.0.60304-76.el8.x86_64.rpm",
+        "version": "25.1.0.60304"
+      }
+    ],
+    "version": "25.1.0.60304"
   },
   "comgr": {
     "deps": [
@@ -26,18 +46,38 @@
     "components": [
       {
         "name": "comgr",
-        "sha256": "8e9b65bce6411fc4e2c7a0e3cf53b695cc78a90b780269118bbf40ee0edc81ab",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/c/comgr/comgr_2.8.0.60304-76~20.04_amd64.deb",
-        "version": "2.8.0.60304-76"
+        "sha256": "a381b5f79e21c52763a8fbfc0e51bbae1eca2955bbf0c413fe83423b56acd9c0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/comgr-2.8.0.60304-76.el8.x86_64.rpm",
+        "version": "2.8.0.60304"
       },
       {
         "name": "comgr-rpath",
-        "sha256": "2498d3a257c94d6bcd9f03598557f53c7948d52bab707203e544deb597433f1b",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/c/comgr-rpath6.3.4/comgr-rpath6.3.4_2.8.0.60304-76~20.04_amd64.deb",
-        "version": "2.8.0.60304-76"
+        "sha256": "c53fa32377f242cd27e2d63b8bf8507f2a4c7a0a24d678202333c89189f74694",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/comgr-rpath6.3.4-2.8.0.60304-76.el8.x86_64.rpm",
+        "version": "2.8.0.60304"
       }
     ],
-    "version": "2.8.0.60304-76"
+    "version": "2.8.0.60304"
+  },
+  "comgr-asan": {
+    "deps": [
+      "rocm-core-asan"
+    ],
+    "components": [
+      {
+        "name": "comgr-asan",
+        "sha256": "1fb67f9e92e323408db93f8849e17255a173593eb904e811c582fcd8e500e245",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/comgr-asan-2.8.0.60304-76.el8.x86_64.rpm",
+        "version": "2.8.0.60304"
+      },
+      {
+        "name": "comgr-asan-rpath",
+        "sha256": "0fbc465f393bcf6acce5054f2aab3c33e957b9f99b6a17b12ec4e8bb1a88331c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/comgr-asan-rpath6.3.4-2.8.0.60304-76.el8.x86_64.rpm",
+        "version": "2.8.0.60304"
+      }
+    ],
+    "version": "2.8.0.60304"
   },
   "composablekernel-ckprofiler": {
     "deps": [
@@ -46,38 +86,38 @@
     "components": [
       {
         "name": "composablekernel-ckprofiler",
-        "sha256": "b00f5e35c78b021b7903e6133cc6949d7905f7f6770f5b0bd9932df2bf10195d",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/c/composablekernel-ckprofiler/composablekernel-ckprofiler_1.1.0.60304-76~20.04_amd64.deb",
-        "version": "1.1.0.60304-76"
+        "sha256": "72363d48c618a1c31cf459ad4921273b5a16b45eedc80cc00020139034b1e3fa",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/composablekernel-ckprofiler-1.1.0.60304-76.el8.x86_64.rpm",
+        "version": "1.1.0.60304"
       },
       {
         "name": "composablekernel-ckprofiler-rpath",
-        "sha256": "0c27c781bdf1bf73be56a2921b0bf30eb9a903422e7d6888f1a8064c961dbbcf",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/c/composablekernel-ckprofiler-rpath6.3.4/composablekernel-ckprofiler-rpath6.3.4_1.1.0.60304-76~20.04_amd64.deb",
-        "version": "1.1.0.60304-76"
+        "sha256": "96bf8ad79524e581b7ae3d2444910766eea8054c66dd9e910632ec6073152de9",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/composablekernel-ckprofiler-rpath6.3.4-1.1.0.60304-76.el8.x86_64.rpm",
+        "version": "1.1.0.60304"
       }
     ],
-    "version": "1.1.0.60304-76"
+    "version": "1.1.0.60304"
   },
-  "composablekernel-dev": {
+  "composablekernel-devel": {
     "deps": [
       "rocm-core"
     ],
     "components": [
       {
-        "name": "composablekernel-dev",
-        "sha256": "e92385a09447156d5e6ae8e63b5e2d08c092fd36bdb6289d4fe3ca7ae9017e38",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/c/composablekernel-dev/composablekernel-dev_1.1.0.60304-76~20.04_amd64.deb",
-        "version": "1.1.0.60304-76"
+        "name": "composablekernel-devel",
+        "sha256": "0a6a6411ec9f02805340351ef76a6080238d2d0cfd0a8658bed2b57006360fa9",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/composablekernel-devel-1.1.0.60304-76.el8.x86_64.rpm",
+        "version": "1.1.0.60304"
       },
       {
-        "name": "composablekernel-dev-rpath",
-        "sha256": "4a591c5a5965337d79de267dd8c70eb4303ba0849adfa6553aa34ec843b9ccaa",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/c/composablekernel-dev-rpath6.3.4/composablekernel-dev-rpath6.3.4_1.1.0.60304-76~20.04_amd64.deb",
-        "version": "1.1.0.60304-76"
+        "name": "composablekernel-devel-rpath",
+        "sha256": "07b101f47334f34aed7370e55b525564c7f75face09937f0365eb198968f3d90",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/composablekernel-devel-rpath6.3.4-1.1.0.60304-76.el8.x86_64.rpm",
+        "version": "1.1.0.60304"
       }
     ],
-    "version": "1.1.0.60304-76"
+    "version": "1.1.0.60304"
   },
   "half": {
     "deps": [
@@ -86,20 +126,20 @@
     "components": [
       {
         "name": "half",
-        "sha256": "5af54dfccdf16d578f21c00cc6d03eae0a8113a332748105989c77aaa5abbaf5",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/half/half_1.12.0.60304-76~20.04_amd64.deb",
-        "version": "1.12.0.60304-76"
+        "sha256": "5c040299bc7abbcd59ef450e6343277305e3a5024788df6168272ae43f1eaadd",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/half-1.12.0.60304-76.el8.x86_64.rpm",
+        "version": "1.12.0.60304"
       },
       {
         "name": "half-rpath",
-        "sha256": "ae41dda60265fc3ebce12de98d299110f386cecc1b52ee2bd4e2ec2f5a5edc2f",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/half-rpath6.3.4/half-rpath6.3.4_1.12.0.60304-76~20.04_amd64.deb",
-        "version": "1.12.0.60304-76"
+        "sha256": "6c0eb08ac3fbd1d58b9d6a9a4ab3e2d50af570e62587fb1121a44afe4a6a402d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/half-rpath6.3.4-1.12.0.60304-76.el8.x86_64.rpm",
+        "version": "1.12.0.60304"
       }
     ],
-    "version": "1.12.0.60304-76"
+    "version": "1.12.0.60304"
   },
-  "hip-dev": {
+  "hip-devel": {
     "deps": [
       "hip-runtime-amd",
       "hsa-rocr",
@@ -108,40 +148,40 @@
     ],
     "components": [
       {
-        "name": "hip-dev",
-        "sha256": "f25b71b76a7c5ec0e93ac168121e59c4e4482c55ca629f36c36f6141a43be07c",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hip-dev/hip-dev_6.3.42134.60304-76~20.04_amd64.deb",
-        "version": "6.3.42134.60304-76"
+        "name": "hip-devel",
+        "sha256": "08716e7e0ce4cd1b9fc4fa19b167bca78b48e5de4aadffd9e5c1def2502cdab6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hip-devel-6.3.42134.60304-76.el8.x86_64.rpm",
+        "version": "6.3.42134.60304"
       },
       {
-        "name": "hip-dev-rpath",
-        "sha256": "6468450992e11a11594bf84c124c78b9f2aee4522b813de7715b4c83c27536d2",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hip-dev-rpath6.3.4/hip-dev-rpath6.3.4_6.3.42134.60304-76~20.04_amd64.deb",
-        "version": "6.3.42134.60304-76"
+        "name": "hip-devel-rpath",
+        "sha256": "ad9d6d76d0d58c61896c92d3d586e21527e4cb2d562d30dab8acb8cc50d0abbc",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hip-devel-rpath6.3.4-6.3.42134.60304-76.el8.x86_64.rpm",
+        "version": "6.3.42134.60304"
       }
     ],
-    "version": "6.3.42134.60304-76"
+    "version": "6.3.42134.60304"
   },
   "hip-doc": {
     "deps": [
-      "hip-dev",
+      "hip-devel",
       "rocm-core"
     ],
     "components": [
       {
         "name": "hip-doc",
-        "sha256": "c0c3aafbd387eb60293089a674353c5b149fcfe24a8527f21e6734900e0dfcd3",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hip-doc/hip-doc_6.3.42134.60304-76~20.04_amd64.deb",
-        "version": "6.3.42134.60304-76"
+        "sha256": "8d5bab2f3be04821fa94f0e1744160a929c2a48f166f052074f35830e77b7b12",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hip-doc-6.3.42134.60304-76.el8.x86_64.rpm",
+        "version": "6.3.42134.60304"
       },
       {
         "name": "hip-doc-rpath",
-        "sha256": "b143503bedf7d756427f03e1030cc25c63f47c4df6ab59ab378101e84a2898bc",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hip-doc-rpath6.3.4/hip-doc-rpath6.3.4_6.3.42134.60304-76~20.04_amd64.deb",
-        "version": "6.3.42134.60304-76"
+        "sha256": "472fd11f0cd347061ed9c3316712ceab37481d82ed8b42c736178e8fa4e4e4e5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hip-doc-rpath6.3.4-6.3.42134.60304-76.el8.x86_64.rpm",
+        "version": "6.3.42134.60304"
       }
     ],
-    "version": "6.3.42134.60304-76"
+    "version": "6.3.42134.60304"
   },
   "hip-runtime-amd": {
     "deps": [
@@ -154,18 +194,42 @@
     "components": [
       {
         "name": "hip-runtime-amd",
-        "sha256": "2706dba757e5548917b700623e8c79f84314e3d1f454c87cd8e6e5dd2769aa31",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hip-runtime-amd/hip-runtime-amd_6.3.42134.60304-76~20.04_amd64.deb",
-        "version": "6.3.42134.60304-76"
+        "sha256": "a7acb59bad3c621049f82e5c231c684c37348a7e4e05b1e259cdcf062f08ceb5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hip-runtime-amd-6.3.42134.60304-76.el8.x86_64.rpm",
+        "version": "6.3.42134.60304"
       },
       {
         "name": "hip-runtime-amd-rpath",
-        "sha256": "f812b91b11e2ba0806d15c68321049492bc52a9c15ea87e89a76b358125969d1",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hip-runtime-amd-rpath6.3.4/hip-runtime-amd-rpath6.3.4_6.3.42134.60304-76~20.04_amd64.deb",
-        "version": "6.3.42134.60304-76"
+        "sha256": "07b04f77e746554df19219d2a01e623a0fd9fc922d391740fe613a23a1bcc519",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hip-runtime-amd-rpath6.3.4-6.3.42134.60304-76.el8.x86_64.rpm",
+        "version": "6.3.42134.60304"
       }
     ],
-    "version": "6.3.42134.60304-76"
+    "version": "6.3.42134.60304"
+  },
+  "hip-runtime-amd-asan": {
+    "deps": [
+      "comgr-asan",
+      "hsa-rocr-asan",
+      "rocm-core-asan",
+      "rocm-llvm",
+      "rocminfo"
+    ],
+    "components": [
+      {
+        "name": "hip-runtime-amd-asan",
+        "sha256": "3906e359c68ac0d6c91f2104fe2466e6f0a836e464170c7c20ec552ba7d47045",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hip-runtime-amd-asan-6.3.42134.60304-76.el8.x86_64.rpm",
+        "version": "6.3.42134.60304"
+      },
+      {
+        "name": "hip-runtime-amd-asan-rpath",
+        "sha256": "89f76e93eb032f4c7059f319b56b60821d88ff7ab65644ae18ea7a30e2badc31",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hip-runtime-amd-asan-rpath6.3.4-6.3.42134.60304-76.el8.x86_64.rpm",
+        "version": "6.3.42134.60304"
+      }
+    ],
+    "version": "6.3.42134.60304"
   },
   "hip-runtime-nvidia": {
     "deps": [
@@ -175,44 +239,44 @@
     "components": [
       {
         "name": "hip-runtime-nvidia",
-        "sha256": "0100b7cc0c56770a52c30cd71a50aa9d70d6642f8c0306e88ac7a4bf06b1380a",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hip-runtime-nvidia/hip-runtime-nvidia_6.3.42134.60304-76~20.04_amd64.deb",
-        "version": "6.3.42134.60304-76"
+        "sha256": "33fa1fe6201d125886a4541c94a5816f0040c54c95987697e23d306552afeeea",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hip-runtime-nvidia-6.3.42134.60304-76.el8.x86_64.rpm",
+        "version": "6.3.42134.60304"
       },
       {
         "name": "hip-runtime-nvidia-rpath",
-        "sha256": "e3cbf5e9a4e3289148a15a69db4393cca826afddaa3bc1134addb889ecd59fc1",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hip-runtime-nvidia-rpath6.3.4/hip-runtime-nvidia-rpath6.3.4_6.3.42134.60304-76~20.04_amd64.deb",
-        "version": "6.3.42134.60304-76"
+        "sha256": "b89de359afe9b18705fc36bd93a2b3e93d90a4fea7fbd59e647113d9e1b4680c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hip-runtime-nvidia-rpath6.3.4-6.3.42134.60304-76.el8.x86_64.rpm",
+        "version": "6.3.42134.60304"
       }
     ],
-    "version": "6.3.42134.60304-76"
+    "version": "6.3.42134.60304"
   },
   "hip-samples": {
     "deps": [
-      "hip-dev",
+      "hip-devel",
       "hipcc",
       "rocm-core"
     ],
     "components": [
       {
         "name": "hip-samples",
-        "sha256": "fe3e5d533b31041ca64f6fc67caf29e90e02d79b066ab7e46dee1ac4cd590bc9",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hip-samples/hip-samples_6.3.42134.60304-76~20.04_amd64.deb",
-        "version": "6.3.42134.60304-76"
+        "sha256": "4a871c85c1ca36e2d4f862fd647460773a12f6bacfb356a2253551fb4bd8e440",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hip-samples-6.3.42134.60304-76.el8.x86_64.rpm",
+        "version": "6.3.42134.60304"
       },
       {
         "name": "hip-samples-rpath",
-        "sha256": "a351b9ce4b5194c2b0d7ab1c2e3da2c1cfc718f4cde9178bc23738abda7b37ba",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hip-samples-rpath6.3.4/hip-samples-rpath6.3.4_6.3.42134.60304-76~20.04_amd64.deb",
-        "version": "6.3.42134.60304-76"
+        "sha256": "ba4626d9b783e3ad7e58b26e397569d7274edfc180238c17e019fe9337e5cf46",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hip-samples-rpath6.3.4-6.3.42134.60304-76.el8.x86_64.rpm",
+        "version": "6.3.42134.60304"
       }
     ],
-    "version": "6.3.42134.60304-76"
+    "version": "6.3.42134.60304"
   },
   "hipblas": {
     "deps": [
-      "hipblas-common-dev",
+      "hipblas-common-devel",
       "rocblas",
       "rocm-core",
       "rocsolver"
@@ -220,147 +284,189 @@
     "components": [
       {
         "name": "hipblas",
-        "sha256": "16446eea710e61e2cbe055a8295bbd91510d87926565577398dd88299d23f93b",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipblas/hipblas_2.3.0.60304-76~20.04_amd64.deb",
-        "version": "2.3.0.60304-76"
+        "sha256": "54f032eb4c0998159493e86d1e6cc09c67e154a00cdc4d9b8309ab43f816bc9a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipblas-2.3.0.60304-76.el8.x86_64.rpm",
+        "version": "2.3.0.60304"
       },
       {
-        "name": "hipblas-dev",
-        "sha256": "900f9a6cafa4103fc7274a0e92ee84ec4d2c9a573716822f6e1da22c5fe20380",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipblas-dev/hipblas-dev_2.3.0.60304-76~20.04_amd64.deb",
-        "version": "2.3.0.60304-76"
+        "name": "hipblas-devel",
+        "sha256": "73396d6f05dd0addf9b280ee0e54e4ab6d0570b9f9372a153fa73ccdf86ec6e7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipblas-devel-2.3.0.60304-76.el8.x86_64.rpm",
+        "version": "2.3.0.60304"
       },
       {
-        "name": "hipblas-dev-rpath",
-        "sha256": "0ac3f4325dc147f7f3d038204dfdce6e4a6fc1bf8662da703a5ec7ede6184f81",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipblas-dev-rpath6.3.4/hipblas-dev-rpath6.3.4_2.3.0.60304-76~20.04_amd64.deb",
-        "version": "2.3.0.60304-76"
+        "name": "hipblas-devel-rpath",
+        "sha256": "93f0ee9de524f858b2190c2bbc77079df9db2bf5f6754715c00ad1480bb26298",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipblas-devel-rpath6.3.4-2.3.0.60304-76.el8.x86_64.rpm",
+        "version": "2.3.0.60304"
       },
       {
         "name": "hipblas-rpath",
-        "sha256": "689e2065c7146463461aeceec4e1c6a83a9f2fbfe60eff934f7cd8a6f1978a1c",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipblas-rpath6.3.4/hipblas-rpath6.3.4_2.3.0.60304-76~20.04_amd64.deb",
-        "version": "2.3.0.60304-76"
+        "sha256": "7471893e129d3c1dc3c60f911b3f6131cafefb582c02521edb8d7cc15b829da8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipblas-rpath6.3.4-2.3.0.60304-76.el8.x86_64.rpm",
+        "version": "2.3.0.60304"
       }
     ],
-    "version": "2.3.0.60304-76"
+    "version": "2.3.0.60304"
   },
-  "hipblas-common-dev": {
+  "hipblas-asan": {
+    "deps": [
+      "rocblas",
+      "rocm-core-asan",
+      "rocsolver"
+    ],
+    "components": [
+      {
+        "name": "hipblas-asan",
+        "sha256": "86485c0b74fa53c6571f6ef456963a264ce6094153630dc1619cf9f1797e3aee",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipblas-asan-2.3.0.60304-76.el8.x86_64.rpm",
+        "version": "2.3.0.60304"
+      },
+      {
+        "name": "hipblas-asan-rpath",
+        "sha256": "866782d9bdecb853f506a6b8751a56e57412f179aa584cce8f7b8423ffde3f0a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipblas-asan-rpath6.3.4-2.3.0.60304-76.el8.x86_64.rpm",
+        "version": "2.3.0.60304"
+      }
+    ],
+    "version": "2.3.0.60304"
+  },
+  "hipblas-common-devel": {
     "deps": [
       "rocm-core"
     ],
     "components": [
       {
-        "name": "hipblas-common-dev",
-        "sha256": "06d8ffc34cf9f8923a0fd16a357d07ef65e0198ae14dd3e4bc095e1afa69a2c4",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipblas-common-dev/hipblas-common-dev_1.0.0.60304-76~20.04_amd64.deb",
-        "version": "1.0.0.60304-76"
+        "name": "hipblas-common-devel",
+        "sha256": "e6c7994f5cbc7a7af133c14783f7817f856afc4e2b2ff96861507e74148401b6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipblas-common-devel-1.0.0.60304-76.el8.x86_64.rpm",
+        "version": "1.0.0.60304"
       },
       {
-        "name": "hipblas-common-dev-rpath",
-        "sha256": "3bd40f3f50e1529cedafe7e3a3c03a372697622973de6e633902790e6789adf3",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipblas-common-dev-rpath6.3.4/hipblas-common-dev-rpath6.3.4_1.0.0.60304-76~20.04_amd64.deb",
-        "version": "1.0.0.60304-76"
+        "name": "hipblas-common-devel-rpath",
+        "sha256": "bf7de882a7b5d5254702f46d5ead50510be3a17ff1372729094947e083cb113d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipblas-common-devel-rpath6.3.4-1.0.0.60304-76.el8.x86_64.rpm",
+        "version": "1.0.0.60304"
       }
     ],
-    "version": "1.0.0.60304-76"
+    "version": "1.0.0.60304"
   },
   "hipblaslt": {
     "deps": [
-      "hipblas-common-dev",
+      "hipblas-common-devel",
       "rocm-core"
     ],
     "components": [
       {
         "name": "hipblaslt",
-        "sha256": "0e5fea1983dd886d6e2667249bdebf0686770e0641710c59a808ece30f7778e7",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipblaslt/hipblaslt_0.10.0.60304-76~20.04_amd64.deb",
-        "version": "0.10.0.60304-76"
+        "sha256": "f89bad4b67fd4c97451186d88cb9f36a53c9dad6e549ce83f9e581ac7ff4e01a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipblaslt-0.10.0.60304-76.el8.x86_64.rpm",
+        "version": "0.10.0.60304"
       },
       {
-        "name": "hipblaslt-dev",
-        "sha256": "f98aef3961ef34727bb27277641943ca22500a4d097ea7efd4e6b9aa847a2a56",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipblaslt-dev/hipblaslt-dev_0.10.0.60304-76~20.04_amd64.deb",
-        "version": "0.10.0.60304-76"
+        "name": "hipblaslt-devel",
+        "sha256": "85163f24ea129a1c13fb164274d6d21c28d47606eb4995045d3c7b690c5e7755",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipblaslt-devel-0.10.0.60304-76.el8.x86_64.rpm",
+        "version": "0.10.0.60304"
       },
       {
-        "name": "hipblaslt-dev-rpath",
-        "sha256": "0d9f2f7ba78e5586a52601773a4d1734b99ac2386da963b14999243a5f0a76d6",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipblaslt-dev-rpath6.3.4/hipblaslt-dev-rpath6.3.4_0.10.0.60304-76~20.04_amd64.deb",
-        "version": "0.10.0.60304-76"
+        "name": "hipblaslt-devel-rpath",
+        "sha256": "525aba7fb13a7d3a82419f37c942fad6026a7d8dbdfe34d3245bfa2dacf692c1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipblaslt-devel-rpath6.3.4-0.10.0.60304-76.el8.x86_64.rpm",
+        "version": "0.10.0.60304"
       },
       {
         "name": "hipblaslt-rpath",
-        "sha256": "ab2f61c2b880c9576e8d3a03a796cd44cc40ac5ce90e745a96691f42dfdeb139",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipblaslt-rpath6.3.4/hipblaslt-rpath6.3.4_0.10.0.60304-76~20.04_amd64.deb",
-        "version": "0.10.0.60304-76"
+        "sha256": "fb13ced5984a1ed7ec2ab3feb439c8443941f53ee13578c032f73e1eb01a6ab1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipblaslt-rpath6.3.4-0.10.0.60304-76.el8.x86_64.rpm",
+        "version": "0.10.0.60304"
       }
     ],
-    "version": "0.10.0.60304-76"
+    "version": "0.10.0.60304"
+  },
+  "hipblaslt-asan": {
+    "deps": [
+      "rocm-core-asan"
+    ],
+    "components": [
+      {
+        "name": "hipblaslt-asan",
+        "sha256": "ef219b395e1d12736eb30affac4e6feee2c4343d4c3ee5be1370e8180e1f7f9c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipblaslt-asan-0.10.0.60304-76.el8.x86_64.rpm",
+        "version": "0.10.0.60304"
+      },
+      {
+        "name": "hipblaslt-asan-rpath",
+        "sha256": "82c3470fdcc2761fd5d24b0e0961da31a98cbf8ad4b46ba97f6ef8277a88bde5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipblaslt-asan-rpath6.3.4-0.10.0.60304-76.el8.x86_64.rpm",
+        "version": "0.10.0.60304"
+      }
+    ],
+    "version": "0.10.0.60304"
   },
   "hipcc": {
     "deps": [
-      "hip-dev",
+      "hip-devel",
       "rocm-core",
       "rocm-llvm"
     ],
     "components": [
       {
         "name": "hipcc",
-        "sha256": "40a1a69569518208263445d1128a69e01a71b493a07fbd6de35930d9a3829eda",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipcc/hipcc_1.1.1.60304-76~20.04_amd64.deb",
-        "version": "1.1.1.60304-76"
+        "sha256": "90025797ec5a89275e5c1956627d555ce6dfdb405475e018836758d4484965ec",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipcc-1.1.1.60304-76.el8.x86_64.rpm",
+        "version": "1.1.1.60304"
       },
       {
         "name": "hipcc-rpath",
-        "sha256": "2c7e29cd41f71a421412da27bdbaa0b6514e8827a970bd77c2ce981c40a99709",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipcc-rpath6.3.4/hipcc-rpath6.3.4_1.1.1.60304-76~20.04_amd64.deb",
-        "version": "1.1.1.60304-76"
+        "sha256": "a26e86a3891466be6587c3de9a5a993f43cc61ea367ce17914edec34ec74ed86",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipcc-rpath6.3.4-1.1.1.60304-76.el8.x86_64.rpm",
+        "version": "1.1.1.60304"
       }
     ],
-    "version": "1.1.1.60304-76"
+    "version": "1.1.1.60304"
   },
   "hipcc-nvidia": {
     "deps": [
-      "hip-dev",
+      "hip-devel",
       "rocm-core"
     ],
     "components": [
       {
         "name": "hipcc-nvidia",
-        "sha256": "318590d18305d05bc36e14f6a577d85f759ced5008572cbc0417a08189b0fcbe",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipcc-nvidia/hipcc-nvidia_1.1.1.60304-76~20.04_amd64.deb",
-        "version": "1.1.1.60304-76"
+        "sha256": "d3e43037b8e056a8ed8f00b3237515d56a5fd2dc5649706509d78cd8a2b192f4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipcc-nvidia-1.1.1.60304-76.el8.x86_64.rpm",
+        "version": "1.1.1.60304"
       },
       {
         "name": "hipcc-nvidia-rpath",
-        "sha256": "305603da595e9646c05d68fac46efa1c28a30d8dc7295043d4f4d9effbb0ad4e",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipcc-nvidia-rpath6.3.4/hipcc-nvidia-rpath6.3.4_1.1.1.60304-76~20.04_amd64.deb",
-        "version": "1.1.1.60304-76"
+        "sha256": "beb5e7abcff0fc5a0c913a172c3942709514ff1c15e1a6afec9d4cae38fe978e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipcc-nvidia-rpath6.3.4-1.1.1.60304-76.el8.x86_64.rpm",
+        "version": "1.1.1.60304"
       }
     ],
-    "version": "1.1.1.60304-76"
+    "version": "1.1.1.60304"
   },
-  "hipcub-dev": {
+  "hipcub-devel": {
     "deps": [
       "rocm-core",
-      "rocprim-dev"
+      "rocprim-devel"
     ],
     "components": [
       {
-        "name": "hipcub-dev",
-        "sha256": "00313373204c4e87e6807171c4f1bf46e9c65dc35e9632cdaf9012fd72df4db2",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipcub-dev/hipcub-dev_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "name": "hipcub-devel",
+        "sha256": "2ccaf1a78a31eed0a6dc308390dfad31ceacb3d7b15d7724f27222dcf896be48",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipcub-devel-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       },
       {
-        "name": "hipcub-dev-rpath",
-        "sha256": "6d691a0e8eb7f8a4c36da35d44ef5f27c5861e61356d5d057ff8fd30692fed6c",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipcub-dev-rpath6.3.4/hipcub-dev-rpath6.3.4_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "name": "hipcub-devel-rpath",
+        "sha256": "ab1cd5a67b886301f6a7a3356f25d18ebd49f4d69400dd7acaecc40213000744",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipcub-devel-rpath6.3.4-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       }
     ],
-    "version": "3.3.0.60304-76"
+    "version": "3.3.0.60304"
   },
   "hipfft": {
     "deps": [
@@ -370,51 +476,72 @@
     "components": [
       {
         "name": "hipfft",
-        "sha256": "84819b55e96bd87e81d85485236ec8ca6c91275b07f059f3405f27e4cb9861fa",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipfft/hipfft_1.0.17.60304-76~20.04_amd64.deb",
-        "version": "1.0.17.60304-76"
+        "sha256": "2db8618ccf24975fc8eb5cedc8ddc8fd42a452172c1f14d4de25e2adc9f2b4ed",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipfft-1.0.17.60304-76.el8.x86_64.rpm",
+        "version": "1.0.17.60304"
       },
       {
-        "name": "hipfft-dev",
-        "sha256": "db32281cebf10536ee38a4b62deb8284a4dffc719aa0832a919deea7ae626059",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipfft-dev/hipfft-dev_1.0.17.60304-76~20.04_amd64.deb",
-        "version": "1.0.17.60304-76"
+        "name": "hipfft-devel",
+        "sha256": "8d1258f7a4efe2c4fdb294d4435c47198c75e418ffd0e0f43b9914cc3639d5c8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipfft-devel-1.0.17.60304-76.el8.x86_64.rpm",
+        "version": "1.0.17.60304"
       },
       {
-        "name": "hipfft-dev-rpath",
-        "sha256": "7e34e2fb16cbac2d236238ec39af89f03812f8b529a111b5715c7e2b629e831f",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipfft-dev-rpath6.3.4/hipfft-dev-rpath6.3.4_1.0.17.60304-76~20.04_amd64.deb",
-        "version": "1.0.17.60304-76"
+        "name": "hipfft-devel-rpath",
+        "sha256": "1946192a6c6a5c4e570479d19dd3dbc0aeb4d5e5925a7efbffad7fe25ca9f2a0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipfft-devel-rpath6.3.4-1.0.17.60304-76.el8.x86_64.rpm",
+        "version": "1.0.17.60304"
       },
       {
         "name": "hipfft-rpath",
-        "sha256": "ed8381775f65091ddcc86fb4a39169d60d7f06fccc9145e9f46e67fa98478841",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipfft-rpath6.3.4/hipfft-rpath6.3.4_1.0.17.60304-76~20.04_amd64.deb",
-        "version": "1.0.17.60304-76"
+        "sha256": "139dc39def7b00361866a5d0809e86032a7783263cd666cdd4b2f0533f20c643",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipfft-rpath6.3.4-1.0.17.60304-76.el8.x86_64.rpm",
+        "version": "1.0.17.60304"
       }
     ],
-    "version": "1.0.17.60304-76"
+    "version": "1.0.17.60304"
   },
-  "hipfort-dev": {
+  "hipfft-asan": {
+    "deps": [
+      "rocfft",
+      "rocm-core-asan"
+    ],
+    "components": [
+      {
+        "name": "hipfft-asan",
+        "sha256": "f5388480deedd2ad1a053f0a29f50484807d99c94bf7094b112950c92a2866b4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipfft-asan-1.0.17.60304-76.el8.x86_64.rpm",
+        "version": "1.0.17.60304"
+      },
+      {
+        "name": "hipfft-asan-rpath",
+        "sha256": "8f597ce2801d399f40b9a7c68b2020ee18ccb89ad37c06885fe3160d64353a7c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipfft-asan-rpath6.3.4-1.0.17.60304-76.el8.x86_64.rpm",
+        "version": "1.0.17.60304"
+      }
+    ],
+    "version": "1.0.17.60304"
+  },
+  "hipfort-devel": {
     "deps": [
       "hip-runtime-amd",
       "rocm-core"
     ],
     "components": [
       {
-        "name": "hipfort-dev",
-        "sha256": "eabc5e2812f137945dc6f97722a8be0cce5132fad0bf4809cf3bc598fd9e4bec",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipfort-dev/hipfort-dev_0.5.1.60304-76~20.04_amd64.deb",
-        "version": "0.5.1.60304-76"
+        "name": "hipfort-devel",
+        "sha256": "7c3cf6cf674d67a14611b23c81334e1f707580162836e9ea38571f769ba40b60",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipfort-devel-0.5.1.60304-76.el8.x86_64.rpm",
+        "version": "0.5.1.60304"
       },
       {
-        "name": "hipfort-dev-rpath",
-        "sha256": "d828490bab9e9a3dbd136e296015d3a15928a628aa3c15faa77390ad80aa739a",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipfort-dev-rpath6.3.4/hipfort-dev-rpath6.3.4_0.5.1.60304-76~20.04_amd64.deb",
-        "version": "0.5.1.60304-76"
+        "name": "hipfort-devel-rpath",
+        "sha256": "90b63244be7644a8cb6f15c939ed79e4e713c601cb06626a3a80d4ad02d69bba",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipfort-devel-rpath6.3.4-0.5.1.60304-76.el8.x86_64.rpm",
+        "version": "0.5.1.60304"
       }
     ],
-    "version": "0.5.1.60304-76"
+    "version": "0.5.1.60304"
   },
   "hipify-clang": {
     "deps": [
@@ -423,18 +550,18 @@
     "components": [
       {
         "name": "hipify-clang",
-        "sha256": "856dcb62a4334c9f10501db1fabba5b1178fbe62e2d64cc8d9e751439845b4bc",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipify-clang/hipify-clang_18.0.0.60304-76~20.04_amd64.deb",
-        "version": "18.0.0.60304-76"
+        "sha256": "ba0883d3101526a37cc6fcbac139cde93545261fee1cafef02e6c0c5f20f00c1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipify-clang-18.0.0.60304-76.el8.x86_64.rpm",
+        "version": "18.0.0.60304"
       },
       {
         "name": "hipify-clang-rpath",
-        "sha256": "c7a87056f874014e88037801d85891ce9cd616dfeadf4f0965d023832874bbcb",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipify-clang-rpath6.3.4/hipify-clang-rpath6.3.4_18.0.0.60304-76~20.04_amd64.deb",
-        "version": "18.0.0.60304-76"
+        "sha256": "35187d5614731e7370bd639a624bd6a9cedbfdc28ca1c1d3563f83367c5ac2af",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipify-clang-rpath6.3.4-18.0.0.60304-76.el8.x86_64.rpm",
+        "version": "18.0.0.60304"
       }
     ],
-    "version": "18.0.0.60304-76"
+    "version": "18.0.0.60304"
   },
   "hiprand": {
     "deps": [
@@ -443,30 +570,50 @@
     "components": [
       {
         "name": "hiprand",
-        "sha256": "4a6d4d7c6b13edf032b7499abcb72d6f463c1795473abb124315f10a9bae60df",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hiprand/hiprand_2.11.1.60304-76~20.04_amd64.deb",
-        "version": "2.11.1.60304-76"
+        "sha256": "1f46494b7c2c2e217f0bdecd4ff77796d936499c3ca965c8bfdb546b9303292d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hiprand-2.11.1.60304-76.el8.x86_64.rpm",
+        "version": "2.11.1.60304"
       },
       {
-        "name": "hiprand-dev",
-        "sha256": "e09944535cfb798538cb244de0efe094ab02f6944546f4da6ac884a4f4e5b162",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hiprand-dev/hiprand-dev_2.11.1.60304-76~20.04_amd64.deb",
-        "version": "2.11.1.60304-76"
+        "name": "hiprand-devel",
+        "sha256": "f580484c74bcc2060f66d36bed8e0b2ffff8e267a710bc8f3a3ae0d891af6424",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hiprand-devel-2.11.1.60304-76.el8.x86_64.rpm",
+        "version": "2.11.1.60304"
       },
       {
-        "name": "hiprand-dev-rpath",
-        "sha256": "a92ca22a5111223f0435a73921c4bf3bbd96a92d9b3c2c04e94e68450354ca20",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hiprand-dev-rpath6.3.4/hiprand-dev-rpath6.3.4_2.11.1.60304-76~20.04_amd64.deb",
-        "version": "2.11.1.60304-76"
+        "name": "hiprand-devel-rpath",
+        "sha256": "0dc8722b70c9fb702c4a539140936c7b486a4325e3d60b739b56be6499eaf6b7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hiprand-devel-rpath6.3.4-2.11.1.60304-76.el8.x86_64.rpm",
+        "version": "2.11.1.60304"
       },
       {
         "name": "hiprand-rpath",
-        "sha256": "a200acd4d3d8c8ffd43c85774a0db22583d2e85e19122e43009ef59ad1f15945",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hiprand-rpath6.3.4/hiprand-rpath6.3.4_2.11.1.60304-76~20.04_amd64.deb",
-        "version": "2.11.1.60304-76"
+        "sha256": "20a05df65d5a70d2f6389b4885ce54bf4933b16e66003ff66338df2b9b1c28e5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hiprand-rpath6.3.4-2.11.1.60304-76.el8.x86_64.rpm",
+        "version": "2.11.1.60304"
       }
     ],
-    "version": "2.11.1.60304-76"
+    "version": "2.11.1.60304"
+  },
+  "hiprand-asan": {
+    "deps": [
+      "rocm-core-asan"
+    ],
+    "components": [
+      {
+        "name": "hiprand-asan",
+        "sha256": "40b113b79c9ca755e0ddf78aca83b556f154e3abbda1eb2d60952b8cbb67b00c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hiprand-asan-2.11.1.60304-76.el8.x86_64.rpm",
+        "version": "2.11.1.60304"
+      },
+      {
+        "name": "hiprand-asan-rpath",
+        "sha256": "974e736582b315393b6aca4a447d354eae5f2180e5625c255195d10f7fe13b25",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hiprand-asan-rpath6.3.4-2.11.1.60304-76.el8.x86_64.rpm",
+        "version": "2.11.1.60304"
+      }
+    ],
+    "version": "2.11.1.60304"
   },
   "hipsolver": {
     "deps": [
@@ -477,30 +624,52 @@
     "components": [
       {
         "name": "hipsolver",
-        "sha256": "c5af544febb15f63ff0d37f7d542666ba7582e49b6d6e7e8144e300e8db57292",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipsolver/hipsolver_2.3.0.60304-76~20.04_amd64.deb",
-        "version": "2.3.0.60304-76"
+        "sha256": "559cc1cbd5e3bc1b4560d02b4bf6b735b52e811b67b04547f404183bdf44213b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipsolver-2.3.0.60304-76.el8.x86_64.rpm",
+        "version": "2.3.0.60304"
       },
       {
-        "name": "hipsolver-dev",
-        "sha256": "157f38a818830ebc2931f656f73566a0d7a326bc0b46216f3b873bc5e5695079",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipsolver-dev/hipsolver-dev_2.3.0.60304-76~20.04_amd64.deb",
-        "version": "2.3.0.60304-76"
+        "name": "hipsolver-devel",
+        "sha256": "37b2a530872a6c41582fbb683e9feba88113bfb22b11dd9a0132e566cc7e807e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipsolver-devel-2.3.0.60304-76.el8.x86_64.rpm",
+        "version": "2.3.0.60304"
       },
       {
-        "name": "hipsolver-dev-rpath",
-        "sha256": "e392b49e550d3eca36d4c2c64d2d544a6321dd227221c1c4e3731971b30f03b2",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipsolver-dev-rpath6.3.4/hipsolver-dev-rpath6.3.4_2.3.0.60304-76~20.04_amd64.deb",
-        "version": "2.3.0.60304-76"
+        "name": "hipsolver-devel-rpath",
+        "sha256": "5408afb303e3c7fc024508f6afabe3a9cf4c4725bb3fb6a84e4c6ffc674c85f0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipsolver-devel-rpath6.3.4-2.3.0.60304-76.el8.x86_64.rpm",
+        "version": "2.3.0.60304"
       },
       {
         "name": "hipsolver-rpath",
-        "sha256": "156602015b7893117da5d4dcc76523d38717bf9eaeb5d783cb5b956d8a4aa68c",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipsolver-rpath6.3.4/hipsolver-rpath6.3.4_2.3.0.60304-76~20.04_amd64.deb",
-        "version": "2.3.0.60304-76"
+        "sha256": "657f6bdc888166cabda6f97eb4f71c45108e667eebcc3eef3bf6e03940ed9d9d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipsolver-rpath6.3.4-2.3.0.60304-76.el8.x86_64.rpm",
+        "version": "2.3.0.60304"
       }
     ],
-    "version": "2.3.0.60304-76"
+    "version": "2.3.0.60304"
+  },
+  "hipsolver-asan": {
+    "deps": [
+      "rocblas",
+      "rocm-core-asan",
+      "rocsolver"
+    ],
+    "components": [
+      {
+        "name": "hipsolver-asan",
+        "sha256": "fdd358ea1d09af161d5d6c657c07e8bb8db31a30437fe6b0d923a6a7b5f033e1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipsolver-asan-2.3.0.60304-76.el8.x86_64.rpm",
+        "version": "2.3.0.60304"
+      },
+      {
+        "name": "hipsolver-asan-rpath",
+        "sha256": "0c23df1f141c80afa2d683e8b0322a77a11be1986b8ee67dd238789c6f6c4810",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipsolver-asan-rpath6.3.4-2.3.0.60304-76.el8.x86_64.rpm",
+        "version": "2.3.0.60304"
+      }
+    ],
+    "version": "2.3.0.60304"
   },
   "hipsparse": {
     "deps": [
@@ -510,30 +679,51 @@
     "components": [
       {
         "name": "hipsparse",
-        "sha256": "1a2de431eae6abf192818bc299a6ebbf5364610b27953744929b8524f823db80",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipsparse/hipsparse_3.1.2.60304-76~20.04_amd64.deb",
-        "version": "3.1.2.60304-76"
+        "sha256": "9680293ce45f99aaa2345a19916f24d203ea3a0c962be4b46b31ee1b873a8c6c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipsparse-3.1.2.60304-76.el8.x86_64.rpm",
+        "version": "3.1.2.60304"
       },
       {
-        "name": "hipsparse-dev",
-        "sha256": "b937f418409457bd17b064445e3f46fdf18d0222e9d40eec5782468c53fe8696",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipsparse-dev/hipsparse-dev_3.1.2.60304-76~20.04_amd64.deb",
-        "version": "3.1.2.60304-76"
+        "name": "hipsparse-devel",
+        "sha256": "df957e49410dde8c94b4d7e9ea8e17f150390b886812b31d4b8d80a242c3762f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipsparse-devel-3.1.2.60304-76.el8.x86_64.rpm",
+        "version": "3.1.2.60304"
       },
       {
-        "name": "hipsparse-dev-rpath",
-        "sha256": "0f85966a7be282673c0cc8261a4d2b3cfefed511ad56d9b4d3f7d5cc6e7eb782",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipsparse-dev-rpath6.3.4/hipsparse-dev-rpath6.3.4_3.1.2.60304-76~20.04_amd64.deb",
-        "version": "3.1.2.60304-76"
+        "name": "hipsparse-devel-rpath",
+        "sha256": "a8a9ef74047dcd3a8dd7cee883f1236e49c5aa8c5a2cc843c69e4e29a6d9ab4a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipsparse-devel-rpath6.3.4-3.1.2.60304-76.el8.x86_64.rpm",
+        "version": "3.1.2.60304"
       },
       {
         "name": "hipsparse-rpath",
-        "sha256": "f5bfc49efcb87afd2ae8479d2e03f85b84f5d10f6178ff79bc67e9e6a15c7c1c",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipsparse-rpath6.3.4/hipsparse-rpath6.3.4_3.1.2.60304-76~20.04_amd64.deb",
-        "version": "3.1.2.60304-76"
+        "sha256": "87ad514a6466f887d70bb272bc9680375a984e96f86c4b807b21f541cc6a8fe7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipsparse-rpath6.3.4-3.1.2.60304-76.el8.x86_64.rpm",
+        "version": "3.1.2.60304"
       }
     ],
-    "version": "3.1.2.60304-76"
+    "version": "3.1.2.60304"
+  },
+  "hipsparse-asan": {
+    "deps": [
+      "rocm-core-asan",
+      "rocsparse"
+    ],
+    "components": [
+      {
+        "name": "hipsparse-asan",
+        "sha256": "4304415abdedb74ed7c9aaa2fd1396d387b296fa36bd0b98de39e194076c9877",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipsparse-asan-3.1.2.60304-76.el8.x86_64.rpm",
+        "version": "3.1.2.60304"
+      },
+      {
+        "name": "hipsparse-asan-rpath",
+        "sha256": "4988abed9aa01298f765cd0c1dc1fcecae20abf11efbefdc3c6b77836664b024",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipsparse-asan-rpath6.3.4-3.1.2.60304-76.el8.x86_64.rpm",
+        "version": "3.1.2.60304"
+      }
+    ],
+    "version": "3.1.2.60304"
   },
   "hipsparselt": {
     "deps": [
@@ -543,30 +733,51 @@
     "components": [
       {
         "name": "hipsparselt",
-        "sha256": "e6a413cc028822d280c37a9a74e78fbe0e471ded7f9f07b59d252ed80cff84b3",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipsparselt/hipsparselt_0.2.2.60304-76~20.04_amd64.deb",
-        "version": "0.2.2.60304-76"
+        "sha256": "bd86aab2fe01d56c241a05c9bdd188ca9652866edaa145b80d340f37bfa06cf0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipsparselt-0.2.2.60304-76.el8.x86_64.rpm",
+        "version": "0.2.2.60304"
       },
       {
-        "name": "hipsparselt-dev",
-        "sha256": "1f991394133dd328e54f17cab95feb35babb573affb04ef4f2f444a7f476030f",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipsparselt-dev/hipsparselt-dev_0.2.2.60304-76~20.04_amd64.deb",
-        "version": "0.2.2.60304-76"
+        "name": "hipsparselt-devel",
+        "sha256": "3f9b747e8b9d316e906a30b4cf43d1106a6796092f71954ad514bca38dbf8924",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipsparselt-devel-0.2.2.60304-76.el8.x86_64.rpm",
+        "version": "0.2.2.60304"
       },
       {
-        "name": "hipsparselt-dev-rpath",
-        "sha256": "f0130e9271a8d0f35a4a5c7119f6898ed8f2ffb4ad2abc3ad1a10e7242ebd25c",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipsparselt-dev-rpath6.3.4/hipsparselt-dev-rpath6.3.4_0.2.2.60304-76~20.04_amd64.deb",
-        "version": "0.2.2.60304-76"
+        "name": "hipsparselt-devel-rpath",
+        "sha256": "66f94b879474fbbdde1f28cfafc781c8bfdb2bac4c27a41a6384c12736ad7b88",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipsparselt-devel-rpath6.3.4-0.2.2.60304-76.el8.x86_64.rpm",
+        "version": "0.2.2.60304"
       },
       {
         "name": "hipsparselt-rpath",
-        "sha256": "1c512263035fbb88ca053f8a4f9134cacf066d162adecc209f18354ccde4f87e",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hipsparselt-rpath6.3.4/hipsparselt-rpath6.3.4_0.2.2.60304-76~20.04_amd64.deb",
-        "version": "0.2.2.60304-76"
+        "sha256": "ed5741f613bec037269601e591d683ebc8f3ff9a9abbee1ca1bbacc2e2b34c23",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipsparselt-rpath6.3.4-0.2.2.60304-76.el8.x86_64.rpm",
+        "version": "0.2.2.60304"
       }
     ],
-    "version": "0.2.2.60304-76"
+    "version": "0.2.2.60304"
+  },
+  "hipsparselt-asan": {
+    "deps": [
+      "hipsparse",
+      "rocm-core-asan"
+    ],
+    "components": [
+      {
+        "name": "hipsparselt-asan",
+        "sha256": "61dde142aae1bb929dd4e27243f9973d46474b075939ff0ae62fe48ec850b32f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipsparselt-asan-0.2.2.60304-76.el8.x86_64.rpm",
+        "version": "0.2.2.60304"
+      },
+      {
+        "name": "hipsparselt-asan-rpath",
+        "sha256": "37ed2c652ca022fc5845c6500f8f6818c7433743ef73c16c0e9f0275f64a2751",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hipsparselt-asan-rpath6.3.4-0.2.2.60304-76.el8.x86_64.rpm",
+        "version": "0.2.2.60304"
+      }
+    ],
+    "version": "0.2.2.60304"
   },
   "hiptensor": {
     "deps": [
@@ -575,30 +786,50 @@
     "components": [
       {
         "name": "hiptensor",
-        "sha256": "117ae8588715db6e88a3996ef6291b8928acfa4c78a92deec3027a387d2a2991",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hiptensor/hiptensor_1.4.0.60304-76~20.04_amd64.deb",
-        "version": "1.4.0.60304-76"
+        "sha256": "6b80c65b4737ad95a4df0dbcce7ccaafb0172b284ea15504741ac68d7b203abd",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hiptensor-1.4.0.60304-76.el8.x86_64.rpm",
+        "version": "1.4.0.60304"
       },
       {
-        "name": "hiptensor-dev",
-        "sha256": "2a7b087bbd72f9222e2402b20c87978265c4c58fb579d2e844396e712fa7eb2b",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hiptensor-dev/hiptensor-dev_1.4.0.60304-76~20.04_amd64.deb",
-        "version": "1.4.0.60304-76"
+        "name": "hiptensor-devel",
+        "sha256": "91e217597d330292f3e13da74868bb8fa1c934e222ca2d45deb029024a7d4b94",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hiptensor-devel-1.4.0.60304-76.el8.x86_64.rpm",
+        "version": "1.4.0.60304"
       },
       {
-        "name": "hiptensor-dev-rpath",
-        "sha256": "924721d506c22adb8bc2c8f36e28e961934440715c4641e9b1bd7d9713fdea5d",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hiptensor-dev-rpath6.3.4/hiptensor-dev-rpath6.3.4_1.4.0.60304-76~20.04_amd64.deb",
-        "version": "1.4.0.60304-76"
+        "name": "hiptensor-devel-rpath",
+        "sha256": "c942f8ce6a451a453dd9c31245b5bd8241e79c2fe95073615af1703725e0593f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hiptensor-devel-rpath6.3.4-1.4.0.60304-76.el8.x86_64.rpm",
+        "version": "1.4.0.60304"
       },
       {
         "name": "hiptensor-rpath",
-        "sha256": "32cd357589885869847ec1084b8eaee5d4303453d674c0bf0d7d12c421ed7c4a",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hiptensor-rpath6.3.4/hiptensor-rpath6.3.4_1.4.0.60304-76~20.04_amd64.deb",
-        "version": "1.4.0.60304-76"
+        "sha256": "4434cc0ae3fbf9ea3acbcfd2e68dffb88897deb84d4cf6e38f6c99dd26f0bcb8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hiptensor-rpath6.3.4-1.4.0.60304-76.el8.x86_64.rpm",
+        "version": "1.4.0.60304"
       }
     ],
-    "version": "1.4.0.60304-76"
+    "version": "1.4.0.60304"
+  },
+  "hiptensor-asan": {
+    "deps": [
+      "rocm-core-asan"
+    ],
+    "components": [
+      {
+        "name": "hiptensor-asan",
+        "sha256": "cb2de947911ef7ab0c01cfc80ad86c838a3d546d3bb615111564e62e32f8bc70",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hiptensor-asan-1.4.0.60304-76.el8.x86_64.rpm",
+        "version": "1.4.0.60304"
+      },
+      {
+        "name": "hiptensor-asan-rpath",
+        "sha256": "6c2628b15ba1f6d43c6e6fbe03a4dfcdcc4ed16dd0dd8ddeb05e5be74838b242",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hiptensor-asan-rpath6.3.4-1.4.0.60304-76.el8.x86_64.rpm",
+        "version": "1.4.0.60304"
+      }
+    ],
+    "version": "1.4.0.60304"
   },
   "hsa-amd-aqlprofile": {
     "deps": [
@@ -607,18 +838,38 @@
     "components": [
       {
         "name": "hsa-amd-aqlprofile",
-        "sha256": "61e96dc2341860f787bacb1e9201437a82149057567f64bc14047c36698759cf",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hsa-amd-aqlprofile/hsa-amd-aqlprofile_1.0.0.60304-76~20.04_amd64.deb",
-        "version": "1.0.0.60304-76"
+        "sha256": "0a5c0d4919ed0f520051e1789a79f04505854fbc27ede6733b75cd40dbda705d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hsa-amd-aqlprofile-1.0.0.60304-76.el8.x86_64.rpm",
+        "version": "1.0.0.60304"
       },
       {
         "name": "hsa-amd-aqlprofile-rpath",
-        "sha256": "d4992e6b5718ab78cc3b574ad18e827b263b39ebce3fe3bf20a621f60cefedc4",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hsa-amd-aqlprofile-rpath6.3.4/hsa-amd-aqlprofile-rpath6.3.4_1.0.0.60304-76~20.04_amd64.deb",
-        "version": "1.0.0.60304-76"
+        "sha256": "7110281952357efa83d6422f3dc18df5591fb510c1190af0836051891cb6ecd3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hsa-amd-aqlprofile-rpath6.3.4-1.0.0.60304-76.el8.x86_64.rpm",
+        "version": "1.0.0.60304"
       }
     ],
-    "version": "1.0.0.60304-76"
+    "version": "1.0.0.60304"
+  },
+  "hsa-amd-aqlprofile-asan": {
+    "deps": [
+      "rocm-core-asan"
+    ],
+    "components": [
+      {
+        "name": "hsa-amd-aqlprofile-asan",
+        "sha256": "2a876beb578d4f85fe9644f5fea1b7252ebd670f610bdd6453654f6bffec3bd5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hsa-amd-aqlprofile-asan-1.0.0.60304-76.el8.x86_64.rpm",
+        "version": "1.0.0.60304"
+      },
+      {
+        "name": "hsa-amd-aqlprofile-asan-rpath",
+        "sha256": "e7bdc548c79fc463778d0ade10ef55af31277f33e15b2b077ee3defb79ac82f0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hsa-amd-aqlprofile-asan-rpath6.3.4-1.0.0.60304-76.el8.x86_64.rpm",
+        "version": "1.0.0.60304"
+      }
+    ],
+    "version": "1.0.0.60304"
   },
   "hsa-rocr": {
     "deps": [
@@ -628,35 +879,55 @@
     "components": [
       {
         "name": "hsa-rocr",
-        "sha256": "d7df230caa8bb4d9927fc6dfa6d3876480aecadc332bb4a7c639ad767716b506",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hsa-rocr/hsa-rocr_1.14.0.60304-76~20.04_amd64.deb",
-        "version": "1.14.0.60304-76"
+        "sha256": "5dc25eeeb44d30377964bfb25520ad33c3dfd37156c5ccefc3453b6f67fffb61",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hsa-rocr-1.14.0.60304-76.el8.x86_64.rpm",
+        "version": "1.14.0.60304"
       },
       {
-        "name": "hsa-rocr-dev",
-        "sha256": "11314b23b5b4f83ef58118663aaef68584ecfb1bcc21782c621f9abc168477b4",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hsa-rocr-dev/hsa-rocr-dev_1.14.0.60304-76~20.04_amd64.deb",
-        "version": "1.14.0.60304-76"
+        "name": "hsa-rocr-devel",
+        "sha256": "880096c088b2351c9be3457655d174ae5d7eb277dfb89e618734b0f2e9c8a6f5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hsa-rocr-devel-1.14.0.60304-76.el8.x86_64.rpm",
+        "version": "1.14.0.60304"
       },
       {
-        "name": "hsa-rocr-dev-rpath",
-        "sha256": "4cbebca75b073439b0cc9823ca057e3c7b72b1692e29f4e767fef7d454d49a1a",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hsa-rocr-dev-rpath6.3.4/hsa-rocr-dev-rpath6.3.4_1.14.0.60304-76~20.04_amd64.deb",
-        "version": "1.14.0.60304-76"
+        "name": "hsa-rocr-devel-rpath",
+        "sha256": "bd9ee8c929940c3a20da8f36e046db5a5cc414e5a36658c097ecf08c51bc10b3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hsa-rocr-devel-rpath6.3.4-1.14.0.60304-76.el8.x86_64.rpm",
+        "version": "1.14.0.60304"
       },
       {
         "name": "hsa-rocr-rpath",
-        "sha256": "6ff4b6426e9c7d7e1a87d6f203b1deecd421dfde68c0351545c23caf7a737a70",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/h/hsa-rocr-rpath6.3.4/hsa-rocr-rpath6.3.4_1.14.0.60304-76~20.04_amd64.deb",
-        "version": "1.14.0.60304-76"
+        "sha256": "acd82f7eacffcdbf341e5f4996624000192cf7b0bf740cfa232dcaf24af78729",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hsa-rocr-rpath6.3.4-1.14.0.60304-76.el8.x86_64.rpm",
+        "version": "1.14.0.60304"
       }
     ],
-    "version": "1.14.0.60304-76"
+    "version": "1.14.0.60304"
+  },
+  "hsa-rocr-asan": {
+    "deps": [
+      "rocm-core-asan"
+    ],
+    "components": [
+      {
+        "name": "hsa-rocr-asan",
+        "sha256": "72c53bdbb65c8581407539352267e4df5dd6752da5bed833f02c6ab3307f75ae",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hsa-rocr-asan-1.14.0.60304-76.el8.x86_64.rpm",
+        "version": "1.14.0.60304"
+      },
+      {
+        "name": "hsa-rocr-asan-rpath",
+        "sha256": "3569068b58470544463f34d48d645c750fe82e2cb86117cc169450bc38a26df1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/hsa-rocr-asan-rpath6.3.4-1.14.0.60304-76.el8.x86_64.rpm",
+        "version": "1.14.0.60304"
+      }
+    ],
+    "version": "1.14.0.60304"
   },
   "migraphx": {
     "deps": [
       "half",
-      "hip-dev",
+      "hip-devel",
       "hip-runtime-amd",
       "hipblaslt",
       "miopen-hip",
@@ -666,30 +937,56 @@
     "components": [
       {
         "name": "migraphx",
-        "sha256": "0f9f90fb8f17ba7ef397889ccadd98f57b05a90802f335815bfc3d0c3aae330a",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/migraphx/migraphx_2.11.0.60304-76~20.04_amd64.deb",
-        "version": "2.11.0.60304-76"
+        "sha256": "46deea5455eb5dc56b2273fbc9935d476db28d306962ed07714f5e70bba5265a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/migraphx-2.11.0.60304-76.el8.x86_64.rpm",
+        "version": "2.11.0.60304"
       },
       {
-        "name": "migraphx-dev",
-        "sha256": "10c9149fb9d8a22c2b0c10fabd35d8dddc1d77e9061a1574f104a899c73859e1",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/migraphx-dev/migraphx-dev_2.11.0.60304-76~20.04_amd64.deb",
-        "version": "2.11.0.60304-76"
+        "name": "migraphx-devel",
+        "sha256": "2c89c35197fcbf09e0729c72cfa6a956af2a3a71d2ff8d0c73825712f84db9db",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/migraphx-devel-2.11.0.60304-76.el8.x86_64.rpm",
+        "version": "2.11.0.60304"
       },
       {
-        "name": "migraphx-dev-rpath",
-        "sha256": "4d4c4a10cb728ddb72be857dfae0b5cac880de72f198b8e08215413a3f093664",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/migraphx-dev-rpath6.3.4/migraphx-dev-rpath6.3.4_2.11.0.60304-76~20.04_amd64.deb",
-        "version": "2.11.0.60304-76"
+        "name": "migraphx-devel-rpath",
+        "sha256": "6dfc50fe992bfdbab6a2b844ff7945ffe112e093b6dfb5b003e61aed3bed6ad1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/migraphx-devel-rpath6.3.4-2.11.0.60304-76.el8.x86_64.rpm",
+        "version": "2.11.0.60304"
       },
       {
         "name": "migraphx-rpath",
-        "sha256": "980c64657ba755f1815efcd23459d4de1cff831376563341ca1bca217bf3d7c9",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/migraphx-rpath6.3.4/migraphx-rpath6.3.4_2.11.0.60304-76~20.04_amd64.deb",
-        "version": "2.11.0.60304-76"
+        "sha256": "7186efd93c0f0f28b675652a677556fb9237aea76daac988f8968152362f53dd",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/migraphx-rpath6.3.4-2.11.0.60304-76.el8.x86_64.rpm",
+        "version": "2.11.0.60304"
       }
     ],
-    "version": "2.11.0.60304-76"
+    "version": "2.11.0.60304"
+  },
+  "migraphx-asan": {
+    "deps": [
+      "half",
+      "hip-devel",
+      "hip-runtime-amd",
+      "hipblaslt",
+      "miopen-hip",
+      "rocblas",
+      "rocm-core-asan"
+    ],
+    "components": [
+      {
+        "name": "migraphx-asan",
+        "sha256": "cf5e42f83605041296b95ace4e7fab50da6bbec15628e691b7a977666ae8860c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/migraphx-asan-2.11.0.60304-76.el8.x86_64.rpm",
+        "version": "2.11.0.60304"
+      },
+      {
+        "name": "migraphx-asan-rpath",
+        "sha256": "21267b8b2edc5cf11f551560a59aa19e2f879f80865c20a43781793a6eb7fedf",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/migraphx-asan-rpath6.3.4-2.11.0.60304-76.el8.x86_64.rpm",
+        "version": "2.11.0.60304"
+      }
+    ],
+    "version": "2.11.0.60304"
   },
   "miopen-hip": {
     "deps": [
@@ -704,30 +1001,57 @@
     "components": [
       {
         "name": "miopen-hip",
-        "sha256": "474e5c24be4decf5ebf453b55accfb40d932afb853eaa040314747e4bd1e6b40",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/miopen-hip/miopen-hip_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "sha256": "38bf4a9e4cb9bc4e9b86cfad7ada904796c3ca7a128f76b7fd81446e1a44f7ee",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/miopen-hip-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       },
       {
-        "name": "miopen-hip-dev",
-        "sha256": "8428f301d8ca5f178739ba6de1914f8db37f5ec98061b5160e39a71f4adfd5b1",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/miopen-hip-dev/miopen-hip-dev_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "name": "miopen-hip-devel",
+        "sha256": "2eb5974e0505ede4a3d18a8daf686f2e6cda496ef3075840af7f596a9c42f08c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/miopen-hip-devel-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       },
       {
-        "name": "miopen-hip-dev-rpath",
-        "sha256": "5eb732bc2d27110af078c79972785fa95e35816e0b4d300873165a9dbf0349fb",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/miopen-hip-dev-rpath6.3.4/miopen-hip-dev-rpath6.3.4_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "name": "miopen-hip-devel-rpath",
+        "sha256": "cfb6345c4b94dc96a5c8e62633d7d45db5040dd4bfab29e184688354b00feb46",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/miopen-hip-devel-rpath6.3.4-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       },
       {
         "name": "miopen-hip-rpath",
-        "sha256": "6c98c0ce1419c87d7d887767cf2b72ac0e5740f5efe208190e41484cf06c5057",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/miopen-hip-rpath6.3.4/miopen-hip-rpath6.3.4_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "sha256": "f15b007f8eff17c4d36139cce3a4e8973555c448f057cf8a37e43de0494d8518",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/miopen-hip-rpath6.3.4-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       }
     ],
-    "version": "3.3.0.60304-76"
+    "version": "3.3.0.60304"
+  },
+  "miopen-hip-asan": {
+    "deps": [
+      "comgr",
+      "hip-runtime-amd-asan",
+      "hipblaslt",
+      "rocblas",
+      "rocm-core",
+      "rocm-core-asan",
+      "rocrand",
+      "roctracer"
+    ],
+    "components": [
+      {
+        "name": "miopen-hip-asan",
+        "sha256": "d1c67fc1f51128efdd54ad162b0a9b676e1565bcbb5b24247fe52964b64c27d4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/miopen-hip-asan-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
+      },
+      {
+        "name": "miopen-hip-asan-rpath",
+        "sha256": "c40f2f29ec2e0032cb5c4e1340f74c02dfee0a9ae0a1c56e23037bea8f4b87e3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/miopen-hip-asan-rpath6.3.4-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
+      }
+    ],
+    "version": "3.3.0.60304"
   },
   "miopen-hip-gfx1030kdb": {
     "deps": [
@@ -742,18 +1066,18 @@
     "components": [
       {
         "name": "miopen-hip-gfx1030kdb",
-        "sha256": "a9bc8d73c961aa6636e7bf8969697c34a7dc77e4c6c72c3c3680ee9fa702accb",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/miopen-hip-gfx1030kdb/miopen-hip-gfx1030kdb_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "sha256": "a5305072f310c5e2f6952f0d7c07f5bad4e6d37be1ef087d10ede4aa1dbf82b2",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/miopen-hip-gfx1030kdb-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       },
       {
         "name": "miopen-hip-gfx1030kdb-rpath",
-        "sha256": "c3784087d06d707370a40fde05eba0c0385bb12d4147044b29e083acb498eb0a",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/miopen-hip-gfx1030kdb-rpath6.3.4/miopen-hip-gfx1030kdb-rpath6.3.4_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "sha256": "728d1168c807cdd91dda1182b95f830d367d49e651f6ab0ef496614f0888be9c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/miopen-hip-gfx1030kdb-rpath6.3.4-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       }
     ],
-    "version": "3.3.0.60304-76"
+    "version": "3.3.0.60304"
   },
   "miopen-hip-gfx900kdb": {
     "deps": [
@@ -768,18 +1092,18 @@
     "components": [
       {
         "name": "miopen-hip-gfx900kdb",
-        "sha256": "2e49a09a5a0a2669ddbc8cca8ef4caf73b45de7545f516cf3979e232592df2d8",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/miopen-hip-gfx900kdb/miopen-hip-gfx900kdb_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "sha256": "29520af323c00d16abac75b36d98691f5854428140e27919020fbe09c8b88a74",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/miopen-hip-gfx900kdb-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       },
       {
         "name": "miopen-hip-gfx900kdb-rpath",
-        "sha256": "a59a0e1533659f0a5addce338259cddb1b8ab2d1ef4f2c995230d522db5a48eb",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/miopen-hip-gfx900kdb-rpath6.3.4/miopen-hip-gfx900kdb-rpath6.3.4_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "sha256": "e24ba483f1e963c2917b8ab5817f3a2dfc8bb7a1c50ebe0511d1029f8320d718",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/miopen-hip-gfx900kdb-rpath6.3.4-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       }
     ],
-    "version": "3.3.0.60304-76"
+    "version": "3.3.0.60304"
   },
   "miopen-hip-gfx906kdb": {
     "deps": [
@@ -794,18 +1118,18 @@
     "components": [
       {
         "name": "miopen-hip-gfx906kdb",
-        "sha256": "aa57dc15afed1bb1290f0f1a6fceb7f284958a7487512c47306f0e52c86a8b28",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/miopen-hip-gfx906kdb/miopen-hip-gfx906kdb_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "sha256": "e39747e3db35a579625e61596ec4242b3bd7266b6cca1c80d607179fb7d3435b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/miopen-hip-gfx906kdb-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       },
       {
         "name": "miopen-hip-gfx906kdb-rpath",
-        "sha256": "70de110622a555b7e4dd5d2b59120af280732f361fa017cec9f877e118d7ac7e",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/miopen-hip-gfx906kdb-rpath6.3.4/miopen-hip-gfx906kdb-rpath6.3.4_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "sha256": "abab3c2b99f346bc2c8b4b51e673e1db001373d1dc49683b56471d9c0be65727",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/miopen-hip-gfx906kdb-rpath6.3.4-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       }
     ],
-    "version": "3.3.0.60304-76"
+    "version": "3.3.0.60304"
   },
   "miopen-hip-gfx908kdb": {
     "deps": [
@@ -820,18 +1144,18 @@
     "components": [
       {
         "name": "miopen-hip-gfx908kdb",
-        "sha256": "b3774d65de490a9051ea080ddced93cfceb4a303f905137e38f7debea2a28354",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/miopen-hip-gfx908kdb/miopen-hip-gfx908kdb_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "sha256": "7f26586dd40c9da4a3c4b3dfd2f3b87d92ae3bd84cf6c16d648bfefe894c7a56",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/miopen-hip-gfx908kdb-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       },
       {
         "name": "miopen-hip-gfx908kdb-rpath",
-        "sha256": "83aac4e1042fc90528979ec89660f124d5ae2502fe6e955e9d5c77a6e0e9d4b7",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/miopen-hip-gfx908kdb-rpath6.3.4/miopen-hip-gfx908kdb-rpath6.3.4_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "sha256": "cad1cff252dc299a14deb7a8cd63d63aca06446d1462f09b14bb46ed8b91cbe3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/miopen-hip-gfx908kdb-rpath6.3.4-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       }
     ],
-    "version": "3.3.0.60304-76"
+    "version": "3.3.0.60304"
   },
   "miopen-hip-gfx90akdb": {
     "deps": [
@@ -846,18 +1170,18 @@
     "components": [
       {
         "name": "miopen-hip-gfx90akdb",
-        "sha256": "a051c5f05dc7aa56638cdf48c6a29e3269d9cc12cf2ed4d266041b089e239fd7",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/miopen-hip-gfx90akdb/miopen-hip-gfx90akdb_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "sha256": "fe24b3358dc9bcdd1491f2d8c1fc136bfab19993e4e6ccc7b06c2f7c39d43df4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/miopen-hip-gfx90akdb-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       },
       {
         "name": "miopen-hip-gfx90akdb-rpath",
-        "sha256": "dabf272db16a586f1d23b4bf7181e706b68ba659a0c0697f8e60a9468b936504",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/miopen-hip-gfx90akdb-rpath6.3.4/miopen-hip-gfx90akdb-rpath6.3.4_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "sha256": "5a5c5ef97ce3508c475945380d2d4a06a60726e80608c1d1b8a6ec48c48783be",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/miopen-hip-gfx90akdb-rpath6.3.4-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       }
     ],
-    "version": "3.3.0.60304-76"
+    "version": "3.3.0.60304"
   },
   "miopen-hip-gfx942kdb": {
     "deps": [
@@ -872,18 +1196,18 @@
     "components": [
       {
         "name": "miopen-hip-gfx942kdb",
-        "sha256": "53a99af6fa0696a5a527fdf092f27f8c7175740d70f27ab0a6426cb365e0aa2d",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/miopen-hip-gfx942kdb/miopen-hip-gfx942kdb_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "sha256": "41f04d80650ac5fa2b9800033908caf8de255d7717e2da7bf1197427df097648",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/miopen-hip-gfx942kdb-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       },
       {
         "name": "miopen-hip-gfx942kdb-rpath",
-        "sha256": "0a75a7c08e8992ae8f5257297472be82a41297796f4d153820f094044cad9ad3",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/miopen-hip-gfx942kdb-rpath6.3.4/miopen-hip-gfx942kdb-rpath6.3.4_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "sha256": "d365ac0f74abf5d0019b51c117dd5d4883d63e55677ce02629a576b4843f8ed2",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/miopen-hip-gfx942kdb-rpath6.3.4-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       }
     ],
-    "version": "3.3.0.60304-76"
+    "version": "3.3.0.60304"
   },
   "mivisionx": {
     "deps": [
@@ -898,30 +1222,55 @@
     "components": [
       {
         "name": "mivisionx",
-        "sha256": "1c0a90d7c1fb72ac7f8ff4df5723bbd9e354bd8e4ded4412e50bdc5c43903d46",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/mivisionx/mivisionx_3.1.0.60304-76~20.04_amd64.deb",
-        "version": "3.1.0.60304-76"
+        "sha256": "e97116383160b64bff05e3a2b16b41214f3d0de3f64a2bdca637f74d691606a1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/mivisionx-3.1.0.60304-76.x86_64.rpm",
+        "version": "3.1.0.60304"
       },
       {
-        "name": "mivisionx-dev",
-        "sha256": "012c0297ba0462a4e07a92e98049220a0d3985fb47603493441341faacff0119",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/mivisionx-dev/mivisionx-dev_3.1.0.60304-76~20.04_amd64.deb",
-        "version": "3.1.0.60304-76"
+        "name": "mivisionx-devel",
+        "sha256": "7843467bd58e673801bf06b722ddec625119c8165c8d4405614b6412480b497e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/mivisionx-devel-3.1.0.60304-76.x86_64.rpm",
+        "version": "3.1.0.60304"
       },
       {
-        "name": "mivisionx-dev-rpath",
-        "sha256": "a60ad6ad349cfdba2343a4cc06536d3be6885a9fbd57bc7c62930da58d68e76d",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/mivisionx-dev-rpath6.3.4/mivisionx-dev-rpath6.3.4_3.1.0.60304-76~20.04_amd64.deb",
-        "version": "3.1.0.60304-76"
+        "name": "mivisionx-devel-rpath",
+        "sha256": "2c2bd4c38e4bb6e9a9a5d2d7168033985059c88ab1c2017f796e11db17289648",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/mivisionx-devel-rpath6.3.4-3.1.0.60304-76.x86_64.rpm",
+        "version": "3.1.0.60304"
       },
       {
         "name": "mivisionx-rpath",
-        "sha256": "ec69778c5e5bb62c0e29e6362f8e2bf3a8763b3c6e85d65ac6ffb19de1572c71",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/mivisionx-rpath6.3.4/mivisionx-rpath6.3.4_3.1.0.60304-76~20.04_amd64.deb",
-        "version": "3.1.0.60304-76"
+        "sha256": "82ababdb50b5627b3f814b73dc19a62ec7b0d8ace36ba78bb37f173e35e47dc8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/mivisionx-rpath6.3.4-3.1.0.60304-76.x86_64.rpm",
+        "version": "3.1.0.60304"
       }
     ],
-    "version": "3.1.0.60304-76"
+    "version": "3.1.0.60304"
+  },
+  "mivisionx-asan": {
+    "deps": [
+      "migraphx",
+      "miopen-hip",
+      "rocblas",
+      "rocm-core-asan",
+      "rocm-hip-runtime",
+      "rpp"
+    ],
+    "components": [
+      {
+        "name": "mivisionx-asan",
+        "sha256": "07a2bd94d362c0f5b9e6452df04b215c53e1c0d5aefea39d5c1a815e7cba03e5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/mivisionx-asan-3.1.0.60304-76.x86_64.rpm",
+        "version": "3.1.0.60304"
+      },
+      {
+        "name": "mivisionx-asan-rpath",
+        "sha256": "e28ea06ccad8a38c9f5beb423dd4233e255a86453124a5d170cc4a4f5666983d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/mivisionx-asan-rpath6.3.4-3.1.0.60304-76.x86_64.rpm",
+        "version": "3.1.0.60304"
+      }
+    ],
+    "version": "3.1.0.60304"
   },
   "mivisionx-test": {
     "deps": [
@@ -931,20 +1280,41 @@
     "components": [
       {
         "name": "mivisionx-test",
-        "sha256": "eb63563ff8be1d133cc76a8f9cd7f9c2b340bdac00eee4f9a37fa9fdb7e6516d",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/mivisionx-test/mivisionx-test_3.1.0.60304-76~20.04_amd64.deb",
-        "version": "3.1.0.60304-76"
+        "sha256": "c26ad4cf863bb7577c8acf734468e1d05fd68af1b8fd42ab8d1e0aeb573b2194",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/mivisionx-test-3.1.0.60304-76.x86_64.rpm",
+        "version": "3.1.0.60304"
       },
       {
         "name": "mivisionx-test-rpath",
-        "sha256": "0a6c5ed256244e229e733786eab199ceca586912092985c92ceddff11bec4d4d",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/m/mivisionx-test-rpath6.3.4/mivisionx-test-rpath6.3.4_3.1.0.60304-76~20.04_amd64.deb",
-        "version": "3.1.0.60304-76"
+        "sha256": "b6d5ef3cf40ac101ad5a8411fa7aa7dc994f6ea6e3996cc96ea5883305226972",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/mivisionx-test-rpath6.3.4-3.1.0.60304-76.x86_64.rpm",
+        "version": "3.1.0.60304"
       }
     ],
-    "version": "3.1.0.60304-76"
+    "version": "3.1.0.60304"
   },
-  "openmp-extras-dev": {
+  "openmp-extras-asan": {
+    "deps": [
+      "hsa-rocr-asan",
+      "rocm-core-asan"
+    ],
+    "components": [
+      {
+        "name": "openmp-extras-asan",
+        "sha256": "11d592f2cb29d78491dd88e875ac676cbc4e36df15ab9f76c9f802c7046d31c6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/openmp-extras-asan-18.63.0.60304-76.el8.x86_64.rpm",
+        "version": "18.63.0.60304"
+      },
+      {
+        "name": "openmp-extras-asan-rpath",
+        "sha256": "fca77a56dfebf6af6da9d570455fd1eab0fff881506a524759e832a7c1def331",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/openmp-extras-asan-rpath6.3.4-18.63.0.60304-76.el8.x86_64.rpm",
+        "version": "18.63.0.60304"
+      }
+    ],
+    "version": "18.63.0.60304"
+  },
+  "openmp-extras-devel": {
     "deps": [
       "hsa-rocr",
       "openmp-extras-runtime",
@@ -954,19 +1324,19 @@
     ],
     "components": [
       {
-        "name": "openmp-extras-dev",
-        "sha256": "ccf31d35e90a48ac724b6e3f0d5b6f88d36c9c452cbc73eeb15a99871f07b06f",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/o/openmp-extras-dev/openmp-extras-dev_18.63.0.60304-76~20.04_amd64.deb",
-        "version": "18.63.0.60304-76"
+        "name": "openmp-extras-devel",
+        "sha256": "3d3b2095064ec126174d40df49f8d60f05b11f6f5ab91a10028c8f63863fe321",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/openmp-extras-devel-18.63.0.60304-76.el8.x86_64.rpm",
+        "version": "18.63.0.60304"
       },
       {
-        "name": "openmp-extras-dev-rpath",
-        "sha256": "576e876dbcbf8140c87126724214ca2df78bbed2a561e6617d715a87ce2c465c",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/o/openmp-extras-dev-rpath6.3.4/openmp-extras-dev-rpath6.3.4_18.63.0.60304-76~20.04_amd64.deb",
-        "version": "18.63.0.60304-76"
+        "name": "openmp-extras-devel-rpath",
+        "sha256": "fd69f276033c9dcc51a2662ea7d9d8f226e80469a1c65ee6a161431c5580bdef",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/openmp-extras-devel-rpath6.3.4-18.63.0.60304-76.el8.x86_64.rpm",
+        "version": "18.63.0.60304"
       }
     ],
-    "version": "18.63.0.60304-76"
+    "version": "18.63.0.60304"
   },
   "openmp-extras-runtime": {
     "deps": [
@@ -976,53 +1346,74 @@
     "components": [
       {
         "name": "openmp-extras-runtime",
-        "sha256": "8127791c34f0d4dfcce40de1e79875d6b4cbf02f3fd1519990f68cd7865ba219",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/o/openmp-extras-runtime/openmp-extras-runtime_18.63.0.60304-76~20.04_amd64.deb",
-        "version": "18.63.0.60304-76"
+        "sha256": "24bf666083621094b5c185c23f77c37a6284e11440c6657a18c31337ac689a98",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/openmp-extras-runtime-18.63.0.60304-76.el8.x86_64.rpm",
+        "version": "18.63.0.60304"
       },
       {
         "name": "openmp-extras-runtime-rpath",
-        "sha256": "ebfbb888c7cc184cdfeba94dabf5eb0355ccbd34172d598f06743ce05938cb90",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/o/openmp-extras-runtime-rpath6.3.4/openmp-extras-runtime-rpath6.3.4_18.63.0.60304-76~20.04_amd64.deb",
-        "version": "18.63.0.60304-76"
+        "sha256": "225c29607484bc4f012c980150ee0575041bc0b13be9a42ce92901ae689a08b4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/openmp-extras-runtime-rpath6.3.4-18.63.0.60304-76.el8.x86_64.rpm",
+        "version": "18.63.0.60304"
       }
     ],
-    "version": "18.63.0.60304-76"
+    "version": "18.63.0.60304"
   },
   "rccl": {
     "deps": [
       "hip-runtime-amd",
       "rocm-core",
-      "rocm-smi-lib",
-      "rocprofiler-register"
+      "rocm-smi-lib"
     ],
     "components": [
       {
         "name": "rccl",
-        "sha256": "b457354e4de7217d7d8a0bd6048f7b51ea8a9aad8b4ae35859a2d8ce55aabb01",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rccl/rccl_2.21.5.60304-76~20.04_amd64.deb",
-        "version": "2.21.5.60304-76"
+        "sha256": "b5a191d65fe48b862e8300f1b7286e573da4b886ac113a2b203b4613c5ef82f2",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rccl-2.21.5.60304-76.el8.x86_64.rpm",
+        "version": "2.21.5.60304"
       },
       {
-        "name": "rccl-dev",
-        "sha256": "7ba9f412cecad10728d8f6e9a09f444e51e4316926e0361714ee8cb60f33a26c",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rccl-dev/rccl-dev_2.21.5.60304-76~20.04_amd64.deb",
-        "version": "2.21.5.60304-76"
+        "name": "rccl-devel",
+        "sha256": "eeba8674c7abcf4ba1407dda49fbef1f8d8ba7f127543e0faac6b38bdf7c1927",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rccl-devel-2.21.5.60304-76.el8.x86_64.rpm",
+        "version": "2.21.5.60304"
       },
       {
-        "name": "rccl-dev-rpath",
-        "sha256": "2e9ab0fc01f891c2de7d7c8a34f6c7a37a2e2b71bf23cf56bac4f82781073d72",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rccl-dev-rpath6.3.4/rccl-dev-rpath6.3.4_2.21.5.60304-76~20.04_amd64.deb",
-        "version": "2.21.5.60304-76"
+        "name": "rccl-devel-rpath",
+        "sha256": "e2d6a418e1984d41746bc3537376da61b3b4c238baa7e930e10b8245e08eb7a5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rccl-devel-rpath6.3.4-2.21.5.60304-76.el8.x86_64.rpm",
+        "version": "2.21.5.60304"
       },
       {
         "name": "rccl-rpath",
-        "sha256": "e2c8717f65aaaa5331a913198d5324f8193557dceee857db72a4625ff6beb6bc",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rccl-rpath6.3.4/rccl-rpath6.3.4_2.21.5.60304-76~20.04_amd64.deb",
-        "version": "2.21.5.60304-76"
+        "sha256": "ae423a3ec4bda18ecc1a789ee6d03665f9a9beaf938e263bd444b3c6e06f5592",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rccl-rpath6.3.4-2.21.5.60304-76.el8.x86_64.rpm",
+        "version": "2.21.5.60304"
       }
     ],
-    "version": "2.21.5.60304-76"
+    "version": "2.21.5.60304"
+  },
+  "rccl-asan": {
+    "deps": [
+      "hip-runtime-amd-asan",
+      "rocm-core-asan",
+      "rocm-smi-lib"
+    ],
+    "components": [
+      {
+        "name": "rccl-asan",
+        "sha256": "99ca37611c955e3c1ad946d4704b9a28b7aeaaee006fe501c6c0d4e2446d720e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rccl-asan-2.21.5.60304-76.el8.x86_64.rpm",
+        "version": "2.21.5.60304"
+      },
+      {
+        "name": "rccl-asan-rpath",
+        "sha256": "60cc87cb1485d073af71b26ad32cba67da9aa7cc6adc63deab3c7a779ea5200d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rccl-asan-rpath6.3.4-2.21.5.60304-76.el8.x86_64.rpm",
+        "version": "2.21.5.60304"
+      }
+    ],
+    "version": "2.21.5.60304"
   },
   "rccl-unittests": {
     "deps": [
@@ -1031,18 +1422,18 @@
     "components": [
       {
         "name": "rccl-unittests",
-        "sha256": "05bbaa1c26951bdbd14c1767309ccedd5020995556b8a4391c0d99e9040e24d8",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rccl-unittests/rccl-unittests_2.21.5.60304-76~20.04_amd64.deb",
-        "version": "2.21.5.60304-76"
+        "sha256": "711630ecf1ba06a9127dd606a7cba05b875c40d98d5be1e4ec8a9d0068df26e3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rccl-unittests-2.21.5.60304-76.el8.x86_64.rpm",
+        "version": "2.21.5.60304"
       },
       {
         "name": "rccl-unittests-rpath",
-        "sha256": "5c80668c98665dcf6dd0266b60f33df3f19a5e3d8a830c60dbfc208f2d132782",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rccl-unittests-rpath6.3.4/rccl-unittests-rpath6.3.4_2.21.5.60304-76~20.04_amd64.deb",
-        "version": "2.21.5.60304-76"
+        "sha256": "a54b3183b5604bab0dca26399bd22e0cbffd89b34cb0798d022683e0a5454947",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rccl-unittests-rpath6.3.4-2.21.5.60304-76.el8.x86_64.rpm",
+        "version": "2.21.5.60304"
       }
     ],
-    "version": "2.21.5.60304-76"
+    "version": "2.21.5.60304"
   },
   "rdc": {
     "deps": [
@@ -1051,18 +1442,18 @@
     "components": [
       {
         "name": "rdc",
-        "sha256": "3572379164fe414978d687bd2f70d4fb2dcdf9fc13ad323f96c1d3a8efa5b221",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rdc/rdc_0.3.0.60304-76~20.04_amd64.deb",
-        "version": "0.3.0.60304-76"
+        "sha256": "014af7ee0ad1bd18b9a99118a12371dbc9cb77e07b1e21c6672f160091b28098",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rdc-0.3.0.60304-76.el8.x86_64.rpm",
+        "version": "0.3.0.60304"
       },
       {
         "name": "rdc-rpath",
-        "sha256": "fbafc7cd7a974b36bcb370660079be5e0f18958403b625aa6ff5a601948fbb89",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rdc-rpath6.3.4/rdc-rpath6.3.4_0.3.0.60304-76~20.04_amd64.deb",
-        "version": "0.3.0.60304-76"
+        "sha256": "db3a9eaa42ee784dece724738101aa48c8bdb737fe62564e1beb7bc734e57bbe",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rdc-rpath6.3.4-0.3.0.60304-76.el8.x86_64.rpm",
+        "version": "0.3.0.60304"
       }
     ],
-    "version": "0.3.0.60304-76"
+    "version": "0.3.0.60304"
   },
   "rocal": {
     "deps": [
@@ -1072,30 +1463,30 @@
     "components": [
       {
         "name": "rocal",
-        "sha256": "760f565046f582386147a7f2320cb2d73c32151718507f1fc6b3846094fdbe2f",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocal/rocal_2.1.0.60304-76~20.04_amd64.deb",
-        "version": "2.1.0.60304-76"
+        "sha256": "39a96a74554d94d970364baaff706f0a5ce9c2972452fb797175f6125a55caf3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocal-2.1.0.60304-76.x86_64.rpm",
+        "version": "2.1.0.60304"
       },
       {
-        "name": "rocal-dev",
-        "sha256": "bd4cca90ee8b46de69631c099ab0563e9c887bace03ba34ebd73eab87489227a",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocal-dev/rocal-dev_2.1.0.60304-76~20.04_amd64.deb",
-        "version": "2.1.0.60304-76"
+        "name": "rocal-devel",
+        "sha256": "a73ee9362b61e806dd7d789d6ae286bc9d013a4fa2cd87fe589a41aae7fbab6c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocal-devel-2.1.0.60304-76.x86_64.rpm",
+        "version": "2.1.0.60304"
       },
       {
-        "name": "rocal-dev-rpath",
-        "sha256": "86d873550d6e1787da62b2a6ac97a8f77b9668d286d5eb979d6437694493553e",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocal-dev-rpath6.3.4/rocal-dev-rpath6.3.4_2.1.0.60304-76~20.04_amd64.deb",
-        "version": "2.1.0.60304-76"
+        "name": "rocal-devel-rpath",
+        "sha256": "fa9398c912078b26410376a5aa02a3fed26114c4a840a07930f6fec3c0c578b7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocal-devel-rpath6.3.4-2.1.0.60304-76.x86_64.rpm",
+        "version": "2.1.0.60304"
       },
       {
         "name": "rocal-rpath",
-        "sha256": "3aff694238c93a9f9a2620611a5793c4cd3d3aef346c6a4638946860aa7b1e04",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocal-rpath6.3.4/rocal-rpath6.3.4_2.1.0.60304-76~20.04_amd64.deb",
-        "version": "2.1.0.60304-76"
+        "sha256": "8a6dd7c9bcce99804faeb5610771d0b31143cee3716fb0e8ed974706d7bae5b5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocal-rpath6.3.4-2.1.0.60304-76.x86_64.rpm",
+        "version": "2.1.0.60304"
       }
     ],
-    "version": "2.1.0.60304-76"
+    "version": "2.1.0.60304"
   },
   "rocal-test": {
     "deps": [
@@ -1104,18 +1495,18 @@
     "components": [
       {
         "name": "rocal-test",
-        "sha256": "0de630866889881049c29b4c3a1dce32cb7052d1e77c21345978c3d49574c698",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocal-test/rocal-test_2.1.0.60304-76~20.04_amd64.deb",
-        "version": "2.1.0.60304-76"
+        "sha256": "8154131b1f7b9d6c9d8e101ae4c303f03e371e086f46219cf35653aae39b4641",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocal-test-2.1.0.60304-76.x86_64.rpm",
+        "version": "2.1.0.60304"
       },
       {
         "name": "rocal-test-rpath",
-        "sha256": "f3659f07b242a23dfcca8ddd4af482d355846c2999c91cb8a1ba157974704e0e",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocal-test-rpath6.3.4/rocal-test-rpath6.3.4_2.1.0.60304-76~20.04_amd64.deb",
-        "version": "2.1.0.60304-76"
+        "sha256": "c48bb68b34054946ac3b75e462aa79dfa9d00cdfd1c9d3b3e0ab1c655832fdc1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocal-test-rpath6.3.4-2.1.0.60304-76.x86_64.rpm",
+        "version": "2.1.0.60304"
       }
     ],
-    "version": "2.1.0.60304-76"
+    "version": "2.1.0.60304"
   },
   "rocalution": {
     "deps": [
@@ -1128,30 +1519,54 @@
     "components": [
       {
         "name": "rocalution",
-        "sha256": "5b58f11a8a35e108d8d63455a98f3c8b279fbdfe9d94cc48397783df63f3e2f0",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocalution/rocalution_3.2.1.60304-76~20.04_amd64.deb",
-        "version": "3.2.1.60304-76"
+        "sha256": "5a16c3c5710033879805608d4f4228b025f1d0820f730fd8246b88bd82069f19",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocalution-3.2.1.60304-76.el8.x86_64.rpm",
+        "version": "3.2.1.60304"
       },
       {
-        "name": "rocalution-dev",
-        "sha256": "316cdc52ed3feb0eca81c75f7b192c59175e047bc19fa571c3749f40b3f2be54",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocalution-dev/rocalution-dev_3.2.1.60304-76~20.04_amd64.deb",
-        "version": "3.2.1.60304-76"
+        "name": "rocalution-devel",
+        "sha256": "5c2cde4f9b12fa7b17d1440f0f563d963451f69ebcf598399dccd6cd3f2aef30",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocalution-devel-3.2.1.60304-76.el8.x86_64.rpm",
+        "version": "3.2.1.60304"
       },
       {
-        "name": "rocalution-dev-rpath",
-        "sha256": "9211a11089f6dc6ac363cb3f7ea99ef2c8550f01ed075b451be4692a590cd850",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocalution-dev-rpath6.3.4/rocalution-dev-rpath6.3.4_3.2.1.60304-76~20.04_amd64.deb",
-        "version": "3.2.1.60304-76"
+        "name": "rocalution-devel-rpath",
+        "sha256": "70e823e97f7d03f349d5fcafaa73160035c6a5cca7bcfe22f3e47071f8b1e646",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocalution-devel-rpath6.3.4-3.2.1.60304-76.el8.x86_64.rpm",
+        "version": "3.2.1.60304"
       },
       {
         "name": "rocalution-rpath",
-        "sha256": "02e46f446566af2f8a6df70a77987e41b552ca221b7c434c84ef70fac9356cb7",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocalution-rpath6.3.4/rocalution-rpath6.3.4_3.2.1.60304-76~20.04_amd64.deb",
-        "version": "3.2.1.60304-76"
+        "sha256": "89cde8c4130082dfa59723a7162a18bcc51adc169346855f263855672000764f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocalution-rpath6.3.4-3.2.1.60304-76.el8.x86_64.rpm",
+        "version": "3.2.1.60304"
       }
     ],
-    "version": "3.2.1.60304-76"
+    "version": "3.2.1.60304"
+  },
+  "rocalution-asan": {
+    "deps": [
+      "hip-runtime-amd-asan",
+      "rocblas",
+      "rocm-core-asan",
+      "rocrand",
+      "rocsparse"
+    ],
+    "components": [
+      {
+        "name": "rocalution-asan",
+        "sha256": "1364769f00b2a43a2796d82a24dda17bdec0a76b6655c008341f24e53aa15767",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocalution-asan-3.2.1.60304-76.el8.x86_64.rpm",
+        "version": "3.2.1.60304"
+      },
+      {
+        "name": "rocalution-asan-rpath",
+        "sha256": "24d792571d1efa046095e5fc41619ece12df91f7a18259a8ffafdd3e67656a72",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocalution-asan-rpath6.3.4-3.2.1.60304-76.el8.x86_64.rpm",
+        "version": "3.2.1.60304"
+      }
+    ],
+    "version": "3.2.1.60304"
   },
   "rocblas": {
     "deps": [
@@ -1162,30 +1577,52 @@
     "components": [
       {
         "name": "rocblas",
-        "sha256": "f51d3eed8a505043e6455b03e17e43aad7b7db8f6565f9b3e99636da68dfff65",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocblas/rocblas_4.3.0.60304-76~20.04_amd64.deb",
-        "version": "4.3.0.60304-76"
+        "sha256": "e207bc8120c877a87d03186044875580ccc51da03caa9454e73f4c593f1a1fc7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocblas-4.3.0.60304-76.el8.x86_64.rpm",
+        "version": "4.3.0.60304"
       },
       {
-        "name": "rocblas-dev",
-        "sha256": "28032156591ceb7cad0a571732c47517e93db193d9f88b80cb66cd06c24a097b",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocblas-dev/rocblas-dev_4.3.0.60304-76~20.04_amd64.deb",
-        "version": "4.3.0.60304-76"
+        "name": "rocblas-devel",
+        "sha256": "b73d2e0ca0d054b5b904044da4ec70cbf5655f431b3e28e82d14a36722ebd019",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocblas-devel-4.3.0.60304-76.el8.x86_64.rpm",
+        "version": "4.3.0.60304"
       },
       {
-        "name": "rocblas-dev-rpath",
-        "sha256": "16e865d68dd199a3ca0b404dc7a654ccae5d04eb27e23203366f10a57a694e46",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocblas-dev-rpath6.3.4/rocblas-dev-rpath6.3.4_4.3.0.60304-76~20.04_amd64.deb",
-        "version": "4.3.0.60304-76"
+        "name": "rocblas-devel-rpath",
+        "sha256": "13f74938f543a7fe50f57c34413f99b9c44a39a3093d0aba289af5b462fb97b1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocblas-devel-rpath6.3.4-4.3.0.60304-76.el8.x86_64.rpm",
+        "version": "4.3.0.60304"
       },
       {
         "name": "rocblas-rpath",
-        "sha256": "fe30bd3e4a6f04e742ce257ec883e3584fea2993997c6dd957fd2d705938dd61",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocblas-rpath6.3.4/rocblas-rpath6.3.4_4.3.0.60304-76~20.04_amd64.deb",
-        "version": "4.3.0.60304-76"
+        "sha256": "2e42b1a3d9cf75ce2a811ed8b9208b5dc4fc4ed74fd059c17fbb739fbf620dd1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocblas-rpath6.3.4-4.3.0.60304-76.el8.x86_64.rpm",
+        "version": "4.3.0.60304"
       }
     ],
-    "version": "4.3.0.60304-76"
+    "version": "4.3.0.60304"
+  },
+  "rocblas-asan": {
+    "deps": [
+      "hip-runtime-amd-asan",
+      "hipblaslt",
+      "rocm-core-asan"
+    ],
+    "components": [
+      {
+        "name": "rocblas-asan",
+        "sha256": "6a38cf1a62aecb115388c0a340bfba4d9835dd42499346ebae77b718fbbd8d35",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocblas-asan-4.3.0.60304-76.el8.x86_64.rpm",
+        "version": "4.3.0.60304"
+      },
+      {
+        "name": "rocblas-asan-rpath",
+        "sha256": "d8df10a8f8df0259107d2de143aad2a253c6e89766f55194d401913c5047ba69",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocblas-asan-rpath6.3.4-4.3.0.60304-76.el8.x86_64.rpm",
+        "version": "4.3.0.60304"
+      }
+    ],
+    "version": "4.3.0.60304"
   },
   "rocdecode": {
     "deps": [
@@ -1195,30 +1632,30 @@
     "components": [
       {
         "name": "rocdecode",
-        "sha256": "ac9dd7a9f11549f5b25195287be7f2d40cf4717f4d01f3d8bd2f774348fe8c39",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocdecode/rocdecode_0.8.0.60304-76~20.04_amd64.deb",
-        "version": "0.8.0.60304-76"
+        "sha256": "17fe7de2c99c9889a0399053fb367dfbe969a29abd8649b6e7402e0a8f9c6c29",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocdecode-0.8.0.60304-76.x86_64.rpm",
+        "version": "0.8.0.60304"
       },
       {
-        "name": "rocdecode-dev",
-        "sha256": "344f9009dfb9de7ca86723bd733d3319d09b044d7ced4d0d3f89d6c984d9772a",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocdecode-dev/rocdecode-dev_0.8.0.60304-76~20.04_amd64.deb",
-        "version": "0.8.0.60304-76"
+        "name": "rocdecode-devel",
+        "sha256": "5fb230b9de1a40b9fb80f54a376a80b2e26e3db348bd8499fc325b4ea97cd5d5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocdecode-devel-0.8.0.60304-76.x86_64.rpm",
+        "version": "0.8.0.60304"
       },
       {
-        "name": "rocdecode-dev-rpath",
-        "sha256": "17d55b3f277a8d4e7380bbe0c71f9c081ae4be91f8dbd209831904a1ae1b22a0",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocdecode-dev-rpath6.3.4/rocdecode-dev-rpath6.3.4_0.8.0.60304-76~20.04_amd64.deb",
-        "version": "0.8.0.60304-76"
+        "name": "rocdecode-devel-rpath",
+        "sha256": "f850c0574bbd784cf3cab9a1821797886faddaabaebd8b51f8051c0584c65787",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocdecode-devel-rpath6.3.4-0.8.0.60304-76.x86_64.rpm",
+        "version": "0.8.0.60304"
       },
       {
         "name": "rocdecode-rpath",
-        "sha256": "9d62af19eb11e16685c73c5036926a199c12dc47661311c6655f0617520dfe31",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocdecode-rpath6.3.4/rocdecode-rpath6.3.4_0.8.0.60304-76~20.04_amd64.deb",
-        "version": "0.8.0.60304-76"
+        "sha256": "e6de6ffefdb1ab3260f7271293e27d0f9eb0674ec4a6b4950d3d85e151e81563",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocdecode-rpath6.3.4-0.8.0.60304-76.x86_64.rpm",
+        "version": "0.8.0.60304"
       }
     ],
-    "version": "0.8.0.60304-76"
+    "version": "0.8.0.60304"
   },
   "rocdecode-test": {
     "deps": [
@@ -1228,18 +1665,18 @@
     "components": [
       {
         "name": "rocdecode-test",
-        "sha256": "9ae005de0abedc2f29e7928737fcb7a6cdb777bc0700fc268082d3e90c2e348e",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocdecode-test/rocdecode-test_0.8.0.60304-76~20.04_amd64.deb",
-        "version": "0.8.0.60304-76"
+        "sha256": "99be44b3a6bb65eb9512e01dd31b08aa5e0d984a343f953b3a97b3b76cb43693",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocdecode-test-0.8.0.60304-76.x86_64.rpm",
+        "version": "0.8.0.60304"
       },
       {
         "name": "rocdecode-test-rpath",
-        "sha256": "780c52e0462b292b95196f9de73bec40335e31aa45398fac05d63ecd0b5a6e56",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocdecode-test-rpath6.3.4/rocdecode-test-rpath6.3.4_0.8.0.60304-76~20.04_amd64.deb",
-        "version": "0.8.0.60304-76"
+        "sha256": "b2eed8c9e25a145ddaa9dc5f884515828baaa8f87767478872b432d7c37f4184",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocdecode-test-rpath6.3.4-0.8.0.60304-76.x86_64.rpm",
+        "version": "0.8.0.60304"
       }
     ],
-    "version": "0.8.0.60304-76"
+    "version": "0.8.0.60304"
   },
   "rocfft": {
     "deps": [
@@ -1248,30 +1685,50 @@
     "components": [
       {
         "name": "rocfft",
-        "sha256": "be943ec42b55f5786cf13cd6a4fa218fcf42955ec8001c98622be020a766735e",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocfft/rocfft_1.0.31.60304-76~20.04_amd64.deb",
-        "version": "1.0.31.60304-76"
+        "sha256": "4b6ad7d187ed099c25d141003b1fda80c66d50a285e0a2699eb2d20d68b65a07",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocfft-1.0.31.60304-76.el8.x86_64.rpm",
+        "version": "1.0.31.60304"
       },
       {
-        "name": "rocfft-dev",
-        "sha256": "5f463ca01f41ce51418f44d460688eba7d0e99353aff4c44d6492bd503757c18",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocfft-dev/rocfft-dev_1.0.31.60304-76~20.04_amd64.deb",
-        "version": "1.0.31.60304-76"
+        "name": "rocfft-devel",
+        "sha256": "c5e70e3a5bc096180795cc1107a43904c945437956944e6254b8448bf4adb7ba",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocfft-devel-1.0.31.60304-76.el8.x86_64.rpm",
+        "version": "1.0.31.60304"
       },
       {
-        "name": "rocfft-dev-rpath",
-        "sha256": "da04c1a4dad64ceecfd8ed7b5e94a7e1bcdb9582b4de66d80aea742bbcef0f35",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocfft-dev-rpath6.3.4/rocfft-dev-rpath6.3.4_1.0.31.60304-76~20.04_amd64.deb",
-        "version": "1.0.31.60304-76"
+        "name": "rocfft-devel-rpath",
+        "sha256": "e00426568275099ca50cb71f3b7801433ee9531ba148b8bdf66a46d53a53591c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocfft-devel-rpath6.3.4-1.0.31.60304-76.el8.x86_64.rpm",
+        "version": "1.0.31.60304"
       },
       {
         "name": "rocfft-rpath",
-        "sha256": "473decd613c05697a379702527d0db0c5e0196f322bc5213643f72b54b64e64f",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocfft-rpath6.3.4/rocfft-rpath6.3.4_1.0.31.60304-76~20.04_amd64.deb",
-        "version": "1.0.31.60304-76"
+        "sha256": "6d68137bcdc263fa7b31d0e0f0b821db2962f15b62a1c42beaf0398269d4e69d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocfft-rpath6.3.4-1.0.31.60304-76.el8.x86_64.rpm",
+        "version": "1.0.31.60304"
       }
     ],
-    "version": "1.0.31.60304-76"
+    "version": "1.0.31.60304"
+  },
+  "rocfft-asan": {
+    "deps": [
+      "rocm-core-asan"
+    ],
+    "components": [
+      {
+        "name": "rocfft-asan",
+        "sha256": "d356ffca384758209b3ecc693caaa227f6d036ce9b8993e88d0eef3973838d5b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocfft-asan-1.0.31.60304-76.el8.x86_64.rpm",
+        "version": "1.0.31.60304"
+      },
+      {
+        "name": "rocfft-asan-rpath",
+        "sha256": "2f3b866fe90688b54ebba4368ab77f589438925d59962e8eb34fdde3bb785a97",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocfft-asan-rpath6.3.4-1.0.31.60304-76.el8.x86_64.rpm",
+        "version": "1.0.31.60304"
+      }
+    ],
+    "version": "1.0.31.60304"
   },
   "rocjpeg": {
     "deps": [
@@ -1281,30 +1738,30 @@
     "components": [
       {
         "name": "rocjpeg",
-        "sha256": "1c122eb93e46538d0717702539763208e7c16754bc026c8e340c3bd71a23b996",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocjpeg/rocjpeg_0.6.0.60304-76~20.04_amd64.deb",
-        "version": "0.6.0.60304-76"
+        "sha256": "8c7ea2daf6432f4fbd3e8694ae04dfcf9fcb334c4fc7bc8cb3399286d33c7a29",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocjpeg-0.6.0.60304-76.x86_64.rpm",
+        "version": "0.6.0.60304"
       },
       {
-        "name": "rocjpeg-dev",
-        "sha256": "3dfc499380fd554fbc4ffa28c863b44d16421f6244e71d4191aac306f66d8468",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocjpeg-dev/rocjpeg-dev_0.6.0.60304-76~20.04_amd64.deb",
-        "version": "0.6.0.60304-76"
+        "name": "rocjpeg-devel",
+        "sha256": "a2b567809ab92b942f4f330cfc5cf17522585bc66c33ca4c2d26ee7688aca98a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocjpeg-devel-0.6.0.60304-76.x86_64.rpm",
+        "version": "0.6.0.60304"
       },
       {
-        "name": "rocjpeg-dev-rpath",
-        "sha256": "be0a5b9b7385dfe40b1fdfcb939cdc6dda8b83bf8107d1d922b7a74c7758e498",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocjpeg-dev-rpath6.3.4/rocjpeg-dev-rpath6.3.4_0.6.0.60304-76~20.04_amd64.deb",
-        "version": "0.6.0.60304-76"
+        "name": "rocjpeg-devel-rpath",
+        "sha256": "c0468e5f1c215ba0c1c41293953f0a49327e81909ea1febf63dbcd82c2f06121",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocjpeg-devel-rpath6.3.4-0.6.0.60304-76.x86_64.rpm",
+        "version": "0.6.0.60304"
       },
       {
         "name": "rocjpeg-rpath",
-        "sha256": "e2cd1e72b1d7dc6dc755bb5ef04f21643f82dfc0f865e375918148a759e425cb",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocjpeg-rpath6.3.4/rocjpeg-rpath6.3.4_0.6.0.60304-76~20.04_amd64.deb",
-        "version": "0.6.0.60304-76"
+        "sha256": "db743130c52c9ec14ebc49b72d9d6e13a27ca3158f27f8158be527f829efe9cf",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocjpeg-rpath6.3.4-0.6.0.60304-76.x86_64.rpm",
+        "version": "0.6.0.60304"
       }
     ],
-    "version": "0.6.0.60304-76"
+    "version": "0.6.0.60304"
   },
   "rocjpeg-test": {
     "deps": [
@@ -1314,84 +1771,73 @@
     "components": [
       {
         "name": "rocjpeg-test",
-        "sha256": "db9076e8bfe0105d720f1b132ef10a562fda51fcc49184b72a9335367dcc2ec0",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocjpeg-test/rocjpeg-test_0.6.0.60304-76~20.04_amd64.deb",
-        "version": "0.6.0.60304-76"
+        "sha256": "186fbc96ce0a5443e7fd476ac42b4da3e23251efbcd1e42bd4f9b92441f6d812",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocjpeg-test-0.6.0.60304-76.x86_64.rpm",
+        "version": "0.6.0.60304"
       },
       {
         "name": "rocjpeg-test-rpath",
-        "sha256": "1b37ca3843db8a8d2047e0ab735fd72dbc997d68449a5886e8bb682b59c02d69",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocjpeg-test-rpath6.3.4/rocjpeg-test-rpath6.3.4_0.6.0.60304-76~20.04_amd64.deb",
-        "version": "0.6.0.60304-76"
+        "sha256": "a90ae0cb4534e60586d7e297426df19ae60903c19edc37609e29511fe366bb71",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocjpeg-test-rpath6.3.4-0.6.0.60304-76.x86_64.rpm",
+        "version": "0.6.0.60304"
       }
     ],
-    "version": "0.6.0.60304-76"
+    "version": "0.6.0.60304"
   },
   "rocm": {
     "deps": [
-      "amd-smi-lib",
-      "comgr",
-      "hip-dev",
-      "hip-doc",
-      "hip-runtime-amd",
-      "hip-samples",
-      "hipcc",
-      "hipify-clang",
-      "hsa-amd-aqlprofile",
-      "hsa-rocr",
       "migraphx",
       "mivisionx",
-      "openmp-extras-dev",
-      "openmp-extras-runtime",
-      "rocm-cmake",
       "rocm-core",
-      "rocm-dbgapi",
-      "rocm-debug-agent",
       "rocm-developer-tools",
-      "rocm-device-libs",
-      "rocm-gdb",
-      "rocm-llvm",
       "rocm-ml-sdk",
-      "rocm-opencl",
       "rocm-opencl-sdk",
       "rocm-openmp-sdk",
-      "rocm-smi-lib",
       "rocm-utils",
-      "rocprofiler",
-      "rocprofiler-plugins",
-      "rocprofiler-register",
-      "rocprofiler-sdk",
-      "rocprofiler-sdk-roctx",
-      "roctracer",
       "rpp"
     ],
     "components": [
       {
         "name": "rocm",
-        "sha256": "9e573d34ec7bec91eba81a644fc585b02b62c59b15c2cd36b1b9bfbd187922ed",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm/rocm_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
-      },
-      {
-        "name": "rocm-dev",
-        "sha256": "296cb7ba9cc00037d849a07635ebeff9dc4d9adbd4583c269e4d8aa719fc892c",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-dev/rocm-dev_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
-      },
-      {
-        "name": "rocm-dev-rpath",
-        "sha256": "90a592f3735affed9b2da89ba5416a85b3a09e6ebf996f41ee84f00d80b44c09",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-dev-rpath6.3.4/rocm-dev-rpath6.3.4_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "dcb7da59424c520335ada1363e3bf59f57b9b8432a08e50dee24d6004a16608c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       },
       {
         "name": "rocm-rpath",
-        "sha256": "86f642718056b3301f9585f970de437dfec76359c04e5028ec017ec940e039b4",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-rpath6.3.4/rocm-rpath6.3.4_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "59896eb6d619774261c628f699319e11fc6e7aac00ccba5ac0e866ac9391ac42",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       }
     ],
-    "version": "6.3.4.60304-76"
+    "version": "6.3.4.60304"
+  },
+  "rocm-asan": {
+    "deps": [
+      "migraphx-asan",
+      "mivisionx-asan",
+      "rocm",
+      "rocm-core-asan",
+      "rocm-developer-tools-asan",
+      "rocm-language-runtime-asan",
+      "rocm-ml-libraries-asan",
+      "rocm-opencl-runtime-asan"
+    ],
+    "components": [
+      {
+        "name": "rocm-asan",
+        "sha256": "038115315cf3f7d6bc4ad4300ce045598821d3c4e3058c59e7b9eeeb59988171",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-asan-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      },
+      {
+        "name": "rocm-asan-rpath",
+        "sha256": "2340d3f02a0be1d4a561451eca27d976c4cfdf872adfbfb1e1c7448308c71842",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-asan-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      }
+    ],
+    "version": "6.3.4.60304"
   },
   "rocm-bandwidth-test": {
     "deps": [
@@ -1400,18 +1846,18 @@
     "components": [
       {
         "name": "rocm-bandwidth-test",
-        "sha256": "18ec4bc190327830119745d98bf2ed803079c871ef54067fa3e7b052cdc5f05b",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-bandwidth-test/rocm-bandwidth-test_1.4.0.60304-76~20.04_amd64.deb",
-        "version": "1.4.0.60304-76"
+        "sha256": "1d7a3f50c8c61f8afd4b2a5eeab97e800ed24128ed138d6377dd250364bf0a19",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-bandwidth-test-1.4.0.60304-76.el8.x86_64.rpm",
+        "version": "1.4.0.60304"
       },
       {
         "name": "rocm-bandwidth-test-rpath",
-        "sha256": "85ed911383f9e7a3cb17b36b8fd35d9fde67883fad6bfe6468f8a9095cfa2a0f",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-bandwidth-test-rpath6.3.4/rocm-bandwidth-test-rpath6.3.4_1.4.0.60304-76~20.04_amd64.deb",
-        "version": "1.4.0.60304-76"
+        "sha256": "69f831db6c395b8cc383705682c6204a6d21604fad0e7e73d057036106027ce3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-bandwidth-test-rpath6.3.4-1.4.0.60304-76.el8.x86_64.rpm",
+        "version": "1.4.0.60304"
       }
     ],
-    "version": "1.4.0.60304-76"
+    "version": "1.4.0.60304"
   },
   "rocm-cmake": {
     "deps": [
@@ -1420,56 +1866,98 @@
     "components": [
       {
         "name": "rocm-cmake",
-        "sha256": "dd76201f8be1f684eea8c04c8ba5b4842d53a3b48cfe5361796a6726c034b970",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-cmake/rocm-cmake_0.14.0.60304-76~20.04_amd64.deb",
-        "version": "0.14.0.60304-76"
+        "sha256": "97a49d36640b224a0f1b19af2ca720380160484c4d73c5453787318cf081a4e5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-cmake-0.14.0.60304-76.el8.x86_64.rpm",
+        "version": "0.14.0.60304"
       },
       {
         "name": "rocm-cmake-rpath",
-        "sha256": "f4080ef739f719e123d653deca275f731e6370389bcd4d09e8b9461ee1ed8dfc",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-cmake-rpath6.3.4/rocm-cmake-rpath6.3.4_0.14.0.60304-76~20.04_amd64.deb",
-        "version": "0.14.0.60304-76"
+        "sha256": "933980511bd393a89b4a52aec95faaa6dbe989ac1c1d4ba535decaf83a3e1862",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-cmake-rpath6.3.4-0.14.0.60304-76.el8.x86_64.rpm",
+        "version": "0.14.0.60304"
       }
     ],
-    "version": "0.14.0.60304-76"
+    "version": "0.14.0.60304"
   },
   "rocm-core": {
     "deps": [],
     "components": [
       {
         "name": "rocm-core",
-        "sha256": "3a17542c3674966c001f750af237b6532a59d85180e2b8aefff061c6d032ca6a",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-core/rocm-core_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "ceab641445ffb41c8d351eff733f6b938fcb404e627f2e79456bd040e9d44808",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-core-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       },
       {
         "name": "rocm-core-rpath",
-        "sha256": "a407c77e329ba80c9bc3525846a5c08ae77d869b14f1ec4afae1ca6087b49d64",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-core-rpath6.3.4/rocm-core-rpath6.3.4_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "d1a2abcb0ef38d9869211618aa71119f3c62e4737c77ed22058c991bfad7555e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-core-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       }
     ],
-    "version": "6.3.4.60304-76"
+    "version": "6.3.4.60304"
   },
-  "rocm-dbgapi": {
+  "rocm-core-asan": {
     "deps": [
       "rocm-core"
     ],
     "components": [
       {
+        "name": "rocm-core-asan",
+        "sha256": "d5f78db2bd65bb701e237f9b202b7e358356db7f04e718a4f4225d41c31e0eff",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-core-asan-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      },
+      {
+        "name": "rocm-core-asan-rpath",
+        "sha256": "4de589e4c655e36ea2e71a7b07f6dff1e2f12063fe7d1dacb9720fc9da49a9d6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-core-asan-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      }
+    ],
+    "version": "6.3.4.60304"
+  },
+  "rocm-dbgapi": {
+    "deps": [
+      "comgr",
+      "rocm-core"
+    ],
+    "components": [
+      {
         "name": "rocm-dbgapi",
-        "sha256": "6b39e9ce564c74a9512d71779c35cf3e42dc76f6917b7564ca3b1cc5838bb4ee",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-dbgapi/rocm-dbgapi_0.77.0.60304-76~20.04_amd64.deb",
-        "version": "0.77.0.60304-76"
+        "sha256": "2ccd6e9ece224996d8b2f3f691c12b4c0c0b21a806eb86486aae30bbfcc5f80a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-dbgapi-0.77.0.60304-76.el8.x86_64.rpm",
+        "version": "0.77.0.60304"
       },
       {
         "name": "rocm-dbgapi-rpath",
-        "sha256": "4f383c686d8b9df319370938ea4c5f4ee6bdde4c7a7288ca1635b51f15afde87",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-dbgapi-rpath6.3.4/rocm-dbgapi-rpath6.3.4_0.77.0.60304-76~20.04_amd64.deb",
-        "version": "0.77.0.60304-76"
+        "sha256": "79aa08dd901ef4f76dc26ca6ac2cfd2b95254e11f04bedee608c52f10dee1ad2",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-dbgapi-rpath6.3.4-0.77.0.60304-76.el8.x86_64.rpm",
+        "version": "0.77.0.60304"
       }
     ],
-    "version": "0.77.0.60304-76"
+    "version": "0.77.0.60304"
+  },
+  "rocm-dbgapi-asan": {
+    "deps": [
+      "comgr-asan",
+      "rocm-core-asan"
+    ],
+    "components": [
+      {
+        "name": "rocm-dbgapi-asan",
+        "sha256": "2013d050f3253355a6496aa4156fff17a43aeff0ef84a105b989d06cb748373a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-dbgapi-asan-0.77.0.60304-76.el8.x86_64.rpm",
+        "version": "0.77.0.60304"
+      },
+      {
+        "name": "rocm-dbgapi-asan-rpath",
+        "sha256": "66d057111b94cdd4518c3685636c9107bc9f0fcd7b0640af2371158dfca6d6de",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-dbgapi-asan-rpath6.3.4-0.77.0.60304-76.el8.x86_64.rpm",
+        "version": "0.77.0.60304"
+      }
+    ],
+    "version": "0.77.0.60304"
   },
   "rocm-debug-agent": {
     "deps": [
@@ -1479,18 +1967,119 @@
     "components": [
       {
         "name": "rocm-debug-agent",
-        "sha256": "8f8c5a51405378b9b7bdc7dbb265d2f081dcb10168c0f0d722687164348676f6",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-debug-agent/rocm-debug-agent_2.0.3.60304-76~20.04_amd64.deb",
-        "version": "2.0.3.60304-76"
+        "sha256": "76de61a11b8c1ca6d83524ac2834dd9a788595a5c4848b935c1d55c890818811",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-debug-agent-2.0.3.60304-76.el8.x86_64.rpm",
+        "version": "2.0.3.60304"
       },
       {
         "name": "rocm-debug-agent-rpath",
-        "sha256": "92d33937adf74c244cc6355263fd1115a1c52ab0a0f51ece07fccee8d61fca0e",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-debug-agent-rpath6.3.4/rocm-debug-agent-rpath6.3.4_2.0.3.60304-76~20.04_amd64.deb",
-        "version": "2.0.3.60304-76"
+        "sha256": "150d3db41fc079ed4fe4e812137c9f04e2a6f8c1aff67e2a989797220dd68017",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-debug-agent-rpath6.3.4-2.0.3.60304-76.el8.x86_64.rpm",
+        "version": "2.0.3.60304"
       }
     ],
-    "version": "2.0.3.60304-76"
+    "version": "2.0.3.60304"
+  },
+  "rocm-debug-agent-asan": {
+    "deps": [
+      "rocm-core-asan",
+      "rocm-dbgapi-asan"
+    ],
+    "components": [
+      {
+        "name": "rocm-debug-agent-asan",
+        "sha256": "0b387910400d5f21bc0b22ddcf35b4e02ab43f163204dc910319c10aa1007e3d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-debug-agent-asan-2.0.3.60304-76.el8.x86_64.rpm",
+        "version": "2.0.3.60304"
+      },
+      {
+        "name": "rocm-debug-agent-asan-rpath",
+        "sha256": "11c36b6252c05a55c8ac9b5b8e31495db551aae79dce1b3e477e0cd460afc018",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-debug-agent-asan-rpath6.3.4-2.0.3.60304-76.el8.x86_64.rpm",
+        "version": "2.0.3.60304"
+      }
+    ],
+    "version": "2.0.3.60304"
+  },
+  "rocm-dev": {
+    "deps": [
+      "amd-smi-lib",
+      "comgr",
+      "hip-devel",
+      "hip-doc",
+      "hip-runtime-amd",
+      "hip-samples",
+      "hipcc",
+      "hipify-clang",
+      "hsa-amd-aqlprofile",
+      "hsa-rocr",
+      "openmp-extras-devel",
+      "openmp-extras-runtime",
+      "rocm-cmake",
+      "rocm-core",
+      "rocm-dbgapi",
+      "rocm-debug-agent",
+      "rocm-device-libs",
+      "rocm-gdb",
+      "rocm-llvm",
+      "rocm-opencl",
+      "rocm-smi-lib",
+      "rocm-utils",
+      "rocprofiler",
+      "rocprofiler-plugins",
+      "rocprofiler-register",
+      "rocprofiler-sdk",
+      "rocprofiler-sdk-roctx",
+      "roctracer"
+    ],
+    "components": [
+      {
+        "name": "rocm-dev",
+        "sha256": "958b12a42a4dca174c7afe378f145b67b39be6f50fad51c8e10348950f290b98",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-dev-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      },
+      {
+        "name": "rocm-dev-rpath",
+        "sha256": "3fd4f3a957edb0c53e0cb23b5b35c419b0c8675ee3be495fd3cd0cacd7a93938",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-dev-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      }
+    ],
+    "version": "6.3.4.60304"
+  },
+  "rocm-dev-asan": {
+    "deps": [
+      "amd-smi-lib-asan",
+      "comgr-asan",
+      "hip-runtime-amd-asan",
+      "hsa-amd-aqlprofile-asan",
+      "hsa-rocr-asan",
+      "openmp-extras-asan",
+      "rocm-core-asan",
+      "rocm-dbgapi-asan",
+      "rocm-debug-agent-asan",
+      "rocm-dev",
+      "rocm-opencl-asan",
+      "rocm-smi-lib-asan",
+      "rocprofiler-asan",
+      "roctracer-asan"
+    ],
+    "components": [
+      {
+        "name": "rocm-dev-asan",
+        "sha256": "131b9725813359d95e51c46be9010312a4fb45c6048cd54eae683d2016698536",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-dev-asan-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      },
+      {
+        "name": "rocm-dev-asan-rpath",
+        "sha256": "03f31407d2c5e64fe26309fd4d48665e0ce5bc041fee080d08d804a04c9e0560",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-dev-asan-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      }
+    ],
+    "version": "6.3.4.60304"
   },
   "rocm-developer-tools": {
     "deps": [
@@ -1512,18 +2101,47 @@
     "components": [
       {
         "name": "rocm-developer-tools",
-        "sha256": "eb08e727593645d8bf2ee9ac53485abbcf38a1469b0c2f86fcfc1d1fe7c7a5cc",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-developer-tools/rocm-developer-tools_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "550343cc4064fc69ef1d3558499ea826c7ffb1602347b3c97b715a1453bfc0ba",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-developer-tools-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       },
       {
         "name": "rocm-developer-tools-rpath",
-        "sha256": "e724421d54a45070d4fd1b947268114c98dd32d1dcb2f34e49e4ee8e742f91b6",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-developer-tools-rpath6.3.4/rocm-developer-tools-rpath6.3.4_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "1f60156c4b325ae405422273202f04a95b4817c22ba32c1e0bc355b5c449f431",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-developer-tools-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       }
     ],
-    "version": "6.3.4.60304-76"
+    "version": "6.3.4.60304"
+  },
+  "rocm-developer-tools-asan": {
+    "deps": [
+      "amd-smi-lib-asan",
+      "hsa-amd-aqlprofile-asan",
+      "rocm-core-asan",
+      "rocm-dbgapi-asan",
+      "rocm-debug-agent-asan",
+      "rocm-developer-tools",
+      "rocm-language-runtime-asan",
+      "rocm-smi-lib-asan",
+      "rocprofiler-asan",
+      "roctracer-asan"
+    ],
+    "components": [
+      {
+        "name": "rocm-developer-tools-asan",
+        "sha256": "164bf9883f930c4751b5c7cce86231137cfee5546d3a6c56277a26e5758805a2",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-developer-tools-asan-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      },
+      {
+        "name": "rocm-developer-tools-asan-rpath",
+        "sha256": "267fc2c90be7652fbb683406dfe83cdc0e2201e3bb08a7cb354546c443904044",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-developer-tools-asan-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      }
+    ],
+    "version": "6.3.4.60304"
   },
   "rocm-device-libs": {
     "deps": [
@@ -1532,39 +2150,38 @@
     "components": [
       {
         "name": "rocm-device-libs",
-        "sha256": "f393b03bacf2c47240d4d9e09d7f89ef0f67d4a6055bb286b96814ba3df27ffb",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-device-libs/rocm-device-libs_1.0.0.60304-76~20.04_amd64.deb",
-        "version": "1.0.0.60304-76"
+        "sha256": "63c33ee0e82b12dc3401af29dfe04b29fcb1b55f97970522b5db6670ae709b70",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-device-libs-1.0.0.60304-76.el8.x86_64.rpm",
+        "version": "1.0.0.60304"
       },
       {
         "name": "rocm-device-libs-rpath",
-        "sha256": "e0ddba319f38206f70d3c35df51f44f9849bee8953b0844f5c8b3481c0219023",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-device-libs-rpath6.3.4/rocm-device-libs-rpath6.3.4_1.0.0.60304-76~20.04_amd64.deb",
-        "version": "1.0.0.60304-76"
+        "sha256": "c4390c4c3b216f4d21abedfcda00093b34fffbb0fd034ca24ca654917afc45f1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-device-libs-rpath6.3.4-1.0.0.60304-76.el8.x86_64.rpm",
+        "version": "1.0.0.60304"
       }
     ],
-    "version": "1.0.0.60304-76"
+    "version": "1.0.0.60304"
   },
   "rocm-gdb": {
     "deps": [
-      "rocm-core",
-      "rocm-dbgapi"
+      "rocm-core"
     ],
     "components": [
       {
         "name": "rocm-gdb",
-        "sha256": "b80721c04493c49b14b5af40b81c861a5935f4950d158afe581ecc883f0f5539",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-gdb/rocm-gdb_15.2.60304-76~20.04_amd64.deb",
-        "version": "15.2.60304-76"
+        "sha256": "ec8b20266a7a1a41c39e5c52d1b50d1dda96ce09fe5d159d5826d73e0d66498a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-gdb-15.2.60304-76.el8.x86_64.rpm",
+        "version": "15.2.60304"
       },
       {
         "name": "rocm-gdb-rpath",
-        "sha256": "7ec7482d5d1842bd50f6bd7cb375c6a29cacb77aecfec535aceec0a7dda00e32",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-gdb-rpath6.3.4/rocm-gdb-rpath6.3.4_15.2.60304-76~20.04_amd64.deb",
-        "version": "15.2.60304-76"
+        "sha256": "55908ddf12b0f52691f319df3fde52736f8d675e658a907471690d7c91323548",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-gdb-rpath6.3.4-15.2.60304-76.el8.x86_64.rpm",
+        "version": "15.2.60304"
       }
     ],
-    "version": "15.2.60304-76"
+    "version": "15.2.60304"
   },
   "rocm-hip-libraries": {
     "deps": [
@@ -1590,22 +2207,60 @@
     "components": [
       {
         "name": "rocm-hip-libraries",
-        "sha256": "95ea26949cddae4bebc688a5c59c4dca6b754984a9bbad101c80d11d6aa25421",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-hip-libraries/rocm-hip-libraries_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "f26047de044e6a47bb294a35a4cb5ee225f27b96b32fbba07a29c9380f1b5fc4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-hip-libraries-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       },
       {
         "name": "rocm-hip-libraries-rpath",
-        "sha256": "da0b3562e3793fa3d0f7709ed8aaf080e6992a43bbc425232210976896da1ab8",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-hip-libraries-rpath6.3.4/rocm-hip-libraries-rpath6.3.4_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "a1dd10944aeb06fde9b52af4bfcae8c60caf3d453695a50c61b37267b838244a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-hip-libraries-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       }
     ],
-    "version": "6.3.4.60304-76"
+    "version": "6.3.4.60304"
+  },
+  "rocm-hip-libraries-asan": {
+    "deps": [
+      "hipblas-asan",
+      "hipblaslt-asan",
+      "hipfft-asan",
+      "hiprand-asan",
+      "hipsolver-asan",
+      "hipsparse-asan",
+      "hipsparselt-asan",
+      "hiptensor-asan",
+      "rccl-asan",
+      "rocalution-asan",
+      "rocblas-asan",
+      "rocfft-asan",
+      "rocm-core-asan",
+      "rocm-hip-libraries",
+      "rocm-hip-runtime-asan",
+      "rocm-smi-lib-asan",
+      "rocrand-asan",
+      "rocsolver-asan",
+      "rocsparse-asan"
+    ],
+    "components": [
+      {
+        "name": "rocm-hip-libraries-asan",
+        "sha256": "308b019f5f4b59ade6ce1fabf576afb7dad6edce8b94e34344afd9cb1bd52eca",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-hip-libraries-asan-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      },
+      {
+        "name": "rocm-hip-libraries-asan-rpath",
+        "sha256": "92a3b62914071405d2daef417e80c47707d1d3dcc9767dd681b15f4d00cf3caf",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-hip-libraries-asan-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      }
+    ],
+    "version": "6.3.4.60304"
   },
   "rocm-hip-runtime": {
     "deps": [
-      "hip-dev",
+      "hip-devel",
       "hip-doc",
       "hip-runtime-amd",
       "hip-samples",
@@ -1622,39 +2277,62 @@
     "components": [
       {
         "name": "rocm-hip-runtime",
-        "sha256": "3129fdc919f4d62c822513651b591cfd8ff2be862fe84a7ebe44e78546da5dc6",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-hip-runtime/rocm-hip-runtime_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "562a00dc49f521916913497669200089feee71fc88ff62ef822dcf177c152d7a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-hip-runtime-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       },
       {
-        "name": "rocm-hip-runtime-dev",
-        "sha256": "a56658f781c49b6231bf1a1d9dae2f22e272e5c399ab4cc0197122773970b935",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-hip-runtime-dev/rocm-hip-runtime-dev_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "name": "rocm-hip-runtime-devel",
+        "sha256": "cac378f338180e252c0f63426e997c77e1466d29e048f76aa7c98093b98e698a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-hip-runtime-devel-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       },
       {
-        "name": "rocm-hip-runtime-dev-rpath",
-        "sha256": "6c99dfa39fdfe5d5188037c20e44c255d5757dc1c891efb1cb88bedaac1ee2b2",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-hip-runtime-dev-rpath6.3.4/rocm-hip-runtime-dev-rpath6.3.4_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "name": "rocm-hip-runtime-devel-rpath",
+        "sha256": "653997e50e833443fd1f5e3fcbe3f5d98eb330bf4764723acc5deee0637305e0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-hip-runtime-devel-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       },
       {
         "name": "rocm-hip-runtime-rpath",
-        "sha256": "56356087ee2167e921da65929a84dc20066032ddbb24cd80be44676d8951d7f9",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-hip-runtime-rpath6.3.4/rocm-hip-runtime-rpath6.3.4_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "f95095cbadd462f76b48e026d04a36b8f76a58d4a02a1af868294500a38d13b3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-hip-runtime-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       }
     ],
-    "version": "6.3.4.60304-76"
+    "version": "6.3.4.60304"
+  },
+  "rocm-hip-runtime-asan": {
+    "deps": [
+      "hip-runtime-amd-asan",
+      "rocm-core-asan",
+      "rocm-hip-runtime",
+      "rocm-language-runtime-asan"
+    ],
+    "components": [
+      {
+        "name": "rocm-hip-runtime-asan",
+        "sha256": "25f06c00d2567e6f0a24008e98884ea63c80dd9afb63909b1b0a8cb62d35a697",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-hip-runtime-asan-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      },
+      {
+        "name": "rocm-hip-runtime-asan-rpath",
+        "sha256": "5806c38adccda2d2a29052b7bf7ecf5adc384f1cbbc74e0fefc82787e5083376",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-hip-runtime-asan-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      }
+    ],
+    "version": "6.3.4.60304"
   },
   "rocm-hip-sdk": {
     "deps": [
-      "composablekernel-dev",
+      "composablekernel-devel",
       "hipblas",
       "hipblaslt",
-      "hipcub-dev",
+      "hipcub-devel",
       "hipfft",
-      "hipfort-dev",
+      "hipfort-devel",
       "hiprand",
       "hipsolver",
       "hipsparse",
@@ -1667,28 +2345,28 @@
       "rocm-core",
       "rocm-hip-libraries",
       "rocm-hip-runtime",
-      "rocprim-dev",
+      "rocprim-devel",
       "rocrand",
       "rocsolver",
       "rocsparse",
-      "rocthrust-dev",
-      "rocwmma-dev"
+      "rocthrust-devel",
+      "rocwmma-devel"
     ],
     "components": [
       {
         "name": "rocm-hip-sdk",
-        "sha256": "212bea1d4eeb6c9e770c6727994ee51cf45a30ee5165cb7367b133607f1becf2",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-hip-sdk/rocm-hip-sdk_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "93bde1cfb16540749b0278bab0312a5c3cc61a291cdd309534fa312ecc8d86b8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-hip-sdk-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       },
       {
         "name": "rocm-hip-sdk-rpath",
-        "sha256": "335caff366a54a0cc9969163d7329d2952634b79bbb643a6361e87671d984444",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-hip-sdk-rpath6.3.4/rocm-hip-sdk-rpath6.3.4_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "40155cc04a8f673e4221975bbcfbaecfb7b436924118de76435ae2c7447706e0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-hip-sdk-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       }
     ],
-    "version": "6.3.4.60304-76"
+    "version": "6.3.4.60304"
   },
   "rocm-language-runtime": {
     "deps": [
@@ -1700,26 +2378,50 @@
     "components": [
       {
         "name": "rocm-language-runtime",
-        "sha256": "a55f0f0321771d78226aa613238ad59abdc0f6046d59d8397172f49e4bf37c54",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-language-runtime/rocm-language-runtime_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "7be13973682826d229c286b6a07ec72f1b3e9be1994d72ea1e1ac14cc15c7a2e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-language-runtime-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       },
       {
         "name": "rocm-language-runtime-rpath",
-        "sha256": "b7e454009afdd945a31c3732878162c6e81083d72e0d62895b01551c38fa84c3",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-language-runtime-rpath6.3.4/rocm-language-runtime-rpath6.3.4_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "0af39b08f1e7e53ff5c4097312bb0d0cf93796b33804a6bec71c036ffbe9feb7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-language-runtime-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       }
     ],
-    "version": "6.3.4.60304-76"
+    "version": "6.3.4.60304"
+  },
+  "rocm-language-runtime-asan": {
+    "deps": [
+      "comgr-asan",
+      "hsa-rocr-asan",
+      "openmp-extras-asan",
+      "rocm-core-asan",
+      "rocm-language-runtime"
+    ],
+    "components": [
+      {
+        "name": "rocm-language-runtime-asan",
+        "sha256": "3b3a51c046c3f6083f89a1b001bbd36ed71d2799229c0a82ee29578a424659bb",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-language-runtime-asan-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      },
+      {
+        "name": "rocm-language-runtime-asan-rpath",
+        "sha256": "6a54b9243d04bf89952403e16da6b21906c9a2ad3cf19e939a279be399a70bd1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-language-runtime-asan-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      }
+    ],
+    "version": "6.3.4.60304"
   },
   "rocm-libs": {
     "deps": [
-      "composablekernel-dev",
+      "composablekernel-devel",
       "half",
       "hipblas",
       "hipblaslt",
-      "hipcub-dev",
+      "hipcub-devel",
       "hipfft",
       "hiprand",
       "hipsolver",
@@ -1732,28 +2434,28 @@
       "rocblas",
       "rocfft",
       "rocm-core",
-      "rocprim-dev",
+      "rocprim-devel",
       "rocrand",
       "rocsolver",
       "rocsparse",
-      "rocthrust-dev",
-      "rocwmma-dev"
+      "rocthrust-devel",
+      "rocwmma-devel"
     ],
     "components": [
       {
         "name": "rocm-libs",
-        "sha256": "c160aea047ab1e4c9ca1d2652fd1938445a52cdf1ed06c9afa9876d50840e0f3",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-libs/rocm-libs_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "61e3534a0341e5303f7a7f39fc643fb674b2b2d16fee5357c75f61d90a57f4ba",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-libs-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       },
       {
         "name": "rocm-libs-rpath",
-        "sha256": "b6954d4cb93cb686e59cd9166a8428df6be6c54de3b839e717bbb75b4384ebdb",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-libs-rpath6.3.4/rocm-libs-rpath6.3.4_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "0a006b92125639969f48c65cd292927237dc322268b42589bb8f1e93a32e2f76",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-libs-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       }
     ],
-    "version": "6.3.4.60304-76"
+    "version": "6.3.4.60304"
   },
   "rocm-llvm": {
     "deps": [
@@ -1762,30 +2464,30 @@
     "components": [
       {
         "name": "rocm-llvm",
-        "sha256": "abcfd63d67e8d1648364076ead1b02577927992fea9f326edf1be43cc5238e9d",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-llvm/rocm-llvm_18.0.0.25012.60304-76~20.04_amd64.deb",
-        "version": "18.0.0.25012.60304-76"
+        "sha256": "8d793f422cd5a691e42f71355f1b9698d4ce207857034aa36c5adf783164bd92",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-llvm-18.0.0.25012.60304-76.el8.x86_64.rpm",
+        "version": "18.0.0.25012.60304"
       },
       {
-        "name": "rocm-llvm-dev",
-        "sha256": "948ee77f2df5aa7addf33df983c1e48157cf2f96520d43358c50e44313e8e58c",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-llvm-dev/rocm-llvm-dev_18.0.0.25012.60304-76~20.04_amd64.deb",
-        "version": "18.0.0.25012.60304-76"
+        "name": "rocm-llvm-devel",
+        "sha256": "dcf1355d646e50ce87edaa62eb842d6ae354fff5533657aac372ace0e6d8bef3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-llvm-devel-18.0.0.25012.60304-76.el8.x86_64.rpm",
+        "version": "18.0.0.25012.60304"
       },
       {
-        "name": "rocm-llvm-dev-rpath",
-        "sha256": "e3d36a9b6fd60cf494917fdc42ce3d667c0662885566ee8354b0f0723268c9c5",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-llvm-dev-rpath6.3.4/rocm-llvm-dev-rpath6.3.4_18.0.0.25012.60304-76~20.04_amd64.deb",
-        "version": "18.0.0.25012.60304-76"
+        "name": "rocm-llvm-devel-rpath",
+        "sha256": "445a43dd54e30d95dfd3bb671f7c1c2f727b858a379fda6d4d33d32a32afa789",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-llvm-devel-rpath6.3.4-18.0.0.25012.60304-76.el8.x86_64.rpm",
+        "version": "18.0.0.25012.60304"
       },
       {
         "name": "rocm-llvm-rpath",
-        "sha256": "1897d656ff8360ac8efdae7a0d4c8bddb5ff1630c9148276e79fa4c6f8775d96",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-llvm-rpath6.3.4/rocm-llvm-rpath6.3.4_18.0.0.25012.60304-76~20.04_amd64.deb",
-        "version": "18.0.0.25012.60304-76"
+        "sha256": "252e1b1eff6c3941be036f92e63e46c1be34fd1c40b568a38008f5b265cdd6a3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-llvm-rpath6.3.4-18.0.0.25012.60304-76.el8.x86_64.rpm",
+        "version": "18.0.0.25012.60304"
       }
     ],
-    "version": "18.0.0.25012.60304-76"
+    "version": "18.0.0.25012.60304"
   },
   "rocm-llvm-docs": {
     "deps": [
@@ -1794,18 +2496,18 @@
     "components": [
       {
         "name": "rocm-llvm-docs",
-        "sha256": "7842e9a3f11486f0e08b5cddebb16429c50925693d113c574ffaa2ba21de76e0",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-llvm-docs/rocm-llvm-docs_18.0.0.25012.60304-76~20.04_amd64.deb",
-        "version": "18.0.0.25012.60304-76"
+        "sha256": "a2721780b57ace059a58d55dabcf7b80214d3682d280767ee4c9862f7ed3f393",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-llvm-docs-18.0.0.25012.60304-76.el8.x86_64.rpm",
+        "version": "18.0.0.25012.60304"
       },
       {
         "name": "rocm-llvm-docs-rpath",
-        "sha256": "12329097398f19784cd84bf3ad0b40feff86bddc41b1dc44751e2f0940fa7913",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-llvm-docs-rpath6.3.4/rocm-llvm-docs-rpath6.3.4_18.0.0.25012.60304-76~20.04_amd64.deb",
-        "version": "18.0.0.25012.60304-76"
+        "sha256": "dacafb70a5aa15746b39dfde6f75071565f9f342c0e694d6c35778696fae9831",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-llvm-docs-rpath6.3.4-18.0.0.25012.60304-76.el8.x86_64.rpm",
+        "version": "18.0.0.25012.60304"
       }
     ],
-    "version": "18.0.0.25012.60304-76"
+    "version": "18.0.0.25012.60304"
   },
   "rocm-ml-libraries": {
     "deps": [
@@ -1818,18 +2520,41 @@
     "components": [
       {
         "name": "rocm-ml-libraries",
-        "sha256": "586b9138851ba02955c2b8dda8430a9a4f6901b2431ea9944ca832c306e5388f",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-ml-libraries/rocm-ml-libraries_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "65daabdab6d4dd7778b4d5994057a86e577b3f20919d2fe0a0aa21971c17ca3b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-ml-libraries-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       },
       {
         "name": "rocm-ml-libraries-rpath",
-        "sha256": "47ea8716b74fec050bd3922bcc2ade3b32a367cef263e5214e433d8abdada445",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-ml-libraries-rpath6.3.4/rocm-ml-libraries-rpath6.3.4_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "4dbf0c2a39f5a1dcf894f2da47cc282efba7b13bf4ae6bf3edfc836a797aee84",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-ml-libraries-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       }
     ],
-    "version": "6.3.4.60304-76"
+    "version": "6.3.4.60304"
+  },
+  "rocm-ml-libraries-asan": {
+    "deps": [
+      "miopen-hip-asan",
+      "rocm-core-asan",
+      "rocm-hip-libraries-asan",
+      "rocm-ml-libraries"
+    ],
+    "components": [
+      {
+        "name": "rocm-ml-libraries-asan",
+        "sha256": "cba8018a873672df8b2956113c1623cc628da79238616c43fe158b5ce9491142",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-ml-libraries-asan-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      },
+      {
+        "name": "rocm-ml-libraries-asan-rpath",
+        "sha256": "95298540534e1feb295126de09ea9409f8cbb700885fb584f2a3d98d38e9bf46",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-ml-libraries-asan-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      }
+    ],
+    "version": "6.3.4.60304"
   },
   "rocm-ml-sdk": {
     "deps": [
@@ -1841,36 +2566,58 @@
     "components": [
       {
         "name": "rocm-ml-sdk",
-        "sha256": "5c556e85d536cfe90f43e312ab30ae24ea36cbe088e7b175a65619d6af8027f3",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-ml-sdk/rocm-ml-sdk_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "41d48b8a57b01d8f61c2a8f16de7b13c0ed79541cb3d30c1afbbd7b22081285b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-ml-sdk-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       },
       {
         "name": "rocm-ml-sdk-rpath",
-        "sha256": "31d5af68fae9e8f27df10e911a37ceb2062dd3d12206961d07c7bb1302286342",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-ml-sdk-rpath6.3.4/rocm-ml-sdk-rpath6.3.4_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "b55b4df4e510fe6a6382dbcf0d7a1e7ccc74902d29ac0385fc2f5be531df5ae4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-ml-sdk-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       }
     ],
-    "version": "6.3.4.60304-76"
+    "version": "6.3.4.60304"
+  },
+  "rocm-ml-sdk-asan": {
+    "deps": [
+      "rocm-core-asan",
+      "rocm-ml-libraries-asan",
+      "rocm-ml-sdk"
+    ],
+    "components": [
+      {
+        "name": "rocm-ml-sdk-asan",
+        "sha256": "e90eeebbdeb0895720fb974ff63527411c5a0ba8fd583119661025bfb3b9460d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-ml-sdk-asan-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      },
+      {
+        "name": "rocm-ml-sdk-asan-rpath",
+        "sha256": "e3dc38176df6956042a9c1f0f2ddd5b2aa90dcd4d625cf61b930edd79b35c433",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-ml-sdk-asan-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      }
+    ],
+    "version": "6.3.4.60304"
   },
   "rocm-ocltst": {
     "deps": [],
     "components": [
       {
         "name": "rocm-ocltst",
-        "sha256": "1cb2e1906e8d154d221e6b57bfbec36fe616e94582dea447546acfd32491fac9",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-ocltst/rocm-ocltst_2.0.0.60304-76~20.04_amd64.deb",
-        "version": "2.0.0.60304-76"
+        "sha256": "fb7bc31f9a4e5579929b0e7499c6bd8a75f17e4a579fe83b27226d573a8f289c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-ocltst-2.0.0.60304-76.el8.x86_64.rpm",
+        "version": "2.0.0.60304"
       },
       {
         "name": "rocm-ocltst-rpath",
-        "sha256": "dd5ff5c5e7dd14e5bfc0b1b806bfd67ee5924be1926d727c340e71f87eba242d",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-ocltst-rpath6.3.4/rocm-ocltst-rpath6.3.4_2.0.0.60304-76~20.04_amd64.deb",
-        "version": "2.0.0.60304-76"
+        "sha256": "85d23ff39ef6a06cc87152ddfa4973cdbeef26223b1f6254d655db75f816fbd5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-ocltst-rpath6.3.4-2.0.0.60304-76.el8.x86_64.rpm",
+        "version": "2.0.0.60304"
       }
     ],
-    "version": "2.0.0.60304-76"
+    "version": "2.0.0.60304"
   },
   "rocm-opencl": {
     "deps": [
@@ -1881,30 +2628,52 @@
     "components": [
       {
         "name": "rocm-opencl",
-        "sha256": "9bd67352ee030b9d8690682982ec59ba0712199f2352cc5c8bf514dfd8363bb5",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-opencl/rocm-opencl_2.0.0.60304-76~20.04_amd64.deb",
-        "version": "2.0.0.60304-76"
+        "sha256": "ce2e4f0d12d0ab0f41c214c0c276aa36f65f6f85c05c03f7097ee762cbb5e799",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-opencl-2.0.0.60304-76.el8.x86_64.rpm",
+        "version": "2.0.0.60304"
       },
       {
-        "name": "rocm-opencl-dev",
-        "sha256": "70ba51393de011c11c3f710de9c43057822392164358656d8db6df9b790a182b",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-opencl-dev/rocm-opencl-dev_2.0.0.60304-76~20.04_amd64.deb",
-        "version": "2.0.0.60304-76"
+        "name": "rocm-opencl-devel",
+        "sha256": "ae09fd3fe76ba12ed2b0e7c885ae9f291ea65ef16b215582669f6dd68d379348",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-opencl-devel-2.0.0.60304-76.el8.x86_64.rpm",
+        "version": "2.0.0.60304"
       },
       {
-        "name": "rocm-opencl-dev-rpath",
-        "sha256": "c1d8219a4a3f797eed93bcfaf2ace5a299329686ddcafcb201fbfdc787619c77",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-opencl-dev-rpath6.3.4/rocm-opencl-dev-rpath6.3.4_2.0.0.60304-76~20.04_amd64.deb",
-        "version": "2.0.0.60304-76"
+        "name": "rocm-opencl-devel-rpath",
+        "sha256": "cdcc5cf036b2891449bc005a2825b1c9ba9559e77d427cf074ca5910f699b356",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-opencl-devel-rpath6.3.4-2.0.0.60304-76.el8.x86_64.rpm",
+        "version": "2.0.0.60304"
       },
       {
         "name": "rocm-opencl-rpath",
-        "sha256": "a3de926d4aa33f167a9cd9d44412d5d5ffd5975cba7d37ae8a874356c1b0de46",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-opencl-rpath6.3.4/rocm-opencl-rpath6.3.4_2.0.0.60304-76~20.04_amd64.deb",
-        "version": "2.0.0.60304-76"
+        "sha256": "08c2e1cb285b09634ef865dacfcd2df8b7940d2ef23b14793c228a8bd3f76432",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-opencl-rpath6.3.4-2.0.0.60304-76.el8.x86_64.rpm",
+        "version": "2.0.0.60304"
       }
     ],
-    "version": "2.0.0.60304-76"
+    "version": "2.0.0.60304"
+  },
+  "rocm-opencl-asan": {
+    "deps": [
+      "comgr-asan",
+      "hsa-rocr-asan",
+      "rocm-core-asan"
+    ],
+    "components": [
+      {
+        "name": "rocm-opencl-asan",
+        "sha256": "ea6abc12feeddee609ff6ea73b5dceaf592498a505d591c5fad33f557d9ff3c3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-opencl-asan-2.0.0.60304-76.el8.x86_64.rpm",
+        "version": "2.0.0.60304"
+      },
+      {
+        "name": "rocm-opencl-asan-rpath",
+        "sha256": "6dbc571492ce494db0ac03f4e6171dc5eea7c96aa05765d401f36f1baa29be70",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-opencl-asan-rpath6.3.4-2.0.0.60304-76.el8.x86_64.rpm",
+        "version": "2.0.0.60304"
+      }
+    ],
+    "version": "2.0.0.60304"
   },
   "rocm-opencl-runtime": {
     "deps": [
@@ -1915,18 +2684,41 @@
     "components": [
       {
         "name": "rocm-opencl-runtime",
-        "sha256": "12650e03de7ffdf3fd63d917a90ecc6aacbc25cc0838ce53d0e5010f0b367eed",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-opencl-runtime/rocm-opencl-runtime_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "018281fa4b347c2e1274b4447f4d57351d6e81589471c6be1eb81578fea76dec",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-opencl-runtime-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       },
       {
         "name": "rocm-opencl-runtime-rpath",
-        "sha256": "dcd784bb65207f765970bd046c082628d9a634009e0c706354f762f565c2c6c2",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-opencl-runtime-rpath6.3.4/rocm-opencl-runtime-rpath6.3.4_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "00c467121005b4bcbecfc1e4a2f563b705bc6409e3e76dca5e2cc1edeef6bbcb",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-opencl-runtime-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       }
     ],
-    "version": "6.3.4.60304-76"
+    "version": "6.3.4.60304"
+  },
+  "rocm-opencl-runtime-asan": {
+    "deps": [
+      "rocm-core-asan",
+      "rocm-language-runtime-asan",
+      "rocm-opencl-asan",
+      "rocm-opencl-runtime"
+    ],
+    "components": [
+      {
+        "name": "rocm-opencl-runtime-asan",
+        "sha256": "570862f129a6326943f8705582b56bbcb41c3ce125e257afd1acff9cdc6c5e2b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-opencl-runtime-asan-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      },
+      {
+        "name": "rocm-opencl-runtime-asan-rpath",
+        "sha256": "13417ed83c8d3b4ec3543e39cdb90f7d166954c64d1fa96f5c10f3e5e0e4fd5c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-opencl-runtime-asan-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
+      }
+    ],
+    "version": "6.3.4.60304"
   },
   "rocm-opencl-sdk": {
     "deps": [
@@ -1938,23 +2730,23 @@
     "components": [
       {
         "name": "rocm-opencl-sdk",
-        "sha256": "b50536f2264708e97370419f959f4e4a48593e3ab6906a819d14eb2263dc0721",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-opencl-sdk/rocm-opencl-sdk_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "6439f1b5bc6d2b34a7677919bc06b980b6b245e062ef6e68238d7aad68cc4b2e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-opencl-sdk-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       },
       {
         "name": "rocm-opencl-sdk-rpath",
-        "sha256": "66e3a82eb0508c73bbf13a2dc5bb8e8c968b2e5b67f442a6f8af1103488108cf",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-opencl-sdk-rpath6.3.4/rocm-opencl-sdk-rpath6.3.4_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "08db7c8c33df1dff39a40c1cb81b3c971842a1372c3df3568e8bbe59b5a25d83",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-opencl-sdk-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       }
     ],
-    "version": "6.3.4.60304-76"
+    "version": "6.3.4.60304"
   },
   "rocm-openmp-sdk": {
     "deps": [
       "hsa-rocr",
-      "openmp-extras-dev",
+      "openmp-extras-devel",
       "rocm-core",
       "rocm-device-libs",
       "rocm-language-runtime",
@@ -1963,18 +2755,18 @@
     "components": [
       {
         "name": "rocm-openmp-sdk",
-        "sha256": "cb4f65f482d81255a4a96feac65adba961021239cf461fc30282ae774086f626",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-openmp-sdk/rocm-openmp-sdk_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "5303a2394be49c0ce552a551841c6b5100a1b96855173c7c7adc1adabd06d74b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-openmp-sdk-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       },
       {
         "name": "rocm-openmp-sdk-rpath",
-        "sha256": "3fcb4755f95f769c757b92154fe249076f048969d9ce08b6ec034ed3e10b99ed",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-openmp-sdk-rpath6.3.4/rocm-openmp-sdk-rpath6.3.4_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "2d78f432e435b25ed5bef97d809ebffce4074c365d199b433f90b970304fd801",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-openmp-sdk-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       }
     ],
-    "version": "6.3.4.60304-76"
+    "version": "6.3.4.60304"
   },
   "rocm-smi-lib": {
     "deps": [
@@ -1983,18 +2775,38 @@
     "components": [
       {
         "name": "rocm-smi-lib",
-        "sha256": "84f3b2c4cb7f8f5eee708bef970f3c45352edcead8de66b496136f26e7fa3199",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-smi-lib/rocm-smi-lib_7.4.0.60304-76~20.04_amd64.deb",
-        "version": "7.4.0.60304-76"
+        "sha256": "c7a508f776f02f254c6f12531afb62d2fecf47183f087d57ffa6d5a20ff1f34d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-smi-lib-7.4.0.60304-76.el8.x86_64.rpm",
+        "version": "7.4.0.60304"
       },
       {
         "name": "rocm-smi-lib-rpath",
-        "sha256": "90e4ada71e35ef114af10320ca8045c29c089a91ef9a0abdca9f50998a3f989b",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-smi-lib-rpath6.3.4/rocm-smi-lib-rpath6.3.4_7.4.0.60304-76~20.04_amd64.deb",
-        "version": "7.4.0.60304-76"
+        "sha256": "52e6c6dcecf24c8dfa36f8bdffb24eb93c7372cbb76122709d0c69196eeef6f2",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-smi-lib-rpath6.3.4-7.4.0.60304-76.el8.x86_64.rpm",
+        "version": "7.4.0.60304"
       }
     ],
-    "version": "7.4.0.60304-76"
+    "version": "7.4.0.60304"
+  },
+  "rocm-smi-lib-asan": {
+    "deps": [
+      "rocm-core-asan"
+    ],
+    "components": [
+      {
+        "name": "rocm-smi-lib-asan",
+        "sha256": "db290d5b3f503610660818d1a8392405a2e8f7880bae083a21d6762285db7b11",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-smi-lib-asan-7.4.0.60304-76.el8.x86_64.rpm",
+        "version": "7.4.0.60304"
+      },
+      {
+        "name": "rocm-smi-lib-asan-rpath",
+        "sha256": "d9dbe0b604282338b3efe6c04f785018c293b26dd5a0b3fcf0c3390533029fd3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-smi-lib-asan-rpath6.3.4-7.4.0.60304-76.el8.x86_64.rpm",
+        "version": "7.4.0.60304"
+      }
+    ],
+    "version": "7.4.0.60304"
   },
   "rocm-utils": {
     "deps": [
@@ -2005,18 +2817,18 @@
     "components": [
       {
         "name": "rocm-utils",
-        "sha256": "972cf2defa6d46156b23e541cff0fe8160d13dffac73667d92421f93ed4e8226",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-utils/rocm-utils_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "58f1018826bbc079de4c1d46afa31790a7eddb1681136f946bc96be5841c6836",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-utils-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       },
       {
         "name": "rocm-utils-rpath",
-        "sha256": "3a9bfe4e90265c72f4305c3272e889310783d6c4e14ac9b88419f9d0ee6952c7",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-utils-rpath6.3.4/rocm-utils-rpath6.3.4_6.3.4.60304-76~20.04_amd64.deb",
-        "version": "6.3.4.60304-76"
+        "sha256": "360ddb031afa0caef2f4e46daee1f678e833589db802139e69b462621eb4b2f2",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-utils-rpath6.3.4-6.3.4.60304-76.el8.x86_64.rpm",
+        "version": "6.3.4.60304"
       }
     ],
-    "version": "6.3.4.60304-76"
+    "version": "6.3.4.60304"
   },
   "rocm-validation-suite": {
     "deps": [
@@ -2032,18 +2844,18 @@
     "components": [
       {
         "name": "rocm-validation-suite",
-        "sha256": "6f97bdc2575d9c3816cbec3963eb72a97c040103c463c3fd94ade5f5d4fc2b80",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-validation-suite/rocm-validation-suite_1.1.0.60304-76~20.04_amd64.deb",
-        "version": "1.1.0.60304-76"
+        "sha256": "f833a519e0a5608cb7f7e99656eb89a29af4e3b0637e322cb32ff587b5206e58",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-validation-suite-1.1.0.60304-76.el8.x86_64.rpm",
+        "version": "1.1.0.60304"
       },
       {
         "name": "rocm-validation-suite-rpath",
-        "sha256": "bb5a315f839bc026a7e66c37e5993c11b5fe433c8fadabe94a9776989c1cd4b6",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocm-validation-suite-rpath6.3.4/rocm-validation-suite-rpath6.3.4_1.1.0.60304-76~20.04_amd64.deb",
-        "version": "1.1.0.60304-76"
+        "sha256": "9c1a1f035159830ecb62a401643dd2748d52f4bcb8ad4471d8e5b9d680de3e0c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocm-validation-suite-rpath6.3.4-1.1.0.60304-76.el8.x86_64.rpm",
+        "version": "1.1.0.60304"
       }
     ],
-    "version": "1.1.0.60304-76"
+    "version": "1.1.0.60304"
   },
   "rocminfo": {
     "deps": [
@@ -2053,39 +2865,39 @@
     "components": [
       {
         "name": "rocminfo",
-        "sha256": "f3add3cf230f12e9103e608503216b2961e23d77e8f1bd06dc2e5e12fc4f46ec",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocminfo/rocminfo_1.0.0.60304-76~20.04_amd64.deb",
-        "version": "1.0.0.60304-76"
+        "sha256": "e7fa5e0bb90359787337436f0f67a41d9a6cca4a28c4cf8e6ebe9dddc060d674",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocminfo-1.0.0.60304-76.el8.x86_64.rpm",
+        "version": "1.0.0.60304"
       },
       {
         "name": "rocminfo-rpath",
-        "sha256": "b7a5914df25916a8fb330586ac98559a1806f0e5529a906a68aaf706172d3d10",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocminfo-rpath6.3.4/rocminfo-rpath6.3.4_1.0.0.60304-76~20.04_amd64.deb",
-        "version": "1.0.0.60304-76"
+        "sha256": "cf6598fe11fd34f60a7503e73d8785e2c876563cccfea070cf1c4a6e5266e1cb",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocminfo-rpath6.3.4-1.0.0.60304-76.el8.x86_64.rpm",
+        "version": "1.0.0.60304"
       }
     ],
-    "version": "1.0.0.60304-76"
+    "version": "1.0.0.60304"
   },
-  "rocprim-dev": {
+  "rocprim-devel": {
     "deps": [
       "hip-runtime-amd",
       "rocm-core"
     ],
     "components": [
       {
-        "name": "rocprim-dev",
-        "sha256": "10d50acebf433ca2a4bed982d75324fa361557c61af90dae40b1eb3e3c339e4c",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocprim-dev/rocprim-dev_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "name": "rocprim-devel",
+        "sha256": "f6eb3d4d2bdac110a04f39a34719b3a8c57067410e558206f57605a4c8ce1edb",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprim-devel-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       },
       {
-        "name": "rocprim-dev-rpath",
-        "sha256": "c3ef94e0105f1bce4c78674197b2565ef75efdd4e3546d3622cff48e5d41b57d",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocprim-dev-rpath6.3.4/rocprim-dev-rpath6.3.4_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "name": "rocprim-devel-rpath",
+        "sha256": "d71eac36d4ce2b79e4f9b899907cc3a2b402595cfee6395908860f133059a924",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprim-devel-rpath6.3.4-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       }
     ],
-    "version": "3.3.0.60304-76"
+    "version": "3.3.0.60304"
   },
   "rocprofiler": {
     "deps": [
@@ -2096,30 +2908,51 @@
     "components": [
       {
         "name": "rocprofiler",
-        "sha256": "4e8ff90d18030833e906147c93bd221ab9fd02d8c44ced76b36f4694a5579d7e",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocprofiler/rocprofiler_2.0.60304.60304-76~20.04_amd64.deb",
-        "version": "2.0.60304.60304-76"
+        "sha256": "4763bdd5fa85266098d6385eb42e1201a1055431c204ffc1e5bf52cdfb8b13fa",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprofiler-2.0.60304.60304-76.el8.x86_64.rpm",
+        "version": "2.0.60304.60304"
       },
       {
-        "name": "rocprofiler-dev",
-        "sha256": "207bd70d94b26b3b3f93fc0d4e0bacab8476d9b042243b9ddf1a2f1e282dc47a",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocprofiler-dev/rocprofiler-dev_2.0.60304.60304-76~20.04_amd64.deb",
-        "version": "2.0.60304.60304-76"
+        "name": "rocprofiler-devel",
+        "sha256": "d2021a4ed149770190c9c73d028942ccc06999c53ce9bc549f0273b15584d415",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprofiler-devel-2.0.60304.60304-76.el8.x86_64.rpm",
+        "version": "2.0.60304.60304"
       },
       {
-        "name": "rocprofiler-dev-rpath",
-        "sha256": "867e8b455f4c0500fb56f7bc6c5009814f3cd0ba2e5dcb25da559a2fc56d93f6",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocprofiler-dev-rpath6.3.4/rocprofiler-dev-rpath6.3.4_2.0.60304.60304-76~20.04_amd64.deb",
-        "version": "2.0.60304.60304-76"
+        "name": "rocprofiler-devel-rpath",
+        "sha256": "629c8fd7f19da913d70588477b4b95c377352ba18b505b11f113173feb2a97f4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprofiler-devel-rpath6.3.4-2.0.60304.60304-76.el8.x86_64.rpm",
+        "version": "2.0.60304.60304"
       },
       {
         "name": "rocprofiler-rpath",
-        "sha256": "de1c228f039538e7fe5c3eb0620f913a9dc5b333ca471817d7280f3dcc4cd336",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocprofiler-rpath6.3.4/rocprofiler-rpath6.3.4_2.0.60304.60304-76~20.04_amd64.deb",
-        "version": "2.0.60304.60304-76"
+        "sha256": "5586388adc9b8244aafae59a7f9b953879cb39e9baed858bf48785ee38102853",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprofiler-rpath6.3.4-2.0.60304.60304-76.el8.x86_64.rpm",
+        "version": "2.0.60304.60304"
       }
     ],
-    "version": "2.0.60304.60304-76"
+    "version": "2.0.60304.60304"
+  },
+  "rocprofiler-asan": {
+    "deps": [
+      "hsa-rocr-asan",
+      "rocm-core-asan"
+    ],
+    "components": [
+      {
+        "name": "rocprofiler-asan",
+        "sha256": "a24933ababad21bf872fe12954eed8ce6e6c04aa829883f92a2d1ca5f4aa8418",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprofiler-asan-2.0.60304.60304-76.el8.x86_64.rpm",
+        "version": "2.0.60304.60304"
+      },
+      {
+        "name": "rocprofiler-asan-rpath",
+        "sha256": "0d6b1e5002bc3aac8f90a675cb4a80194838b1ff4a612c3c2af254888121ad29",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprofiler-asan-rpath6.3.4-2.0.60304.60304-76.el8.x86_64.rpm",
+        "version": "2.0.60304.60304"
+      }
+    ],
+    "version": "2.0.60304.60304"
   },
   "rocprofiler-compute": {
     "deps": [
@@ -2128,18 +2961,18 @@
     "components": [
       {
         "name": "rocprofiler-compute",
-        "sha256": "e2fdb7d7bac4c8806c81577f320b83c0869a7c69aabac83a57f42c527675586c",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocprofiler-compute/rocprofiler-compute_3.0.0.60304-76~20.04_amd64.deb",
-        "version": "3.0.0.60304-76"
+        "sha256": "904db9efe7608124c768fa13b5365f15ce17a7399a5b359c78515c9830c5146c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprofiler-compute-3.0.0.60304-76.el8.x86_64.rpm",
+        "version": "3.0.0.60304"
       },
       {
         "name": "rocprofiler-compute-rpath",
-        "sha256": "66e484803f114bf51dff36ffd69b24356373fc015348192891180a354bd29907",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocprofiler-compute-rpath6.3.4/rocprofiler-compute-rpath6.3.4_3.0.0.60304-76~20.04_amd64.deb",
-        "version": "3.0.0.60304-76"
+        "sha256": "f85fa83b8378cf471d3e2a3f722a7ee1f3bacd62057573530da12866ec0220d6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprofiler-compute-rpath6.3.4-3.0.0.60304-76.el8.x86_64.rpm",
+        "version": "3.0.0.60304"
       }
     ],
-    "version": "3.0.0.60304-76"
+    "version": "3.0.0.60304"
   },
   "rocprofiler-docs": {
     "deps": [
@@ -2150,18 +2983,18 @@
     "components": [
       {
         "name": "rocprofiler-docs",
-        "sha256": "2cc1feb8a1fd38f6d0b07371e202bfed322def6188bd2a2d3ba392b625ec5cb3",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocprofiler-docs/rocprofiler-docs_2.0.60304.60304-76~20.04_amd64.deb",
-        "version": "2.0.60304.60304-76"
+        "sha256": "6d9740bed7aa3321b23f4c035617b064fff3eae495330c885274d11f8ef432c9",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprofiler-docs-2.0.60304.60304-76.el8.x86_64.rpm",
+        "version": "2.0.60304.60304"
       },
       {
         "name": "rocprofiler-docs-rpath",
-        "sha256": "fe6c0eb95535a0ee256c70b349118e4313ed35328c97454d36482ac96e60a1e8",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocprofiler-docs-rpath6.3.4/rocprofiler-docs-rpath6.3.4_2.0.60304.60304-76~20.04_amd64.deb",
-        "version": "2.0.60304.60304-76"
+        "sha256": "37f662171cc717a1aaa7d9e9422842046c4a0ad7967c64868a3e51c603721c3a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprofiler-docs-rpath6.3.4-2.0.60304.60304-76.el8.x86_64.rpm",
+        "version": "2.0.60304.60304"
       }
     ],
-    "version": "2.0.60304.60304-76"
+    "version": "2.0.60304.60304"
   },
   "rocprofiler-plugins": {
     "deps": [
@@ -2172,18 +3005,18 @@
     "components": [
       {
         "name": "rocprofiler-plugins",
-        "sha256": "30b30be0f672c88ae65d60a8153c931108afb14ec944f412d95f11fffdb3a7d1",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocprofiler-plugins/rocprofiler-plugins_2.0.60304.60304-76~20.04_amd64.deb",
-        "version": "2.0.60304.60304-76"
+        "sha256": "39c9a628adc78792a2a15d174454a50d6457585d4252fe293a2fb22c7948bd6a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprofiler-plugins-2.0.60304.60304-76.el8.x86_64.rpm",
+        "version": "2.0.60304.60304"
       },
       {
         "name": "rocprofiler-plugins-rpath",
-        "sha256": "a5141c75ac5306d6b3a83a50bd0646add6c10150a242c4f89a47a17e514a0c31",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocprofiler-plugins-rpath6.3.4/rocprofiler-plugins-rpath6.3.4_2.0.60304.60304-76~20.04_amd64.deb",
-        "version": "2.0.60304.60304-76"
+        "sha256": "1b4f266c985e4c56a777dc6d6b39e4ba61f6b94b3e409d2c03559a5be7a7cbd8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprofiler-plugins-rpath6.3.4-2.0.60304.60304-76.el8.x86_64.rpm",
+        "version": "2.0.60304.60304"
       }
     ],
-    "version": "2.0.60304.60304-76"
+    "version": "2.0.60304.60304"
   },
   "rocprofiler-register": {
     "deps": [
@@ -2192,18 +3025,18 @@
     "components": [
       {
         "name": "rocprofiler-register",
-        "sha256": "5ba4fb8cd0fc01a915f5c004adad62237efb76728bc69c0860eb7dae52c3c506",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocprofiler-register/rocprofiler-register_0.4.0.60304-76~20.04_amd64.deb",
-        "version": "0.4.0.60304-76"
+        "sha256": "26e6a93c6309139e7e7c41e094b6bf9e89d95567d03ebe3f2663bfc83c561af4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprofiler-register-0.4.0.60304-76.el8.x86_64.rpm",
+        "version": "0.4.0.60304"
       },
       {
         "name": "rocprofiler-register-rpath",
-        "sha256": "be99c270ab4751bd1d69c555405ef8060f292cacfd99969480d2376f9d33565c",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocprofiler-register-rpath6.3.4/rocprofiler-register-rpath6.3.4_0.4.0.60304-76~20.04_amd64.deb",
-        "version": "0.4.0.60304-76"
+        "sha256": "a2bb191f3666aa02a81768ee6fc4ce545f53ec53f9cdc6262ab6594078c52075",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprofiler-register-rpath6.3.4-0.4.0.60304-76.el8.x86_64.rpm",
+        "version": "0.4.0.60304"
       }
     ],
-    "version": "0.4.0.60304-76"
+    "version": "0.4.0.60304"
   },
   "rocprofiler-sdk": {
     "deps": [
@@ -2213,18 +3046,18 @@
     "components": [
       {
         "name": "rocprofiler-sdk",
-        "sha256": "6c79bb9311108e731e5bf826b559a31f0f0aa7a47364b315c8fce7721e2a2b47",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocprofiler-sdk/rocprofiler-sdk_0.5.0-76~20.04_amd64.deb",
-        "version": "0.5.0-76"
+        "sha256": "5a26585c6eae069c9b0ea5b13524b16e21fcdaa7494600da704fcb6306b6c0e0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprofiler-sdk-0.5.0.60304-76.el8.x86_64.rpm",
+        "version": "0.5.0.60304"
       },
       {
         "name": "rocprofiler-sdk-rpath",
-        "sha256": "59e0e665fc491608a8fbaa6570e432f6a8dc4336431e3f76afd805c39b6c4f6b",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocprofiler-sdk-rpath6.3.4/rocprofiler-sdk-rpath6.3.4_0.5.0-76~20.04_amd64.deb",
-        "version": "0.5.0-76"
+        "sha256": "2d75310b8cf7d0c3c1e21277f051558fd2ed37180a96fbda47e0a8833bd6ea73",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprofiler-sdk-rpath6.3.4-0.5.0.60304-76.el8.x86_64.rpm",
+        "version": "0.5.0.60304"
       }
     ],
-    "version": "0.5.0-76"
+    "version": "0.5.0.60304"
   },
   "rocprofiler-sdk-roctx": {
     "deps": [
@@ -2233,40 +3066,36 @@
     "components": [
       {
         "name": "rocprofiler-sdk-roctx",
-        "sha256": "ad1a958cad3e9dfc3df25f60aa7aeb4f9f36caccd7556d3cdccda23755502182",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocprofiler-sdk-roctx/rocprofiler-sdk-roctx_0.5.0-76~20.04_amd64.deb",
-        "version": "0.5.0-76"
+        "sha256": "716b7e34fb670e39adf574d916bf29b4e6c0e3fdec7cbc9aa9afaa1bf1a199f7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprofiler-sdk-roctx-0.5.0.60304-76.el8.x86_64.rpm",
+        "version": "0.5.0.60304"
       },
       {
         "name": "rocprofiler-sdk-roctx-rpath",
-        "sha256": "e3ccf3783b3d0074d3f671b77d433bc762a638fdba913abd9f07ce0fe4a7eeee",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocprofiler-sdk-roctx-rpath6.3.4/rocprofiler-sdk-roctx-rpath6.3.4_0.5.0-76~20.04_amd64.deb",
-        "version": "0.5.0-76"
+        "sha256": "c8ecba79b03a85a1cd15a6d513326f28243d2a5a204ffd6e208f5216d0f3e3d5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprofiler-sdk-roctx-rpath6.3.4-0.5.0.60304-76.el8.x86_64.rpm",
+        "version": "0.5.0.60304"
       }
     ],
-    "version": "0.5.0-76"
+    "version": "0.5.0.60304"
   },
   "rocprofiler-systems": {
-    "deps": [
-      "rocm-smi-lib",
-      "rocprofiler",
-      "roctracer"
-    ],
+    "deps": [],
     "components": [
       {
         "name": "rocprofiler-systems",
-        "sha256": "580f723dc003597a548d89ca59d355c134ead1077c1242e3c2ba759bd65d50a8",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocprofiler-systems/rocprofiler-systems_0.1.2.60304-76~20.04_amd64.deb",
-        "version": "0.1.2.60304-76"
+        "sha256": "6011dcf3a2107dbd4d7976f219cf7566907c08f1b649e23e264b9af6a5e14eec",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprofiler-systems-0.1.2.60304-76.el8.x86_64.rpm",
+        "version": "0.1.2.60304"
       },
       {
         "name": "rocprofiler-systems-rpath",
-        "sha256": "4215ed7228023004ab076b0d03e130599b917ad984f6414a5b307f80e915a375",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocprofiler-systems-rpath6.3.4/rocprofiler-systems-rpath6.3.4_0.1.2.60304-76~20.04_amd64.deb",
-        "version": "0.1.2.60304-76"
+        "sha256": "f8c5825a0147516b90d5d4eb6ee7a4d11a3371d993a07bcb9c2f3912ba0432ce",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocprofiler-systems-rpath6.3.4-0.1.2.60304-76.el8.x86_64.rpm",
+        "version": "0.1.2.60304"
       }
     ],
-    "version": "0.1.2.60304-76"
+    "version": "0.1.2.60304"
   },
   "rocrand": {
     "deps": [
@@ -2275,30 +3104,50 @@
     "components": [
       {
         "name": "rocrand",
-        "sha256": "1137e63eea1d1b57229d11b8e937992fb86ce2e139153330f769028fead6df67",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocrand/rocrand_3.2.0.60304-76~20.04_amd64.deb",
-        "version": "3.2.0.60304-76"
+        "sha256": "c4a0d4008c628d88d806f11c99f20ac276aedf4b7454e6db45f67a45a4dbb678",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocrand-3.2.0.60304-76.el8.x86_64.rpm",
+        "version": "3.2.0.60304"
       },
       {
-        "name": "rocrand-dev",
-        "sha256": "d07cd337e463335ffb0488acb3ceade9fd024444efcd40cc213bcf1846d7b5ae",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocrand-dev/rocrand-dev_3.2.0.60304-76~20.04_amd64.deb",
-        "version": "3.2.0.60304-76"
+        "name": "rocrand-devel",
+        "sha256": "86e1a9950bb9dc4bd4bf548fae03bbfef6c48cee5e3464fe305f423d47af410c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocrand-devel-3.2.0.60304-76.el8.x86_64.rpm",
+        "version": "3.2.0.60304"
       },
       {
-        "name": "rocrand-dev-rpath",
-        "sha256": "618c7d7d6a07ed5962f128a63a9faba42f583fbdc9f3ec4e5234ef355aa073ed",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocrand-dev-rpath6.3.4/rocrand-dev-rpath6.3.4_3.2.0.60304-76~20.04_amd64.deb",
-        "version": "3.2.0.60304-76"
+        "name": "rocrand-devel-rpath",
+        "sha256": "4acd4ec61afdf52938ab401469ca7e80e45ae8afb012ffaba703d0ab195c0399",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocrand-devel-rpath6.3.4-3.2.0.60304-76.el8.x86_64.rpm",
+        "version": "3.2.0.60304"
       },
       {
         "name": "rocrand-rpath",
-        "sha256": "9ba3326b7cb9f51a57d582b5d602c5d1f06d8b7723d57ab9e9ec3b4a4424a994",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocrand-rpath6.3.4/rocrand-rpath6.3.4_3.2.0.60304-76~20.04_amd64.deb",
-        "version": "3.2.0.60304-76"
+        "sha256": "d9e0599926e8850bcfae7c82d1e15394715ded2f8b8a2df1ceb2d34390c94197",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocrand-rpath6.3.4-3.2.0.60304-76.el8.x86_64.rpm",
+        "version": "3.2.0.60304"
       }
     ],
-    "version": "3.2.0.60304-76"
+    "version": "3.2.0.60304"
+  },
+  "rocrand-asan": {
+    "deps": [
+      "rocm-core-asan"
+    ],
+    "components": [
+      {
+        "name": "rocrand-asan",
+        "sha256": "97020c6de57305459bc746c5e3cbe41a25edfbd46979911ae7926e9b0109df0e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocrand-asan-3.2.0.60304-76.el8.x86_64.rpm",
+        "version": "3.2.0.60304"
+      },
+      {
+        "name": "rocrand-asan-rpath",
+        "sha256": "b8c94328a1d1950a897b09f66e5cc4759e1a10d3607a018e102df171b1f3bb18",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocrand-asan-rpath6.3.4-3.2.0.60304-76.el8.x86_64.rpm",
+        "version": "3.2.0.60304"
+      }
+    ],
+    "version": "3.2.0.60304"
   },
   "rocsolver": {
     "deps": [
@@ -2308,30 +3157,51 @@
     "components": [
       {
         "name": "rocsolver",
-        "sha256": "24124241de444af53cdb05163e38ea083cd2180e9ec8f911c86311a524e93f0d",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocsolver/rocsolver_3.27.0.60304-76~20.04_amd64.deb",
-        "version": "3.27.0.60304-76"
+        "sha256": "549acb9aec4c8190d120a7f51b02cb80331405c0220ffc60453772a35f1fe939",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocsolver-3.27.0.60304-76.el8.x86_64.rpm",
+        "version": "3.27.0.60304"
       },
       {
-        "name": "rocsolver-dev",
-        "sha256": "ab7580d88cdea7715e671cc14168ebfdfd8d911982f8e335a911792d59199ad4",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocsolver-dev/rocsolver-dev_3.27.0.60304-76~20.04_amd64.deb",
-        "version": "3.27.0.60304-76"
+        "name": "rocsolver-devel",
+        "sha256": "c10b14b0549840423ca19b7cf8f596f4968f469ec4eba4610c874d491139b4e2",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocsolver-devel-3.27.0.60304-76.el8.x86_64.rpm",
+        "version": "3.27.0.60304"
       },
       {
-        "name": "rocsolver-dev-rpath",
-        "sha256": "16080de1a7eccdbdc207e0f95e1f7c7f4fd9a8ae9fda73ae85f3b5e2e68eb5c1",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocsolver-dev-rpath6.3.4/rocsolver-dev-rpath6.3.4_3.27.0.60304-76~20.04_amd64.deb",
-        "version": "3.27.0.60304-76"
+        "name": "rocsolver-devel-rpath",
+        "sha256": "2aa3a63be510c0d26437e41ba08cf7d70e5a4b4721441305849e58ebeea936db",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocsolver-devel-rpath6.3.4-3.27.0.60304-76.el8.x86_64.rpm",
+        "version": "3.27.0.60304"
       },
       {
         "name": "rocsolver-rpath",
-        "sha256": "ea67d1c74539a66809b0e1d7e1ab74e3253a5babc3aab4bcbc982cbe7b14d372",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocsolver-rpath6.3.4/rocsolver-rpath6.3.4_3.27.0.60304-76~20.04_amd64.deb",
-        "version": "3.27.0.60304-76"
+        "sha256": "aae486c2a37e7375030c0651129727f07570a2d74f583cf388b3dc2220e16506",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocsolver-rpath6.3.4-3.27.0.60304-76.el8.x86_64.rpm",
+        "version": "3.27.0.60304"
       }
     ],
-    "version": "3.27.0.60304-76"
+    "version": "3.27.0.60304"
+  },
+  "rocsolver-asan": {
+    "deps": [
+      "rocblas",
+      "rocm-core-asan"
+    ],
+    "components": [
+      {
+        "name": "rocsolver-asan",
+        "sha256": "ca94bbb3008126654d583699a3f72dad84e7a5f037373dd10ead9472d602a256",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocsolver-asan-3.27.0.60304-76.el8.x86_64.rpm",
+        "version": "3.27.0.60304"
+      },
+      {
+        "name": "rocsolver-asan-rpath",
+        "sha256": "c0d9da21fe5b17ec8f16d378ae0477a6d710b3504f29c95e41b59700ca94a855",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocsolver-asan-rpath6.3.4-3.27.0.60304-76.el8.x86_64.rpm",
+        "version": "3.27.0.60304"
+      }
+    ],
+    "version": "3.27.0.60304"
   },
   "rocsparse": {
     "deps": [
@@ -2341,104 +3211,144 @@
     "components": [
       {
         "name": "rocsparse",
-        "sha256": "a9f933f7677c9818b6a8f8f2aa2e97344c9ff575e6b7e85845abddba591cea28",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocsparse/rocsparse_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "sha256": "a5967a27953bb664e5349b2225b59f7dcc1c81e34bd2de2a9e300c160417aa78",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocsparse-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       },
       {
-        "name": "rocsparse-dev",
-        "sha256": "740cdf0c9de716b6fce488a1785ddc7f96d2a4bdae7d08a0246a941297011c8a",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocsparse-dev/rocsparse-dev_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "name": "rocsparse-devel",
+        "sha256": "362662999c05f42599d6ca778ac22842a551fd1f0df3c4b6ded2732855f065c0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocsparse-devel-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       },
       {
-        "name": "rocsparse-dev-rpath",
-        "sha256": "693710669768bacb2edfdd47203c748793b63bc7d7b5f8621d59e37fef129a76",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocsparse-dev-rpath6.3.4/rocsparse-dev-rpath6.3.4_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "name": "rocsparse-devel-rpath",
+        "sha256": "c7203e4468c66a3c1debfd52aa57c73bedce72b723ab8c1bbd3af65a986b790f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocsparse-devel-rpath6.3.4-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       },
       {
         "name": "rocsparse-rpath",
-        "sha256": "75b5e94664a42c2b6dc1335303b4297801bfacd91615c1ba2fa4b598f1458f64",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocsparse-rpath6.3.4/rocsparse-rpath6.3.4_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "sha256": "5d8e6d20f6d3b902f0be826d39a7a7bff405f03ce5c9c32dd50748ee685d279c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocsparse-rpath6.3.4-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       }
     ],
-    "version": "3.3.0.60304-76"
+    "version": "3.3.0.60304"
   },
-  "rocthrust-dev": {
+  "rocsparse-asan": {
     "deps": [
-      "rocm-core",
-      "rocprim-dev"
+      "hip-runtime-amd-asan",
+      "rocm-core-asan"
     ],
     "components": [
       {
-        "name": "rocthrust-dev",
-        "sha256": "aec1b04e81aba8e9c68bacca4a6de14a6248d1790aff5663cb371617b3745358",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocthrust-dev/rocthrust-dev_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "name": "rocsparse-asan",
+        "sha256": "874c4fa18d918c250aa79d1cbd756ca6f9f6edff5d1eed7efead98346c3a5b3b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocsparse-asan-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       },
       {
-        "name": "rocthrust-dev-rpath",
-        "sha256": "dcc146668efb57d2f62e67b7d1d98a652a67065c8a39508427c334339b4c8c39",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocthrust-dev-rpath6.3.4/rocthrust-dev-rpath6.3.4_3.3.0.60304-76~20.04_amd64.deb",
-        "version": "3.3.0.60304-76"
+        "name": "rocsparse-asan-rpath",
+        "sha256": "1b0089dc920461059518e54d5327d900fc89c029af0aa147a3685434dc1b3c0f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocsparse-asan-rpath6.3.4-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
       }
     ],
-    "version": "3.3.0.60304-76"
+    "version": "3.3.0.60304"
+  },
+  "rocthrust-devel": {
+    "deps": [
+      "rocm-core",
+      "rocprim-devel"
+    ],
+    "components": [
+      {
+        "name": "rocthrust-devel",
+        "sha256": "059b0b2819795a221179c33fd6af285216ec0c69420dca10bf5a42ba57e87b40",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocthrust-devel-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
+      },
+      {
+        "name": "rocthrust-devel-rpath",
+        "sha256": "40ad7bce8e64f18b2e294c61c048e1079d11c572e2a9671eb69ec48eb15335cf",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocthrust-devel-rpath6.3.4-3.3.0.60304-76.el8.x86_64.rpm",
+        "version": "3.3.0.60304"
+      }
+    ],
+    "version": "3.3.0.60304"
   },
   "roctracer": {
     "deps": [
-      "hsa-rocr",
       "rocm-core"
     ],
     "components": [
       {
         "name": "roctracer",
-        "sha256": "c0ab988cce207fcdd87b88fa6c4aa30a8ae2bf981fa312f49ccfcdbfc6cade80",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/roctracer/roctracer_4.1.60304.60304-76~20.04_amd64.deb",
-        "version": "4.1.60304.60304-76"
+        "sha256": "53e0e4143b88baf4bc855cd51f16ab5886463646acc5be1cf3bb5501876377f3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/roctracer-4.1.60304.60304-76.el8.x86_64.rpm",
+        "version": "4.1.60304.60304"
       },
       {
-        "name": "roctracer-dev",
-        "sha256": "a34b7929d31e8adbfbbcbba8c38ccb6cc5eb6d5d236dbde5402e89b3994ce25f",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/roctracer-dev/roctracer-dev_4.1.60304.60304-76~20.04_amd64.deb",
-        "version": "4.1.60304.60304-76"
+        "name": "roctracer-devel",
+        "sha256": "c2b2f2b1ff316d33de1b810a5ff7cc0f0e2160dcd23a36d6d0909bb7af160b64",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/roctracer-devel-4.1.60304.60304-76.el8.x86_64.rpm",
+        "version": "4.1.60304.60304"
       },
       {
-        "name": "roctracer-dev-rpath",
-        "sha256": "970b3d7327d3880cc26b5b11bb66f385015d7d56ba2a6160c5bb969e0504c053",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/roctracer-dev-rpath6.3.4/roctracer-dev-rpath6.3.4_4.1.60304.60304-76~20.04_amd64.deb",
-        "version": "4.1.60304.60304-76"
+        "name": "roctracer-devel-rpath",
+        "sha256": "d7a18765aed466f75d9217c778a4f6ceba6442a31151bb3d1a41415fe8a73693",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/roctracer-devel-rpath6.3.4-4.1.60304.60304-76.el8.x86_64.rpm",
+        "version": "4.1.60304.60304"
       },
       {
         "name": "roctracer-rpath",
-        "sha256": "25a42b9e5e3939d29ed3f9285885935593971d34fb39d308fae78dc44db80156",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/roctracer-rpath6.3.4/roctracer-rpath6.3.4_4.1.60304.60304-76~20.04_amd64.deb",
-        "version": "4.1.60304.60304-76"
+        "sha256": "f091e485069d17c4d6b1a1ff21b8cca7c48aaec3d33670c723aed9d4e791cc85",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/roctracer-rpath6.3.4-4.1.60304.60304-76.el8.x86_64.rpm",
+        "version": "4.1.60304.60304"
       }
     ],
-    "version": "4.1.60304.60304-76"
+    "version": "4.1.60304.60304"
   },
-  "rocwmma-dev": {
+  "roctracer-asan": {
+    "deps": [
+      "rocm-core-asan"
+    ],
+    "components": [
+      {
+        "name": "roctracer-asan",
+        "sha256": "508b87677d2267199c5cdae35c745cd370e3375ca1e39ef5920faa9585055250",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/roctracer-asan-4.1.60304.60304-76.el8.x86_64.rpm",
+        "version": "4.1.60304.60304"
+      },
+      {
+        "name": "roctracer-asan-rpath",
+        "sha256": "8cf271405175836800ce47af7bce309f3dfac8594c02560f7b8c585d6d044fce",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/roctracer-asan-rpath6.3.4-4.1.60304.60304-76.el8.x86_64.rpm",
+        "version": "4.1.60304.60304"
+      }
+    ],
+    "version": "4.1.60304.60304"
+  },
+  "rocwmma-devel": {
     "deps": [
       "rocm-core"
     ],
     "components": [
       {
-        "name": "rocwmma-dev",
-        "sha256": "3893a7fb3c5b4eab44d6dc7b8ddfb0389ad45bf26fc0b3e72afc1f8b7f9ea637",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocwmma-dev/rocwmma-dev_1.6.0.60304-76~20.04_amd64.deb",
-        "version": "1.6.0.60304-76"
+        "name": "rocwmma-devel",
+        "sha256": "18e30f89573d63321625182fce8d2a663933646fcae34c0cf25309582683a8fb",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocwmma-devel-1.6.0.60304-76.el8.x86_64.rpm",
+        "version": "1.6.0.60304"
       },
       {
-        "name": "rocwmma-dev-rpath",
-        "sha256": "fb09ebb1333e86fd44870bf5d67e16e73008da089d6127618545034490a4d1c3",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rocwmma-dev-rpath6.3.4/rocwmma-dev-rpath6.3.4_1.6.0.60304-76~20.04_amd64.deb",
-        "version": "1.6.0.60304-76"
+        "name": "rocwmma-devel-rpath",
+        "sha256": "a62efeb004df95317b05d0ff0c6cc3e7b01f9af675d43fc7ed10f10143c9495b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rocwmma-devel-rpath6.3.4-1.6.0.60304-76.el8.x86_64.rpm",
+        "version": "1.6.0.60304"
       }
     ],
-    "version": "1.6.0.60304-76"
+    "version": "1.6.0.60304"
   },
   "rpp": {
     "deps": [
@@ -2448,30 +3358,50 @@
     "components": [
       {
         "name": "rpp",
-        "sha256": "4ec19d73fd047ab49e3e4e237204a6fb72c3ae95bab696e767a6e8a9d2e8c72c",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rpp/rpp_1.9.1.60304-76~20.04_amd64.deb",
-        "version": "1.9.1.60304-76"
+        "sha256": "1bd81aeebb102a97d8b8a64fa48997fd39b42665847bdfe25800cc3a919a6d3c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rpp-1.9.1.60304-76.el8.x86_64.rpm",
+        "version": "1.9.1.60304"
       },
       {
-        "name": "rpp-dev",
-        "sha256": "5c7cbcab119c926c8e05e50709cb36f718cd5be1a0ac901af6d297fd8a7be487",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rpp-dev/rpp-dev_1.9.1.60304-76~20.04_amd64.deb",
-        "version": "1.9.1.60304-76"
+        "name": "rpp-devel",
+        "sha256": "38e19a0d5e2cabbbf682fc0190af1121326517a3c959f94bae426287834dab83",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rpp-devel-1.9.1.60304-76.el8.x86_64.rpm",
+        "version": "1.9.1.60304"
       },
       {
-        "name": "rpp-dev-rpath",
-        "sha256": "92aa813c30c0c37550bebe0ab7a6f7dd322ef26b462277e281c7bc64a9f59ef5",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rpp-dev-rpath6.3.4/rpp-dev-rpath6.3.4_1.9.1.60304-76~20.04_amd64.deb",
-        "version": "1.9.1.60304-76"
+        "name": "rpp-devel-rpath",
+        "sha256": "976d48025f0624e507d1f8e98b6411a1ca053ec0e2702a20a1bf092171abffed",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rpp-devel-rpath6.3.4-1.9.1.60304-76.el8.x86_64.rpm",
+        "version": "1.9.1.60304"
       },
       {
         "name": "rpp-rpath",
-        "sha256": "5717f3af6cfdeed95cead4a6ce8ea554f0db57192924f7216a3b41cfe53f0b6a",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rpp-rpath6.3.4/rpp-rpath6.3.4_1.9.1.60304-76~20.04_amd64.deb",
-        "version": "1.9.1.60304-76"
+        "sha256": "b119410cdca350cbc13685c45a75ffde2e83188be7d0cc00773d8198b9e9a240",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rpp-rpath6.3.4-1.9.1.60304-76.el8.x86_64.rpm",
+        "version": "1.9.1.60304"
       }
     ],
-    "version": "1.9.1.60304-76"
+    "version": "1.9.1.60304"
+  },
+  "rpp-asan": {
+    "deps": [
+      "rocm-core-asan"
+    ],
+    "components": [
+      {
+        "name": "rpp-asan",
+        "sha256": "2aa29b9a019ac0581bd48716a2063bad029b26fbfc7d730578376d3d94f05710",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rpp-asan-1.9.1.60304-76.el8.x86_64.rpm",
+        "version": "1.9.1.60304"
+      },
+      {
+        "name": "rpp-asan-rpath",
+        "sha256": "4d935469b6a7c4b498db6f618fc5a6ed7c9d2f72d784081385cf73c7e92ba536",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rpp-asan-rpath6.3.4-1.9.1.60304-76.el8.x86_64.rpm",
+        "version": "1.9.1.60304"
+      }
+    ],
+    "version": "1.9.1.60304"
   },
   "rpp-test": {
     "deps": [
@@ -2480,38 +3410,38 @@
     "components": [
       {
         "name": "rpp-test",
-        "sha256": "d95ef5dde019bc8b2144961bf95376ade6a0f05dec658a7a359f5b2df714e007",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rpp-test/rpp-test_1.9.1.60304-76~20.04_amd64.deb",
-        "version": "1.9.1.60304-76"
+        "sha256": "f8b10bf4e7154ee091f1e83bb7dc39890735409cc8fa267060d8e649a9fa6122",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rpp-test-1.9.1.60304-76.el8.x86_64.rpm",
+        "version": "1.9.1.60304"
       },
       {
         "name": "rpp-test-rpath",
-        "sha256": "7ccb99797ab4964a421623042cf9aa2a94c21a614a6da168aad0cb72f8133886",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/r/rpp-test-rpath6.3.4/rpp-test-rpath6.3.4_1.9.1.60304-76~20.04_amd64.deb",
-        "version": "1.9.1.60304-76"
+        "sha256": "82798e5ac21544e7cc948cbfd694b2f735fa528be6c67dbf79579746771d3df0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/rpp-test-rpath6.3.4-1.9.1.60304-76.el8.x86_64.rpm",
+        "version": "1.9.1.60304"
       }
     ],
-    "version": "1.9.1.60304-76"
+    "version": "1.9.1.60304"
   },
-  "transferbench-dev": {
+  "transferbench-devel": {
     "deps": [
       "hsa-rocr",
       "rocm-core"
     ],
     "components": [
       {
-        "name": "transferbench-dev",
-        "sha256": "7e81cd511146e6ff3d5c82009ca05f130503249b6b7fa3dfe619377f182643a5",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/t/transferbench-dev/transferbench-dev_1.52.0.60304-76~20.04_amd64.deb",
-        "version": "1.52.0.60304-76"
+        "name": "transferbench-devel",
+        "sha256": "e66143f4887a0720a3846a9abd84f91c8b1c68b1b92dcb107fb09d0fa1383005",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/transferbench-devel-1.52.0.60304-76.el8.x86_64.rpm",
+        "version": "1.52.0.60304"
       },
       {
-        "name": "transferbench-dev-rpath",
-        "sha256": "11889db20252974d5721d21866abb6b1d92cfd00bc7371f1e3f360b7a401e5aa",
-        "url": "https://repo.radeon.com/rocm/apt/6.3.4/pool/main/t/transferbench-dev-rpath6.3.4/transferbench-dev-rpath6.3.4_1.52.0.60304-76~20.04_amd64.deb",
-        "version": "1.52.0.60304-76"
+        "name": "transferbench-devel-rpath",
+        "sha256": "f5ae00757e5a89c12d07ac0c3612c3c430c68a11e5e3b7caf9629a82762d3d3b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.3.4/main/transferbench-devel-rpath6.3.4-1.52.0.60304-76.el8.x86_64.rpm",
+        "version": "1.52.0.60304"
       }
     ],
-    "version": "1.52.0.60304-76"
+    "version": "1.52.0.60304"
   }
 }

--- a/pkgs/rocm-packages/rocm-6.4.1-metadata.json
+++ b/pkgs/rocm-packages/rocm-6.4.1-metadata.json
@@ -6,18 +6,18 @@
     "components": [
       {
         "name": "amd-smi-lib",
-        "sha256": "20a2da05812f33c02d717ee68eda98b231769016edb04f2416c32c0d1f57496a",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/a/amd-smi-lib/amd-smi-lib_25.4.2.60401-83~22.04_amd64.deb",
-        "version": "25.4.2.60401-83"
+        "sha256": "32788298d27f00879e3f67436ddb22660283dfc0bb6b123ed031321aaf457160",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/amd-smi-lib-25.4.2.60401-83.el8.x86_64.rpm",
+        "version": "25.4.2.60401"
       },
       {
         "name": "amd-smi-lib-rpath",
-        "sha256": "e63932ee741c9397d577a8008b2509dfc5adbd5edacbb8979554ede66dd0a758",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/a/amd-smi-lib-rpath6.4.1/amd-smi-lib-rpath6.4.1_25.4.2.60401-83~22.04_amd64.deb",
-        "version": "25.4.2.60401-83"
+        "sha256": "165be9b50cf993bbe0289ce888bc386d816dfbafc36bf507d8f80d0f39d3c772",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/amd-smi-lib-rpath6.4.1-25.4.2.60401-83.el8.x86_64.rpm",
+        "version": "25.4.2.60401"
       }
     ],
-    "version": "25.4.2.60401-83"
+    "version": "25.4.2.60401"
   },
   "amd-smi-lib-asan": {
     "deps": [
@@ -26,18 +26,18 @@
     "components": [
       {
         "name": "amd-smi-lib-asan",
-        "sha256": "fc58e66943f6b3f43433d6ae0b4ced6d997d69ee5f821781ad335408023eeed1",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/a/amd-smi-lib-asan/amd-smi-lib-asan_25.4.2.60401-83~22.04_amd64.deb",
-        "version": "25.4.2.60401-83"
+        "sha256": "cdfbd67c1b2a8f08bb4d1280eb4b39d3f33bad2be86b38b2b8ee29ff199801e1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/amd-smi-lib-asan-25.4.2.60401-83.el8.x86_64.rpm",
+        "version": "25.4.2.60401"
       },
       {
         "name": "amd-smi-lib-asan-rpath",
-        "sha256": "3a3ada9873d68b31e0992eafd40e7c835b1484fac489ca136db56fed8a0e5874",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/a/amd-smi-lib-asan-rpath6.4.1/amd-smi-lib-asan-rpath6.4.1_25.4.2.60401-83~22.04_amd64.deb",
-        "version": "25.4.2.60401-83"
+        "sha256": "12eadebb741517070c917f2d16e093158ed9895eaacccf51be0acda983c75dd4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/amd-smi-lib-asan-rpath6.4.1-25.4.2.60401-83.el8.x86_64.rpm",
+        "version": "25.4.2.60401"
       }
     ],
-    "version": "25.4.2.60401-83"
+    "version": "25.4.2.60401"
   },
   "comgr": {
     "deps": [
@@ -46,18 +46,18 @@
     "components": [
       {
         "name": "comgr",
-        "sha256": "ba02bdf830458668a39300ad082419f4bac3644bf5727c496846697e9fddf429",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/c/comgr/comgr_3.0.0.60401-83~22.04_amd64.deb",
-        "version": "3.0.0.60401-83"
+        "sha256": "9911ff791baad3530640fae774ffd5b176048c3b0232de66499620e0fa1836fa",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/comgr-3.0.0.60401-83.el8.x86_64.rpm",
+        "version": "3.0.0.60401"
       },
       {
         "name": "comgr-rpath",
-        "sha256": "a8fb3a6a855119aa793fb4d4eed3d2a1b43502165d012c4c2a5cfcc7ae2f82eb",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/c/comgr-rpath6.4.1/comgr-rpath6.4.1_3.0.0.60401-83~22.04_amd64.deb",
-        "version": "3.0.0.60401-83"
+        "sha256": "f2aa5ad30e6b08bdf27b721a56cc299ce03ec85bd2ce5f2783b1a3525f0785c9",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/comgr-rpath6.4.1-3.0.0.60401-83.el8.x86_64.rpm",
+        "version": "3.0.0.60401"
       }
     ],
-    "version": "3.0.0.60401-83"
+    "version": "3.0.0.60401"
   },
   "comgr-asan": {
     "deps": [
@@ -66,18 +66,18 @@
     "components": [
       {
         "name": "comgr-asan",
-        "sha256": "dbd07bee32c269ceb26eecd336b78529bfd023cd030fef53861046cbe8a8b185",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/c/comgr-asan/comgr-asan_3.0.0.60401-83~22.04_amd64.deb",
-        "version": "3.0.0.60401-83"
+        "sha256": "2188269d2bfcea109d27b2b1c3c56f99306f1221f2357675610d1af224774853",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/comgr-asan-3.0.0.60401-83.el8.x86_64.rpm",
+        "version": "3.0.0.60401"
       },
       {
         "name": "comgr-asan-rpath",
-        "sha256": "257381633c847fee3c9b3b0494d80e7351a7a4aa584b59a800e249ea1522e551",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/c/comgr-asan-rpath6.4.1/comgr-asan-rpath6.4.1_3.0.0.60401-83~22.04_amd64.deb",
-        "version": "3.0.0.60401-83"
+        "sha256": "d047dd0a7d1a0336872e615c622b9abfec08fce2d8c42b407bb185559fb01bfd",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/comgr-asan-rpath6.4.1-3.0.0.60401-83.el8.x86_64.rpm",
+        "version": "3.0.0.60401"
       }
     ],
-    "version": "3.0.0.60401-83"
+    "version": "3.0.0.60401"
   },
   "composablekernel-ckprofiler": {
     "deps": [
@@ -86,38 +86,38 @@
     "components": [
       {
         "name": "composablekernel-ckprofiler",
-        "sha256": "c5cd59b6a70b966634ace70a1149d004509c2df453f22bb063b6a05e35202ff5",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/c/composablekernel-ckprofiler/composablekernel-ckprofiler_1.1.0.60401-83~22.04_amd64.deb",
-        "version": "1.1.0.60401-83"
+        "sha256": "1bc44a342642ab8f107b836316cf80588ba78cea108e120da65094164e1852e2",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/composablekernel-ckprofiler-1.1.0.60401-83.el8.x86_64.rpm",
+        "version": "1.1.0.60401"
       },
       {
         "name": "composablekernel-ckprofiler-rpath",
-        "sha256": "0538a0391e2126f6fbd8c739ce5349e913f628902f8bcdd667e263788f930c78",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/c/composablekernel-ckprofiler-rpath6.4.1/composablekernel-ckprofiler-rpath6.4.1_1.1.0.60401-83~22.04_amd64.deb",
-        "version": "1.1.0.60401-83"
+        "sha256": "f883c6a3086153abe7546b4cfe9360449a5213af039a7bd414b5ae8fef9dbda8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/composablekernel-ckprofiler-rpath6.4.1-1.1.0.60401-83.el8.x86_64.rpm",
+        "version": "1.1.0.60401"
       }
     ],
-    "version": "1.1.0.60401-83"
+    "version": "1.1.0.60401"
   },
-  "composablekernel-dev": {
+  "composablekernel-devel": {
     "deps": [
       "rocm-core"
     ],
     "components": [
       {
-        "name": "composablekernel-dev",
-        "sha256": "27b8f62538a856e9769092f29bbdea2cfb6237b3b975539650645adc02a94066",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/c/composablekernel-dev/composablekernel-dev_1.1.0.60401-83~22.04_amd64.deb",
-        "version": "1.1.0.60401-83"
+        "name": "composablekernel-devel",
+        "sha256": "c3422cb8b2f7dae52dd0adaf09f1dcca839e6ae57ccc2b17d1e6ca363c491e02",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/composablekernel-devel-1.1.0.60401-83.el8.x86_64.rpm",
+        "version": "1.1.0.60401"
       },
       {
-        "name": "composablekernel-dev-rpath",
-        "sha256": "590113475c84ec1383645708e17109d64e05e47cb186bd1cdc8ed2cd06381397",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/c/composablekernel-dev-rpath6.4.1/composablekernel-dev-rpath6.4.1_1.1.0.60401-83~22.04_amd64.deb",
-        "version": "1.1.0.60401-83"
+        "name": "composablekernel-devel-rpath",
+        "sha256": "f7e88dc1513c15ed232d567c9d40d5727b3d45c8e288d02a459cdcc306b67068",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/composablekernel-devel-rpath6.4.1-1.1.0.60401-83.el8.x86_64.rpm",
+        "version": "1.1.0.60401"
       }
     ],
-    "version": "1.1.0.60401-83"
+    "version": "1.1.0.60401"
   },
   "half": {
     "deps": [
@@ -126,20 +126,20 @@
     "components": [
       {
         "name": "half",
-        "sha256": "5bffadcfc0c58bc1b8f5e6a3546bde8e4e2ec681d30973dc31afcdaa2952e832",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/half/half_1.12.0.60401-83~22.04_amd64.deb",
-        "version": "1.12.0.60401-83"
+        "sha256": "625cdc8b0deb57c98c06ced174d5bb959dc1d38ae92cc9ef054d197864f3977f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/half-1.12.0.60401-83.el8.x86_64.rpm",
+        "version": "1.12.0.60401"
       },
       {
         "name": "half-rpath",
-        "sha256": "ac848db18ea861e5ed94104df66de8ee86149f2c392d6ea9037f13d268f74ff8",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/half-rpath6.4.1/half-rpath6.4.1_1.12.0.60401-83~22.04_amd64.deb",
-        "version": "1.12.0.60401-83"
+        "sha256": "28c91aec5efb4fb3aeb422a84d2cc052c00b5324c34d83a94082a63a0874f9e8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/half-rpath6.4.1-1.12.0.60401-83.el8.x86_64.rpm",
+        "version": "1.12.0.60401"
       }
     ],
-    "version": "1.12.0.60401-83"
+    "version": "1.12.0.60401"
   },
-  "hip-dev": {
+  "hip-devel": {
     "deps": [
       "hip-runtime-amd",
       "hipcc",
@@ -149,40 +149,40 @@
     ],
     "components": [
       {
-        "name": "hip-dev",
-        "sha256": "e10323a872b833c7846f7a6d204efa8126b2b6b1727f6da317b687ea4da8fb0e",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hip-dev/hip-dev_6.4.43483.60401-83~22.04_amd64.deb",
-        "version": "6.4.43483.60401-83"
+        "name": "hip-devel",
+        "sha256": "8abb4187b277fa51f7e832fc966f7c2a07340e758ce7c4888accf0293a61bdd5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hip-devel-6.4.43483.60401-83.el8.x86_64.rpm",
+        "version": "6.4.43483.60401"
       },
       {
-        "name": "hip-dev-rpath",
-        "sha256": "37b7dc641a15b2aa02f1cd80a44a7cec7135371d323e99a35aaf33e4bb23413c",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hip-dev-rpath6.4.1/hip-dev-rpath6.4.1_6.4.43483.60401-83~22.04_amd64.deb",
-        "version": "6.4.43483.60401-83"
+        "name": "hip-devel-rpath",
+        "sha256": "c2e24671895209488e7da7caeed5e2ee5bbbe24a0819b46d4c1f8d5a66b98618",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hip-devel-rpath6.4.1-6.4.43483.60401-83.el8.x86_64.rpm",
+        "version": "6.4.43483.60401"
       }
     ],
-    "version": "6.4.43483.60401-83"
+    "version": "6.4.43483.60401"
   },
   "hip-doc": {
     "deps": [
-      "hip-dev",
+      "hip-devel",
       "rocm-core"
     ],
     "components": [
       {
         "name": "hip-doc",
-        "sha256": "e0b98e5975a1cb7aedc841a40de8c5681c9207359ccafe80c2a0278dde44ec30",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hip-doc/hip-doc_6.4.43483.60401-83~22.04_amd64.deb",
-        "version": "6.4.43483.60401-83"
+        "sha256": "d01c9f0c8325d4c2d8489dbb419f9c955a205c25bd9c547773219cb8d1458320",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hip-doc-6.4.43483.60401-83.el8.x86_64.rpm",
+        "version": "6.4.43483.60401"
       },
       {
         "name": "hip-doc-rpath",
-        "sha256": "22eeabe0e814f69f5cef28a61102343629379be9680d6293ed23282a3c5c60b7",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hip-doc-rpath6.4.1/hip-doc-rpath6.4.1_6.4.43483.60401-83~22.04_amd64.deb",
-        "version": "6.4.43483.60401-83"
+        "sha256": "147701325f2721c0a54446bced096ac3892ce395b54f11dd74b4c2b3a6b4c835",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hip-doc-rpath6.4.1-6.4.43483.60401-83.el8.x86_64.rpm",
+        "version": "6.4.43483.60401"
       }
     ],
-    "version": "6.4.43483.60401-83"
+    "version": "6.4.43483.60401"
   },
   "hip-runtime-amd": {
     "deps": [
@@ -195,18 +195,18 @@
     "components": [
       {
         "name": "hip-runtime-amd",
-        "sha256": "dee21498aa4fd4dd267efad563b4cc7fc3363d60f46b626c23681631f5f0cf79",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hip-runtime-amd/hip-runtime-amd_6.4.43483.60401-83~22.04_amd64.deb",
-        "version": "6.4.43483.60401-83"
+        "sha256": "4c9199427042590c636e1b4a96408289f9fe54fa2f913c237e2af8803337c1c9",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hip-runtime-amd-6.4.43483.60401-83.el8.x86_64.rpm",
+        "version": "6.4.43483.60401"
       },
       {
         "name": "hip-runtime-amd-rpath",
-        "sha256": "f02f0907490ec365393c8ddda19af2f9c4c9157e397a51e7fc313e3551892791",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hip-runtime-amd-rpath6.4.1/hip-runtime-amd-rpath6.4.1_6.4.43483.60401-83~22.04_amd64.deb",
-        "version": "6.4.43483.60401-83"
+        "sha256": "b7c01440f696f97a84f6db35966881e045a3e96481ceabfc1f689b30a999d5f0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hip-runtime-amd-rpath6.4.1-6.4.43483.60401-83.el8.x86_64.rpm",
+        "version": "6.4.43483.60401"
       }
     ],
-    "version": "6.4.43483.60401-83"
+    "version": "6.4.43483.60401"
   },
   "hip-runtime-amd-asan": {
     "deps": [
@@ -219,18 +219,18 @@
     "components": [
       {
         "name": "hip-runtime-amd-asan",
-        "sha256": "7c3d20d00f108581c772b32a1971a09c204e872ab2f92933559bec7d643532a8",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hip-runtime-amd-asan/hip-runtime-amd-asan_6.4.43483.60401-83~22.04_amd64.deb",
-        "version": "6.4.43483.60401-83"
+        "sha256": "c04e7b93addb4f05320b79ffb03da2b458dc40d5f8ace5c42fa6ac3230c92e75",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hip-runtime-amd-asan-6.4.43483.60401-83.el8.x86_64.rpm",
+        "version": "6.4.43483.60401"
       },
       {
         "name": "hip-runtime-amd-asan-rpath",
-        "sha256": "ca0c09dfd82499086db887ffbc705418b6b6817a37fa20e619cec41cc9390347",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hip-runtime-amd-asan-rpath6.4.1/hip-runtime-amd-asan-rpath6.4.1_6.4.43483.60401-83~22.04_amd64.deb",
-        "version": "6.4.43483.60401-83"
+        "sha256": "8736145209db67d4a6f4d8a0a531f776b7fc6d2cccf1afdb82ef5116b3bada87",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hip-runtime-amd-asan-rpath6.4.1-6.4.43483.60401-83.el8.x86_64.rpm",
+        "version": "6.4.43483.60401"
       }
     ],
-    "version": "6.4.43483.60401-83"
+    "version": "6.4.43483.60401"
   },
   "hip-runtime-nvidia": {
     "deps": [
@@ -240,44 +240,44 @@
     "components": [
       {
         "name": "hip-runtime-nvidia",
-        "sha256": "74d99c0b1db31b401bdc92daaa33c0981ce489b2a2acaa596683fa0eef883eb1",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hip-runtime-nvidia/hip-runtime-nvidia_6.4.43483.60401-83~22.04_amd64.deb",
-        "version": "6.4.43483.60401-83"
+        "sha256": "f7c4c06356aa2e2fe9f32b52f71a6e3b4b58e79efebab32eac0945bde5fad35d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hip-runtime-nvidia-6.4.43483.60401-83.el8.x86_64.rpm",
+        "version": "6.4.43483.60401"
       },
       {
         "name": "hip-runtime-nvidia-rpath",
-        "sha256": "69c0fcc06aa2c61a76621a68fb72cd608b9aa01099dbe316b0fc87ab887a9654",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hip-runtime-nvidia-rpath6.4.1/hip-runtime-nvidia-rpath6.4.1_6.4.43483.60401-83~22.04_amd64.deb",
-        "version": "6.4.43483.60401-83"
+        "sha256": "190573571957872f03d90e962dbfaafc5a57f7430ed55c32b7886b4a2413da13",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hip-runtime-nvidia-rpath6.4.1-6.4.43483.60401-83.el8.x86_64.rpm",
+        "version": "6.4.43483.60401"
       }
     ],
-    "version": "6.4.43483.60401-83"
+    "version": "6.4.43483.60401"
   },
   "hip-samples": {
     "deps": [
-      "hip-dev",
+      "hip-devel",
       "hipcc",
       "rocm-core"
     ],
     "components": [
       {
         "name": "hip-samples",
-        "sha256": "aec7e01c694592de65eab35842e9069e49ee054a0a866afeed6e6bca8b739218",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hip-samples/hip-samples_6.4.43483.60401-83~22.04_amd64.deb",
-        "version": "6.4.43483.60401-83"
+        "sha256": "cff55d969c5376b433ae61c41e49b3d209a8096d8025000a66c5046dba226d31",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hip-samples-6.4.43483.60401-83.el8.x86_64.rpm",
+        "version": "6.4.43483.60401"
       },
       {
         "name": "hip-samples-rpath",
-        "sha256": "b4fb6b59e76875d29c2feb003a951ab6ed1423f14df594ccd2bfd84e706b8817",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hip-samples-rpath6.4.1/hip-samples-rpath6.4.1_6.4.43483.60401-83~22.04_amd64.deb",
-        "version": "6.4.43483.60401-83"
+        "sha256": "dc795e5c0cc4f5c6972d60f7bef4cd4afd1a5025fd01bd0ee5633aa9ca2a7b5a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hip-samples-rpath6.4.1-6.4.43483.60401-83.el8.x86_64.rpm",
+        "version": "6.4.43483.60401"
       }
     ],
-    "version": "6.4.43483.60401-83"
+    "version": "6.4.43483.60401"
   },
   "hipblas": {
     "deps": [
-      "hipblas-common-dev",
+      "hipblas-common-devel",
       "rocblas",
       "rocm-core",
       "rocsolver"
@@ -285,30 +285,30 @@
     "components": [
       {
         "name": "hipblas",
-        "sha256": "9d1bb3a5006a5b69655abbd890efaad1d347b3cd66b5d0a7fe60a6885494b19b",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipblas/hipblas_2.4.0.60401-83~22.04_amd64.deb",
-        "version": "2.4.0.60401-83"
+        "sha256": "0b6997051c500c7888223a92df95a3f8c397f63d5601cfd0549641fc59954fc4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipblas-2.4.0.60401-83.el8.x86_64.rpm",
+        "version": "2.4.0.60401"
       },
       {
-        "name": "hipblas-dev",
-        "sha256": "df5dd894a6840693f060fcdd1e96c0e8cf9eed16b2763643f17a5a9c4baa69a5",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipblas-dev/hipblas-dev_2.4.0.60401-83~22.04_amd64.deb",
-        "version": "2.4.0.60401-83"
+        "name": "hipblas-devel",
+        "sha256": "79d8f76a87e3d3a751771a05621d1a6e4c033d4e3237805705a6db807d37f7a3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipblas-devel-2.4.0.60401-83.el8.x86_64.rpm",
+        "version": "2.4.0.60401"
       },
       {
-        "name": "hipblas-dev-rpath",
-        "sha256": "57b8981b1cc113393a9b1667b9848781af29bd2a89b2a10ea5fc63177287694b",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipblas-dev-rpath6.4.1/hipblas-dev-rpath6.4.1_2.4.0.60401-83~22.04_amd64.deb",
-        "version": "2.4.0.60401-83"
+        "name": "hipblas-devel-rpath",
+        "sha256": "790e288c1c4ad7b5ee08061085d34669319a81e92b392c80c097f0bd943d4b8b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipblas-devel-rpath6.4.1-2.4.0.60401-83.el8.x86_64.rpm",
+        "version": "2.4.0.60401"
       },
       {
         "name": "hipblas-rpath",
-        "sha256": "cdc7fbd02b3d7cf17eeae64ada9655534f4c44ef79b31a85efc96119e234cc1c",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipblas-rpath6.4.1/hipblas-rpath6.4.1_2.4.0.60401-83~22.04_amd64.deb",
-        "version": "2.4.0.60401-83"
+        "sha256": "878523bed83e41f6c82946771aae6468ef2cec0edaead36437dee77a54dee2de",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipblas-rpath6.4.1-2.4.0.60401-83.el8.x86_64.rpm",
+        "version": "2.4.0.60401"
       }
     ],
-    "version": "2.4.0.60401-83"
+    "version": "2.4.0.60401"
   },
   "hipblas-asan": {
     "deps": [
@@ -319,72 +319,72 @@
     "components": [
       {
         "name": "hipblas-asan",
-        "sha256": "7a1f57caeaf6dac5b53732ac92f812b941bf43dba65174d9c67b27ca3db5d119",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipblas-asan/hipblas-asan_2.4.0.60401-83~22.04_amd64.deb",
-        "version": "2.4.0.60401-83"
+        "sha256": "d8a4a9263825287212cd086eae6cd390369bcd25725fdf118a78ba1de0ed8926",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipblas-asan-2.4.0.60401-83.el8.x86_64.rpm",
+        "version": "2.4.0.60401"
       },
       {
         "name": "hipblas-asan-rpath",
-        "sha256": "ab82790eeae5ce9358a67dfca1865ba7a1878137753319829a45db03b70ed7b3",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipblas-asan-rpath6.4.1/hipblas-asan-rpath6.4.1_2.4.0.60401-83~22.04_amd64.deb",
-        "version": "2.4.0.60401-83"
+        "sha256": "c7aa62a421dae058b49903cba935686aeab106179c84c4e2dca5e40bf92beb4f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipblas-asan-rpath6.4.1-2.4.0.60401-83.el8.x86_64.rpm",
+        "version": "2.4.0.60401"
       }
     ],
-    "version": "2.4.0.60401-83"
+    "version": "2.4.0.60401"
   },
-  "hipblas-common-dev": {
+  "hipblas-common-devel": {
     "deps": [
       "rocm-core"
     ],
     "components": [
       {
-        "name": "hipblas-common-dev",
-        "sha256": "5df3e4a8a1959cbf94106f7bf87d7fb71bf06e726cde00c6092ef29bbd8156f0",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipblas-common-dev/hipblas-common-dev_1.0.0.60401-83~22.04_amd64.deb",
-        "version": "1.0.0.60401-83"
+        "name": "hipblas-common-devel",
+        "sha256": "9c74e2d5c1bc455aa0e0971f49ba8c1647affb697c17761251aa12d3b69836d8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipblas-common-devel-1.0.0.60401-83.el8.x86_64.rpm",
+        "version": "1.0.0.60401"
       },
       {
-        "name": "hipblas-common-dev-rpath",
-        "sha256": "8cc90a33fc76a52bdafed839fb13022ceba12beaddb2290c8a3107a17214ca90",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipblas-common-dev-rpath6.4.1/hipblas-common-dev-rpath6.4.1_1.0.0.60401-83~22.04_amd64.deb",
-        "version": "1.0.0.60401-83"
+        "name": "hipblas-common-devel-rpath",
+        "sha256": "8a7903323873504ea2e93c1c77fd2c309c293791bf17530d64199082b31f0e88",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipblas-common-devel-rpath6.4.1-1.0.0.60401-83.el8.x86_64.rpm",
+        "version": "1.0.0.60401"
       }
     ],
-    "version": "1.0.0.60401-83"
+    "version": "1.0.0.60401"
   },
   "hipblaslt": {
     "deps": [
-      "hipblas-common-dev",
+      "hipblas-common-devel",
       "rocm-core",
       "roctracer"
     ],
     "components": [
       {
         "name": "hipblaslt",
-        "sha256": "23e6facad7bd1a17223761e06e9c6d1561c5a9e80f052e5f1589d21ab7167e9e",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipblaslt/hipblaslt_0.12.1.60401-83~22.04_amd64.deb",
-        "version": "0.12.1.60401-83"
+        "sha256": "0acdb6028f31536d0fd24bb4a200e8aab569f6e80b415de98305e09a384458ec",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipblaslt-0.12.1.60401-83.el8.x86_64.rpm",
+        "version": "0.12.1.60401"
       },
       {
-        "name": "hipblaslt-dev",
-        "sha256": "46eb2285c76d246b162eb54cc7f9e5cb7bcdd0aa83d57ecaea440e57260f2f4a",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipblaslt-dev/hipblaslt-dev_0.12.1.60401-83~22.04_amd64.deb",
-        "version": "0.12.1.60401-83"
+        "name": "hipblaslt-devel",
+        "sha256": "be3b3f77f8571426e4f3402a0cf3fd057b5f634eb3a7190bb239384f5c183ac7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipblaslt-devel-0.12.1.60401-83.el8.x86_64.rpm",
+        "version": "0.12.1.60401"
       },
       {
-        "name": "hipblaslt-dev-rpath",
-        "sha256": "f14feb947a230dc7f4dcca3e93d943e82c98002873d3c718a8da84846b94c256",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipblaslt-dev-rpath6.4.1/hipblaslt-dev-rpath6.4.1_0.12.1.60401-83~22.04_amd64.deb",
-        "version": "0.12.1.60401-83"
+        "name": "hipblaslt-devel-rpath",
+        "sha256": "6cbba1ac7b9208fe4a76ae3a47afb40a925192061859b404453bc203fb9f6774",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipblaslt-devel-rpath6.4.1-0.12.1.60401-83.el8.x86_64.rpm",
+        "version": "0.12.1.60401"
       },
       {
         "name": "hipblaslt-rpath",
-        "sha256": "867442899684c74bce696a45e09bd7d4bed45fda874dd2a48a71799ebb751f33",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipblaslt-rpath6.4.1/hipblaslt-rpath6.4.1_0.12.1.60401-83~22.04_amd64.deb",
-        "version": "0.12.1.60401-83"
+        "sha256": "46790f151112808076a304510f0c0b910b1a0951d0b71322727f050757ccfa40",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipblaslt-rpath6.4.1-0.12.1.60401-83.el8.x86_64.rpm",
+        "version": "0.12.1.60401"
       }
     ],
-    "version": "0.12.1.60401-83"
+    "version": "0.12.1.60401"
   },
   "hipblaslt-asan": {
     "deps": [
@@ -394,18 +394,18 @@
     "components": [
       {
         "name": "hipblaslt-asan",
-        "sha256": "52e51caa03cbc0671c8722120f13b648a90e7a07043652394640a1077fce64b4",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipblaslt-asan/hipblaslt-asan_0.12.1.60401-83~22.04_amd64.deb",
-        "version": "0.12.1.60401-83"
+        "sha256": "67f1d1092664757a1bd7af3a3d851283d6c8fdf2ce0cd102cd13d593df1fd0e1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipblaslt-asan-0.12.1.60401-83.el8.x86_64.rpm",
+        "version": "0.12.1.60401"
       },
       {
         "name": "hipblaslt-asan-rpath",
-        "sha256": "5efa7df4853a791b848e4f04509b7654370f31f3c980fd55f80df007cbda9a7d",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipblaslt-asan-rpath6.4.1/hipblaslt-asan-rpath6.4.1_0.12.1.60401-83~22.04_amd64.deb",
-        "version": "0.12.1.60401-83"
+        "sha256": "4f0c27a2d3fdcb9b63e53d64a5f6b88e1dcda760aa89c3badeb39097372bf390",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipblaslt-asan-rpath6.4.1-0.12.1.60401-83.el8.x86_64.rpm",
+        "version": "0.12.1.60401"
       }
     ],
-    "version": "0.12.1.60401-83"
+    "version": "0.12.1.60401"
   },
   "hipcc": {
     "deps": [
@@ -415,18 +415,18 @@
     "components": [
       {
         "name": "hipcc",
-        "sha256": "71aabfdefdd126fe6145b0e21be6964371d550b4be1b955095db6cbb53f9e146",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipcc/hipcc_1.1.1.60401-83~22.04_amd64.deb",
-        "version": "1.1.1.60401-83"
+        "sha256": "a71a4378a77905ce540dc690e010b7c2e7647d10688cc4516792e99e075b854c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipcc-1.1.1.60401-83.el8.x86_64.rpm",
+        "version": "1.1.1.60401"
       },
       {
         "name": "hipcc-rpath",
-        "sha256": "3ce6aa33bae886a3d44941eb984d02a049b904e7aacaa1c2b10904d72ef8cc76",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipcc-rpath6.4.1/hipcc-rpath6.4.1_1.1.1.60401-83~22.04_amd64.deb",
-        "version": "1.1.1.60401-83"
+        "sha256": "6ab3666cb37f3ade62c418a7bd0f635d6f45086315aced1a6cce642d40a77107",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipcc-rpath6.4.1-1.1.1.60401-83.el8.x86_64.rpm",
+        "version": "1.1.1.60401"
       }
     ],
-    "version": "1.1.1.60401-83"
+    "version": "1.1.1.60401"
   },
   "hipcc-nvidia": {
     "deps": [
@@ -435,39 +435,39 @@
     "components": [
       {
         "name": "hipcc-nvidia",
-        "sha256": "8493448cef4a8af9fdd111b4673cd4bbbdb8d561d9a4a412fc20d1feab73d4a7",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipcc-nvidia/hipcc-nvidia_1.1.1.60401-83~22.04_amd64.deb",
-        "version": "1.1.1.60401-83"
+        "sha256": "a8313f76a195f30561d98794e524d649937d8e41e54027552ebccf2123770941",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipcc-nvidia-1.1.1.60401-83.el8.x86_64.rpm",
+        "version": "1.1.1.60401"
       },
       {
         "name": "hipcc-nvidia-rpath",
-        "sha256": "64c4d74760324d2f06598d7f63837ac7f96a3a7a0982be5b02ab187f8098d0bb",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipcc-nvidia-rpath6.4.1/hipcc-nvidia-rpath6.4.1_1.1.1.60401-83~22.04_amd64.deb",
-        "version": "1.1.1.60401-83"
+        "sha256": "fec654b09b1e139b930dc259a64e0117f8160dd46e613565a015aff03bbe1e3f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipcc-nvidia-rpath6.4.1-1.1.1.60401-83.el8.x86_64.rpm",
+        "version": "1.1.1.60401"
       }
     ],
-    "version": "1.1.1.60401-83"
+    "version": "1.1.1.60401"
   },
-  "hipcub-dev": {
+  "hipcub-devel": {
     "deps": [
       "rocm-core",
-      "rocprim-dev"
+      "rocprim-devel"
     ],
     "components": [
       {
-        "name": "hipcub-dev",
-        "sha256": "fb30135690cb247862ab997caec1f92757ac69ed0f734659166dc159a946f407",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipcub-dev/hipcub-dev_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "name": "hipcub-devel",
+        "sha256": "d0a1c84c01f088ecf1d2653054ee5c4b34e0dfc7ef9a27216519f542873d9f73",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipcub-devel-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       },
       {
-        "name": "hipcub-dev-rpath",
-        "sha256": "656720e7f396b1a581c7c902c06e84c60e6be07cf2b6d69d04feeee60f2aee84",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipcub-dev-rpath6.4.1/hipcub-dev-rpath6.4.1_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "name": "hipcub-devel-rpath",
+        "sha256": "7f0d58b415d5807dded283c528eaa45338362b4877ac2f524969716ed57e047c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipcub-devel-rpath6.4.1-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       }
     ],
-    "version": "3.4.0.60401-83"
+    "version": "3.4.0.60401"
   },
   "hipfft": {
     "deps": [
@@ -477,30 +477,30 @@
     "components": [
       {
         "name": "hipfft",
-        "sha256": "64f2bc139adf53f00affdda5b189d60d491b93a7260c4cbcffc7b26af6569348",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipfft/hipfft_1.0.18.60401-83~22.04_amd64.deb",
-        "version": "1.0.18.60401-83"
+        "sha256": "b23e4f1bf5fa6fe547c32336c086f2f9fc57777508568b72d42f95f6c089f187",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipfft-1.0.18.60401-83.el8.x86_64.rpm",
+        "version": "1.0.18.60401"
       },
       {
-        "name": "hipfft-dev",
-        "sha256": "6b7e88ebedd52ec2203679c786f738484d6f2150fe7dca5a90427141a889ed5b",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipfft-dev/hipfft-dev_1.0.18.60401-83~22.04_amd64.deb",
-        "version": "1.0.18.60401-83"
+        "name": "hipfft-devel",
+        "sha256": "c836004fc02aab8f9225c762efeeb5bb660d77ef532797e92d8f23712b4a604f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipfft-devel-1.0.18.60401-83.el8.x86_64.rpm",
+        "version": "1.0.18.60401"
       },
       {
-        "name": "hipfft-dev-rpath",
-        "sha256": "a817ed79b0eb5153e5b1936008d3f15daa82eb006f2172d746f179d3012f75f7",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipfft-dev-rpath6.4.1/hipfft-dev-rpath6.4.1_1.0.18.60401-83~22.04_amd64.deb",
-        "version": "1.0.18.60401-83"
+        "name": "hipfft-devel-rpath",
+        "sha256": "8893fcbbfaaaf53540b9f3b187acc031b7a7473a0f4b4458d5dc1f8f3e9638fb",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipfft-devel-rpath6.4.1-1.0.18.60401-83.el8.x86_64.rpm",
+        "version": "1.0.18.60401"
       },
       {
         "name": "hipfft-rpath",
-        "sha256": "b767c1c9f962aca102710e4a48f0a2ed3adc01a83b3d28db36ebf06a3bfb0d73",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipfft-rpath6.4.1/hipfft-rpath6.4.1_1.0.18.60401-83~22.04_amd64.deb",
-        "version": "1.0.18.60401-83"
+        "sha256": "279dbe71d00330c39c061da22a4a8d61388fdb3db8680f4ab7cefe7652c323bc",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipfft-rpath6.4.1-1.0.18.60401-83.el8.x86_64.rpm",
+        "version": "1.0.18.60401"
       }
     ],
-    "version": "1.0.18.60401-83"
+    "version": "1.0.18.60401"
   },
   "hipfft-asan": {
     "deps": [
@@ -510,39 +510,39 @@
     "components": [
       {
         "name": "hipfft-asan",
-        "sha256": "0b7bdbc1849ebb5d2ce3919860e2c5061c982cec1c7163171e7a124ea2d180f5",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipfft-asan/hipfft-asan_1.0.18.60401-83~22.04_amd64.deb",
-        "version": "1.0.18.60401-83"
+        "sha256": "54898c3ecf84a93119d99b28070dded5c4571199a08fda818dc71d6cd776a009",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipfft-asan-1.0.18.60401-83.el8.x86_64.rpm",
+        "version": "1.0.18.60401"
       },
       {
         "name": "hipfft-asan-rpath",
-        "sha256": "6f21557be0a8d5bdfa9f4f363f37d81d5e3ef5d1beb5ef6fff556482dd4a0bc2",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipfft-asan-rpath6.4.1/hipfft-asan-rpath6.4.1_1.0.18.60401-83~22.04_amd64.deb",
-        "version": "1.0.18.60401-83"
+        "sha256": "b9cc1fc9f7ef71cdc98ee0787e7d611a300766b65fcc5436f079636edf47236c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipfft-asan-rpath6.4.1-1.0.18.60401-83.el8.x86_64.rpm",
+        "version": "1.0.18.60401"
       }
     ],
-    "version": "1.0.18.60401-83"
+    "version": "1.0.18.60401"
   },
-  "hipfort-dev": {
+  "hipfort-devel": {
     "deps": [
       "hip-runtime-amd",
       "rocm-core"
     ],
     "components": [
       {
-        "name": "hipfort-dev",
-        "sha256": "5ba22767b8fb737dd8b307444b543cda232ec692d716bd43006ed1514ec91053",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipfort-dev/hipfort-dev_0.6.0.60401-83~22.04_amd64.deb",
-        "version": "0.6.0.60401-83"
+        "name": "hipfort-devel",
+        "sha256": "6bbc2e584e6a7085e20e3721f51bc7096f08138ee3a93b3c80fd0da9bb0b3330",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipfort-devel-0.6.0.60401-83.el8.x86_64.rpm",
+        "version": "0.6.0.60401"
       },
       {
-        "name": "hipfort-dev-rpath",
-        "sha256": "67ae4968ebbd7981a0eedcf7d7eeb052f381cdeb9e63e1014def7c99cfce510a",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipfort-dev-rpath6.4.1/hipfort-dev-rpath6.4.1_0.6.0.60401-83~22.04_amd64.deb",
-        "version": "0.6.0.60401-83"
+        "name": "hipfort-devel-rpath",
+        "sha256": "086ca39ad5bfc3fd83bc254f68f6a2de6a8e67e2e7db929f9e0b805504d315e8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipfort-devel-rpath6.4.1-0.6.0.60401-83.el8.x86_64.rpm",
+        "version": "0.6.0.60401"
       }
     ],
-    "version": "0.6.0.60401-83"
+    "version": "0.6.0.60401"
   },
   "hipify-clang": {
     "deps": [
@@ -551,18 +551,18 @@
     "components": [
       {
         "name": "hipify-clang",
-        "sha256": "0c7ca7f06b0c543838108c267cfa082663c6991f2da36b1c33a8649625b82141",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipify-clang/hipify-clang_19.0.0.60401-83~22.04_amd64.deb",
-        "version": "19.0.0.60401-83"
+        "sha256": "c939cb4895fdde1bb74fcce43d67f6a6a4fd30152e25768070c6dbf080486e9f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipify-clang-19.0.0.60401-83.el8.x86_64.rpm",
+        "version": "19.0.0.60401"
       },
       {
         "name": "hipify-clang-rpath",
-        "sha256": "cfefde37009f52e19e3a665ae035a9784d021acc30d27630470a8fab7b71caf4",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipify-clang-rpath6.4.1/hipify-clang-rpath6.4.1_19.0.0.60401-83~22.04_amd64.deb",
-        "version": "19.0.0.60401-83"
+        "sha256": "34daddfd9326ad05c752ed5dd50736c9e0c2553b667d70a297c48c0cccfd0864",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipify-clang-rpath6.4.1-19.0.0.60401-83.el8.x86_64.rpm",
+        "version": "19.0.0.60401"
       }
     ],
-    "version": "19.0.0.60401-83"
+    "version": "19.0.0.60401"
   },
   "hiprand": {
     "deps": [
@@ -571,30 +571,30 @@
     "components": [
       {
         "name": "hiprand",
-        "sha256": "1bb01aa2d9b96e999dff6fbf67edeab7d743bb182ce653b048628393e1d9756d",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hiprand/hiprand_2.12.0.60401-83~22.04_amd64.deb",
-        "version": "2.12.0.60401-83"
+        "sha256": "f94bda7c8e88835c9b529695db39d3ea90b82facf2193bfb6f4e6897b8faec27",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hiprand-2.12.0.60401-83.el8.x86_64.rpm",
+        "version": "2.12.0.60401"
       },
       {
-        "name": "hiprand-dev",
-        "sha256": "6deb08288aa1900202d52c34899d5f54195d00d32c96d45b2e6d6f840dc018ae",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hiprand-dev/hiprand-dev_2.12.0.60401-83~22.04_amd64.deb",
-        "version": "2.12.0.60401-83"
+        "name": "hiprand-devel",
+        "sha256": "5d3f6a092108816c8347429949d3ff91ad608c8b6b50a56018bf709ae911ac94",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hiprand-devel-2.12.0.60401-83.el8.x86_64.rpm",
+        "version": "2.12.0.60401"
       },
       {
-        "name": "hiprand-dev-rpath",
-        "sha256": "19be226856ba40351a9c5a7a8831980d70ccac48b7917ee5a6cfcfd99e28de5f",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hiprand-dev-rpath6.4.1/hiprand-dev-rpath6.4.1_2.12.0.60401-83~22.04_amd64.deb",
-        "version": "2.12.0.60401-83"
+        "name": "hiprand-devel-rpath",
+        "sha256": "a7b6c5a80ca02b083d4953ca689b9c0535f1247bb549afb9c00eef57eaeb9552",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hiprand-devel-rpath6.4.1-2.12.0.60401-83.el8.x86_64.rpm",
+        "version": "2.12.0.60401"
       },
       {
         "name": "hiprand-rpath",
-        "sha256": "0fc98ec8208ef4b21fab811d11fd16516b16cfa762614febf9ba04d179525aab",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hiprand-rpath6.4.1/hiprand-rpath6.4.1_2.12.0.60401-83~22.04_amd64.deb",
-        "version": "2.12.0.60401-83"
+        "sha256": "c6917447e3014c08143112b59396621e74eed39a43021bfb91f5b55a1b5590b8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hiprand-rpath6.4.1-2.12.0.60401-83.el8.x86_64.rpm",
+        "version": "2.12.0.60401"
       }
     ],
-    "version": "2.12.0.60401-83"
+    "version": "2.12.0.60401"
   },
   "hiprand-asan": {
     "deps": [
@@ -603,18 +603,18 @@
     "components": [
       {
         "name": "hiprand-asan",
-        "sha256": "5b28404916f4d275e638a8bd6f37b9ff225cd8ca11bcc51da4bee82f80db22a0",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hiprand-asan/hiprand-asan_2.12.0.60401-83~22.04_amd64.deb",
-        "version": "2.12.0.60401-83"
+        "sha256": "bacdda62be129d9a3e4cfd988f51ffe35bdc978fcb860ee59ec8694c99fa803a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hiprand-asan-2.12.0.60401-83.el8.x86_64.rpm",
+        "version": "2.12.0.60401"
       },
       {
         "name": "hiprand-asan-rpath",
-        "sha256": "30f3ffe635f90e8b405cb1d01684495fc8061c9a7719f82bda02a9ddacbf8cae",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hiprand-asan-rpath6.4.1/hiprand-asan-rpath6.4.1_2.12.0.60401-83~22.04_amd64.deb",
-        "version": "2.12.0.60401-83"
+        "sha256": "8672e8d8b875b2cdfb2bc3e93f5ec9338ce36a06c508c3d11a543ef6dea49c60",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hiprand-asan-rpath6.4.1-2.12.0.60401-83.el8.x86_64.rpm",
+        "version": "2.12.0.60401"
       }
     ],
-    "version": "2.12.0.60401-83"
+    "version": "2.12.0.60401"
   },
   "hipsolver": {
     "deps": [
@@ -625,30 +625,30 @@
     "components": [
       {
         "name": "hipsolver",
-        "sha256": "d461a5a321aad9743dd91906b393615cc2066e7ca792092d4d7619aa14903612",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipsolver/hipsolver_2.4.0.60401-83~22.04_amd64.deb",
-        "version": "2.4.0.60401-83"
+        "sha256": "13cedf94b8f5c7385146be86818d67972815b96c4bf531cbea55e5e0876c3398",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipsolver-2.4.0.60401-83.el8.x86_64.rpm",
+        "version": "2.4.0.60401"
       },
       {
-        "name": "hipsolver-dev",
-        "sha256": "a4ffd06f7148b195e68ff80fbdd614992d9d69a841be0ce8ba98ac1c1b7b4491",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipsolver-dev/hipsolver-dev_2.4.0.60401-83~22.04_amd64.deb",
-        "version": "2.4.0.60401-83"
+        "name": "hipsolver-devel",
+        "sha256": "24edcab4f7ffbf4456e2313b5823092472adf4000e4efa8f0dab49b5e848e68d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipsolver-devel-2.4.0.60401-83.el8.x86_64.rpm",
+        "version": "2.4.0.60401"
       },
       {
-        "name": "hipsolver-dev-rpath",
-        "sha256": "137465c39a7abff60342fe40b8d9977f612428fd5b89d7871a7776a02bca975a",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipsolver-dev-rpath6.4.1/hipsolver-dev-rpath6.4.1_2.4.0.60401-83~22.04_amd64.deb",
-        "version": "2.4.0.60401-83"
+        "name": "hipsolver-devel-rpath",
+        "sha256": "a326098e3303774a16e6c164ddf52075c7657d716764c5705d28814e6c6d5495",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipsolver-devel-rpath6.4.1-2.4.0.60401-83.el8.x86_64.rpm",
+        "version": "2.4.0.60401"
       },
       {
         "name": "hipsolver-rpath",
-        "sha256": "20223edabf955aeb7bac7a3893f5f71d8c4a940b7764d8918078ec3a6dfb5775",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipsolver-rpath6.4.1/hipsolver-rpath6.4.1_2.4.0.60401-83~22.04_amd64.deb",
-        "version": "2.4.0.60401-83"
+        "sha256": "8675c3b8457c125b322be9bda79f9f79ab4a874a89594e6d6af37b0d6ebdd06d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipsolver-rpath6.4.1-2.4.0.60401-83.el8.x86_64.rpm",
+        "version": "2.4.0.60401"
       }
     ],
-    "version": "2.4.0.60401-83"
+    "version": "2.4.0.60401"
   },
   "hipsolver-asan": {
     "deps": [
@@ -659,18 +659,18 @@
     "components": [
       {
         "name": "hipsolver-asan",
-        "sha256": "1832c6b1fe2b07d221139e29809cd4223e6e3b1b2d50fc839eb5b4b6da54087f",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipsolver-asan/hipsolver-asan_2.4.0.60401-83~22.04_amd64.deb",
-        "version": "2.4.0.60401-83"
+        "sha256": "1bb34e483cc0051c9c4fe6830a8d4a6814a0e049be72c1549d12385bc4d421c4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipsolver-asan-2.4.0.60401-83.el8.x86_64.rpm",
+        "version": "2.4.0.60401"
       },
       {
         "name": "hipsolver-asan-rpath",
-        "sha256": "88239f93a510d27332e6b642bc1709c6932f1759a2f61fe69558d0618a7e68c2",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipsolver-asan-rpath6.4.1/hipsolver-asan-rpath6.4.1_2.4.0.60401-83~22.04_amd64.deb",
-        "version": "2.4.0.60401-83"
+        "sha256": "0311614ab944478a436bef9d69ec450d05da65fc29c1fa1eac8a975257219af8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipsolver-asan-rpath6.4.1-2.4.0.60401-83.el8.x86_64.rpm",
+        "version": "2.4.0.60401"
       }
     ],
-    "version": "2.4.0.60401-83"
+    "version": "2.4.0.60401"
   },
   "hipsparse": {
     "deps": [
@@ -680,30 +680,30 @@
     "components": [
       {
         "name": "hipsparse",
-        "sha256": "742c06039eb264d8de5338c52acc82f63d8e407eaff4d2d27354280a715380e1",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipsparse/hipsparse_3.2.0.60401-83~22.04_amd64.deb",
-        "version": "3.2.0.60401-83"
+        "sha256": "960e8faeffa52523aa4665a23e2878033ad7f8b944113f0c4b0e4ea9baa27fd5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipsparse-3.2.0.60401-83.el8.x86_64.rpm",
+        "version": "3.2.0.60401"
       },
       {
-        "name": "hipsparse-dev",
-        "sha256": "87077c062653ff1ed63a272482bc970804959ce56b560e057e7788dc4515ec18",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipsparse-dev/hipsparse-dev_3.2.0.60401-83~22.04_amd64.deb",
-        "version": "3.2.0.60401-83"
+        "name": "hipsparse-devel",
+        "sha256": "0f3432e63565edff9bcd2f831f33edd9ff98aa6f38baaa76fdc2cba21baf93eb",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipsparse-devel-3.2.0.60401-83.el8.x86_64.rpm",
+        "version": "3.2.0.60401"
       },
       {
-        "name": "hipsparse-dev-rpath",
-        "sha256": "aca3416b08893476069a0aa0404edbf3fd809212f72ed1379ade247a5285a159",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipsparse-dev-rpath6.4.1/hipsparse-dev-rpath6.4.1_3.2.0.60401-83~22.04_amd64.deb",
-        "version": "3.2.0.60401-83"
+        "name": "hipsparse-devel-rpath",
+        "sha256": "c7bc184eecf412069a9223a37a94c76416fd8dfc9663e762208f039438ca70c2",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipsparse-devel-rpath6.4.1-3.2.0.60401-83.el8.x86_64.rpm",
+        "version": "3.2.0.60401"
       },
       {
         "name": "hipsparse-rpath",
-        "sha256": "f649f7de4c30c7e1d1ce5ecc4e4eba5f42faceee4493b1400d4cb5dc3c3c48ef",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipsparse-rpath6.4.1/hipsparse-rpath6.4.1_3.2.0.60401-83~22.04_amd64.deb",
-        "version": "3.2.0.60401-83"
+        "sha256": "cf2afbe07f8e069427fef8334de0bbd21a17f0d72e8bafae07fee5d84392a01b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipsparse-rpath6.4.1-3.2.0.60401-83.el8.x86_64.rpm",
+        "version": "3.2.0.60401"
       }
     ],
-    "version": "3.2.0.60401-83"
+    "version": "3.2.0.60401"
   },
   "hipsparse-asan": {
     "deps": [
@@ -713,18 +713,18 @@
     "components": [
       {
         "name": "hipsparse-asan",
-        "sha256": "a048f35cd349786a37d39ba216cf7fa2a58b8f76e1b52f3550a2b0776cc3679e",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipsparse-asan/hipsparse-asan_3.2.0.60401-83~22.04_amd64.deb",
-        "version": "3.2.0.60401-83"
+        "sha256": "07ae911eb91609a3a24ecad7f1c0cad86e4b213aaf26fbf8b6bb1868d079a60a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipsparse-asan-3.2.0.60401-83.el8.x86_64.rpm",
+        "version": "3.2.0.60401"
       },
       {
         "name": "hipsparse-asan-rpath",
-        "sha256": "86598fa96ee7dcc8aa0509c2814cf201b8c2da2a896b23fb0986ae34f7ede22e",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipsparse-asan-rpath6.4.1/hipsparse-asan-rpath6.4.1_3.2.0.60401-83~22.04_amd64.deb",
-        "version": "3.2.0.60401-83"
+        "sha256": "edbce4eff64c04ec0f256fae0580c62d58c0e3e2dd1efa3ab8c842ded67a604b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipsparse-asan-rpath6.4.1-3.2.0.60401-83.el8.x86_64.rpm",
+        "version": "3.2.0.60401"
       }
     ],
-    "version": "3.2.0.60401-83"
+    "version": "3.2.0.60401"
   },
   "hipsparselt": {
     "deps": [
@@ -734,30 +734,30 @@
     "components": [
       {
         "name": "hipsparselt",
-        "sha256": "4015b40aee8e6306126bdf6b7c7a8e422563c2a44acb21b77d67a1a06415fee1",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipsparselt/hipsparselt_0.2.3.60401-83~22.04_amd64.deb",
-        "version": "0.2.3.60401-83"
+        "sha256": "1171f8bc92cf1a636102eb98bdf92c4319b2c61fdc750253942c901aab01592d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipsparselt-0.2.3.60401-83.el8.x86_64.rpm",
+        "version": "0.2.3.60401"
       },
       {
-        "name": "hipsparselt-dev",
-        "sha256": "f8ec29a5fee87401d28612ed20fd41e45d180b1263dd84c8aa4956351881d3ce",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipsparselt-dev/hipsparselt-dev_0.2.3.60401-83~22.04_amd64.deb",
-        "version": "0.2.3.60401-83"
+        "name": "hipsparselt-devel",
+        "sha256": "a370faef561ab069e5d39805abbe6c57593b4fd61ea785c3b468415593cb60a3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipsparselt-devel-0.2.3.60401-83.el8.x86_64.rpm",
+        "version": "0.2.3.60401"
       },
       {
-        "name": "hipsparselt-dev-rpath",
-        "sha256": "cf6a6a02f2fe327042be1ff52ea5ef195435df353e737178e481a30021ccf75c",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipsparselt-dev-rpath6.4.1/hipsparselt-dev-rpath6.4.1_0.2.3.60401-83~22.04_amd64.deb",
-        "version": "0.2.3.60401-83"
+        "name": "hipsparselt-devel-rpath",
+        "sha256": "f16a09a94909f93532c9741505f860cb2e66b41ead2da734e395d8f1eeaac7f0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipsparselt-devel-rpath6.4.1-0.2.3.60401-83.el8.x86_64.rpm",
+        "version": "0.2.3.60401"
       },
       {
         "name": "hipsparselt-rpath",
-        "sha256": "9643e5dd269c13ce6d80d63a5c258c813a1a8c18b86cc614ab36742a7e67aee8",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipsparselt-rpath6.4.1/hipsparselt-rpath6.4.1_0.2.3.60401-83~22.04_amd64.deb",
-        "version": "0.2.3.60401-83"
+        "sha256": "ff35978badc88ce59704f9c827978f7dbed464be408c71cb249b7a57bbe1f31f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipsparselt-rpath6.4.1-0.2.3.60401-83.el8.x86_64.rpm",
+        "version": "0.2.3.60401"
       }
     ],
-    "version": "0.2.3.60401-83"
+    "version": "0.2.3.60401"
   },
   "hipsparselt-asan": {
     "deps": [
@@ -767,18 +767,18 @@
     "components": [
       {
         "name": "hipsparselt-asan",
-        "sha256": "d6a516636fc3a10228d4dc9082efd57ad272a3372dd66dfd10886b6b96f9d5ba",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipsparselt-asan/hipsparselt-asan_0.2.3.60401-83~22.04_amd64.deb",
-        "version": "0.2.3.60401-83"
+        "sha256": "baf09af4f5cedd461b1c2f7464119c4ea66e5c3bac0f3296299719298e4263d6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipsparselt-asan-0.2.3.60401-83.el8.x86_64.rpm",
+        "version": "0.2.3.60401"
       },
       {
         "name": "hipsparselt-asan-rpath",
-        "sha256": "cca1b3cba2b68c1725f0bd2948b7c3261f42576f01a83bea29ca7f1053a01f26",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hipsparselt-asan-rpath6.4.1/hipsparselt-asan-rpath6.4.1_0.2.3.60401-83~22.04_amd64.deb",
-        "version": "0.2.3.60401-83"
+        "sha256": "47cf8deb4f828d1f9c01b22c3a148f2ae53fd4a9027727fb86f1641b1367fb99",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hipsparselt-asan-rpath6.4.1-0.2.3.60401-83.el8.x86_64.rpm",
+        "version": "0.2.3.60401"
       }
     ],
-    "version": "0.2.3.60401-83"
+    "version": "0.2.3.60401"
   },
   "hiptensor": {
     "deps": [
@@ -787,30 +787,30 @@
     "components": [
       {
         "name": "hiptensor",
-        "sha256": "a565c334d0d7210ff584b350271262c038abc9d9711defe735e2c934e6fc6228",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hiptensor/hiptensor_1.5.0.60401-83~22.04_amd64.deb",
-        "version": "1.5.0.60401-83"
+        "sha256": "ddb8b2e73ce1d1c30368fcc1a81e32d7afce4d3f54d5e4386defb55daa9ef1a7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hiptensor-1.5.0.60401-83.el8.x86_64.rpm",
+        "version": "1.5.0.60401"
       },
       {
-        "name": "hiptensor-dev",
-        "sha256": "f7e12eeba3b07258daee7445b5e7fc57e998d2ca89f657fb07283a2510723af4",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hiptensor-dev/hiptensor-dev_1.5.0.60401-83~22.04_amd64.deb",
-        "version": "1.5.0.60401-83"
+        "name": "hiptensor-devel",
+        "sha256": "07af51bdbe9791720916e5e4a2357eca735f3bf527e386df04c0ef39e34177ee",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hiptensor-devel-1.5.0.60401-83.el8.x86_64.rpm",
+        "version": "1.5.0.60401"
       },
       {
-        "name": "hiptensor-dev-rpath",
-        "sha256": "ef877bbb20898eab297eb0853207fba20f1e550069bb50599d6aa6b39dbb9af2",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hiptensor-dev-rpath6.4.1/hiptensor-dev-rpath6.4.1_1.5.0.60401-83~22.04_amd64.deb",
-        "version": "1.5.0.60401-83"
+        "name": "hiptensor-devel-rpath",
+        "sha256": "ac87ba1acc079113a509dfcc2caa41cead3b4f60a80350d9e010b95b02f68fba",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hiptensor-devel-rpath6.4.1-1.5.0.60401-83.el8.x86_64.rpm",
+        "version": "1.5.0.60401"
       },
       {
         "name": "hiptensor-rpath",
-        "sha256": "ba3588769e31b50d079bf13a314f3cd9bdcbc7da57819a9e8d16cf80aeaadea4",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hiptensor-rpath6.4.1/hiptensor-rpath6.4.1_1.5.0.60401-83~22.04_amd64.deb",
-        "version": "1.5.0.60401-83"
+        "sha256": "2aa0240a780971846988f8ed7438503bc8e2b9d12683a0da4ab58fbe2405fe8f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hiptensor-rpath6.4.1-1.5.0.60401-83.el8.x86_64.rpm",
+        "version": "1.5.0.60401"
       }
     ],
-    "version": "1.5.0.60401-83"
+    "version": "1.5.0.60401"
   },
   "hiptensor-asan": {
     "deps": [
@@ -819,18 +819,18 @@
     "components": [
       {
         "name": "hiptensor-asan",
-        "sha256": "91f846ae90c4e6178c79ab1a73cc62398f42539338cabba62a27fffb827488c8",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hiptensor-asan/hiptensor-asan_1.5.0.60401-83~22.04_amd64.deb",
-        "version": "1.5.0.60401-83"
+        "sha256": "31a28e503c8cb508ef6a0ffdfe66c7a8d6e71c12be48f41e1ac6bce0000a4a95",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hiptensor-asan-1.5.0.60401-83.el8.x86_64.rpm",
+        "version": "1.5.0.60401"
       },
       {
         "name": "hiptensor-asan-rpath",
-        "sha256": "ad9790538246ca92c781cd87b7f49a7d66378b7f0128d1743acdb9e0e905f55c",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hiptensor-asan-rpath6.4.1/hiptensor-asan-rpath6.4.1_1.5.0.60401-83~22.04_amd64.deb",
-        "version": "1.5.0.60401-83"
+        "sha256": "51ddeaf9e3c7f76b9be13652f02b5843110f5633cbad673bc13acfff87396406",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hiptensor-asan-rpath6.4.1-1.5.0.60401-83.el8.x86_64.rpm",
+        "version": "1.5.0.60401"
       }
     ],
-    "version": "1.5.0.60401-83"
+    "version": "1.5.0.60401"
   },
   "hsa-amd-aqlprofile": {
     "deps": [
@@ -839,18 +839,18 @@
     "components": [
       {
         "name": "hsa-amd-aqlprofile",
-        "sha256": "9e0917b47d40318f73d4323bdc0fdaa27202931544bc4e89f706c4ddd9bd9428",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hsa-amd-aqlprofile/hsa-amd-aqlprofile_1.0.0.60401-83~22.04_amd64.deb",
-        "version": "1.0.0.60401-83"
+        "sha256": "8f64a4594ff9d4c70ed5a2d75d28283b1067dded159cd334fad9661517d72191",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hsa-amd-aqlprofile-1.0.0.60401-83.el8.x86_64.rpm",
+        "version": "1.0.0.60401"
       },
       {
         "name": "hsa-amd-aqlprofile-rpath",
-        "sha256": "68bad576aa79a4b8992ca9a25861343380338ce5739de29aab925d34964b6977",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hsa-amd-aqlprofile-rpath6.4.1/hsa-amd-aqlprofile-rpath6.4.1_1.0.0.60401-83~22.04_amd64.deb",
-        "version": "1.0.0.60401-83"
+        "sha256": "0a1b5b115eb5c1a487b00d247de237aa5693297b230730b4c25595163be644e1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hsa-amd-aqlprofile-rpath6.4.1-1.0.0.60401-83.el8.x86_64.rpm",
+        "version": "1.0.0.60401"
       }
     ],
-    "version": "1.0.0.60401-83"
+    "version": "1.0.0.60401"
   },
   "hsa-amd-aqlprofile-asan": {
     "deps": [
@@ -859,18 +859,18 @@
     "components": [
       {
         "name": "hsa-amd-aqlprofile-asan",
-        "sha256": "0ef49fe4012ef1e254a7fcc4582ea25e0b8e45f0b0dda4818bc27a421a7fd53f",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hsa-amd-aqlprofile-asan/hsa-amd-aqlprofile-asan_1.0.0.60401-83~22.04_amd64.deb",
-        "version": "1.0.0.60401-83"
+        "sha256": "2174ee2f8f41aa4dc0964eff47caeeaaa29c769618eede68204c2062ed5d0df6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hsa-amd-aqlprofile-asan-1.0.0.60401-83.el8.x86_64.rpm",
+        "version": "1.0.0.60401"
       },
       {
         "name": "hsa-amd-aqlprofile-asan-rpath",
-        "sha256": "0cc7bf97b8f5136c0bc9d358685df968e7d2578477e385b09cb4bd366a1a8111",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hsa-amd-aqlprofile-asan-rpath6.4.1/hsa-amd-aqlprofile-asan-rpath6.4.1_1.0.0.60401-83~22.04_amd64.deb",
-        "version": "1.0.0.60401-83"
+        "sha256": "1b918b750afea7547b5ebed33538642922d4c4be92432fdb2f76fcef479d4d8e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hsa-amd-aqlprofile-asan-rpath6.4.1-1.0.0.60401-83.el8.x86_64.rpm",
+        "version": "1.0.0.60401"
       }
     ],
-    "version": "1.0.0.60401-83"
+    "version": "1.0.0.60401"
   },
   "hsa-rocr": {
     "deps": [
@@ -880,30 +880,30 @@
     "components": [
       {
         "name": "hsa-rocr",
-        "sha256": "07a37ac162acbc5f054b0ea9cfd4e37e1640adee367d31aad15d504c49999372",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hsa-rocr/hsa-rocr_1.15.0.60401-83~22.04_amd64.deb",
-        "version": "1.15.0.60401-83"
+        "sha256": "7937d322a1607426a3a894345bf98c23947cea7502e27744082e3d47b58adf07",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hsa-rocr-1.15.0.60401-83.el8.x86_64.rpm",
+        "version": "1.15.0.60401"
       },
       {
-        "name": "hsa-rocr-dev",
-        "sha256": "e1221293f8a5501ef01324c381e61d76a5d2e0f11032e4d33766dc53efc75813",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hsa-rocr-dev/hsa-rocr-dev_1.15.0.60401-83~22.04_amd64.deb",
-        "version": "1.15.0.60401-83"
+        "name": "hsa-rocr-devel",
+        "sha256": "02194c0689c6a266d0cda2f1a01dfbcdfe25a84d00b1e0c7443fa2505aca331c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hsa-rocr-devel-1.15.0.60401-83.el8.x86_64.rpm",
+        "version": "1.15.0.60401"
       },
       {
-        "name": "hsa-rocr-dev-rpath",
-        "sha256": "ce35f529a1170588b7d4f51a3b7f9c583731c67071777b61b47dae66fefe25e5",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hsa-rocr-dev-rpath6.4.1/hsa-rocr-dev-rpath6.4.1_1.15.0.60401-83~22.04_amd64.deb",
-        "version": "1.15.0.60401-83"
+        "name": "hsa-rocr-devel-rpath",
+        "sha256": "5b7cf6aa586b1a309009282aa6bcca745d27ac62352bb59e4ec31f1b1c20083e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hsa-rocr-devel-rpath6.4.1-1.15.0.60401-83.el8.x86_64.rpm",
+        "version": "1.15.0.60401"
       },
       {
         "name": "hsa-rocr-rpath",
-        "sha256": "1c90c5aaf74f6985c5ac666f81bcc77ed7a0206c54c56012689b6ba2167ca9ee",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hsa-rocr-rpath6.4.1/hsa-rocr-rpath6.4.1_1.15.0.60401-83~22.04_amd64.deb",
-        "version": "1.15.0.60401-83"
+        "sha256": "567a30f26fcfe633b7a3e12608d06efdf99a270afc1abdbec308807bce512ff0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hsa-rocr-rpath6.4.1-1.15.0.60401-83.el8.x86_64.rpm",
+        "version": "1.15.0.60401"
       }
     ],
-    "version": "1.15.0.60401-83"
+    "version": "1.15.0.60401"
   },
   "hsa-rocr-asan": {
     "deps": [
@@ -912,23 +912,23 @@
     "components": [
       {
         "name": "hsa-rocr-asan",
-        "sha256": "903615d9fb7ee49702d627765925d390c2a28a90734c69816e148eebe35f59ea",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hsa-rocr-asan/hsa-rocr-asan_1.15.0.60401-83~22.04_amd64.deb",
-        "version": "1.15.0.60401-83"
+        "sha256": "589db2e85cf87421a41b75fc558361d9176077e6056fee4001e72a33169cac41",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hsa-rocr-asan-1.15.0.60401-83.el8.x86_64.rpm",
+        "version": "1.15.0.60401"
       },
       {
         "name": "hsa-rocr-asan-rpath",
-        "sha256": "702a166a30bb36fbdc9c48468de18482be4e79f9e2435d611fb3192ad0b43647",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/h/hsa-rocr-asan-rpath6.4.1/hsa-rocr-asan-rpath6.4.1_1.15.0.60401-83~22.04_amd64.deb",
-        "version": "1.15.0.60401-83"
+        "sha256": "85361539f10469fe2ecf244623b97162d64ce31d3036f1fb82be433cbd0bbc87",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/hsa-rocr-asan-rpath6.4.1-1.15.0.60401-83.el8.x86_64.rpm",
+        "version": "1.15.0.60401"
       }
     ],
-    "version": "1.15.0.60401-83"
+    "version": "1.15.0.60401"
   },
   "migraphx": {
     "deps": [
       "half",
-      "hip-dev",
+      "hip-devel",
       "hip-runtime-amd",
       "hipblaslt",
       "miopen-hip",
@@ -938,35 +938,35 @@
     "components": [
       {
         "name": "migraphx",
-        "sha256": "07bd5f046e52b688a9e3475ae6a37019baf80008a9c19c0f8055c1c2952143ee",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/migraphx/migraphx_2.12.0.60401-83~22.04_amd64.deb",
-        "version": "2.12.0.60401-83"
+        "sha256": "55ef4d4a10013a0992c98ebb009781319662879a3e0f6527d9795412ee42e461",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/migraphx-2.12.0.60401-83.el8.x86_64.rpm",
+        "version": "2.12.0.60401"
       },
       {
-        "name": "migraphx-dev",
-        "sha256": "b2902863a6982d1aaeae50f5b8679dc60983e01e2cbe4fb21f6198a12de189be",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/migraphx-dev/migraphx-dev_2.12.0.60401-83~22.04_amd64.deb",
-        "version": "2.12.0.60401-83"
+        "name": "migraphx-devel",
+        "sha256": "2e094fb3d4af7599c9b9dcbb67a7cb8fd228b310873e071563c265cb3c0d3c86",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/migraphx-devel-2.12.0.60401-83.el8.x86_64.rpm",
+        "version": "2.12.0.60401"
       },
       {
-        "name": "migraphx-dev-rpath",
-        "sha256": "d7ec48bcd89e19173ed9f35790ed406a5c2be3b6e0c5dd872c3a70abe2c3dad6",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/migraphx-dev-rpath6.4.1/migraphx-dev-rpath6.4.1_2.12.0.60401-83~22.04_amd64.deb",
-        "version": "2.12.0.60401-83"
+        "name": "migraphx-devel-rpath",
+        "sha256": "2bdfb317337ae2dfaad20f8064fbf7ef67a434741acdfe1cfafb4dce46df9834",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/migraphx-devel-rpath6.4.1-2.12.0.60401-83.el8.x86_64.rpm",
+        "version": "2.12.0.60401"
       },
       {
         "name": "migraphx-rpath",
-        "sha256": "2f6ad8dcfd8c4c37304b462bd28595d3bb648f84fb4ad98cdfab60fe12d6ad92",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/migraphx-rpath6.4.1/migraphx-rpath6.4.1_2.12.0.60401-83~22.04_amd64.deb",
-        "version": "2.12.0.60401-83"
+        "sha256": "ec84357a8798510d6dbd7166e604100983a1efe9fae1525757b247f79800ffe6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/migraphx-rpath6.4.1-2.12.0.60401-83.el8.x86_64.rpm",
+        "version": "2.12.0.60401"
       }
     ],
-    "version": "2.12.0.60401-83"
+    "version": "2.12.0.60401"
   },
   "migraphx-asan": {
     "deps": [
       "half",
-      "hip-dev",
+      "hip-devel",
       "hip-runtime-amd",
       "hipblaslt",
       "miopen-hip",
@@ -976,18 +976,18 @@
     "components": [
       {
         "name": "migraphx-asan",
-        "sha256": "f0a962449c7978ecfdc85f0b7a55e84534797b6811ef98d062aeab63b82db3c7",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/migraphx-asan/migraphx-asan_2.12.0.60401-83~22.04_amd64.deb",
-        "version": "2.12.0.60401-83"
+        "sha256": "04f2d92d2942b016646441b007131ad0ccbb741e242ddd63008c66ac99eb6aa7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/migraphx-asan-2.12.0.60401-83.el8.x86_64.rpm",
+        "version": "2.12.0.60401"
       },
       {
         "name": "migraphx-asan-rpath",
-        "sha256": "0033fd4787665ea99e0d6ae94764afcbb844a9b7333383e83d070fe6f6d23e6b",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/migraphx-asan-rpath6.4.1/migraphx-asan-rpath6.4.1_2.12.0.60401-83~22.04_amd64.deb",
-        "version": "2.12.0.60401-83"
+        "sha256": "14ba6232e2fbcf3dbf5bbd8c1590ccb45f76e2b16eb2a3812a5121f00d853a43",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/migraphx-asan-rpath6.4.1-2.12.0.60401-83.el8.x86_64.rpm",
+        "version": "2.12.0.60401"
       }
     ],
-    "version": "2.12.0.60401-83"
+    "version": "2.12.0.60401"
   },
   "miopen-hip": {
     "deps": [
@@ -1002,30 +1002,30 @@
     "components": [
       {
         "name": "miopen-hip",
-        "sha256": "584431b94f2809f553633a887a7f88d308391114cc9547da305d5ddcd84bd3e5",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/miopen-hip/miopen-hip_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "sha256": "128c6854b83e3f6b35ae2613e3c17299d8980948b578af05fb7be73bc1a38529",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/miopen-hip-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       },
       {
-        "name": "miopen-hip-dev",
-        "sha256": "939f6650adcbe7f98a79437c063910f397516f535a6a159a0b605bcd1f8d23b1",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/miopen-hip-dev/miopen-hip-dev_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "name": "miopen-hip-devel",
+        "sha256": "5668e3ab586a151d8e3183a311b2ff907f8b31432a16b35866a0acf23ee637ea",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/miopen-hip-devel-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       },
       {
-        "name": "miopen-hip-dev-rpath",
-        "sha256": "7e46dc31c89041c4d08a377011f5a5abb1f435f17be077e69864c529b8f2ed6f",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/miopen-hip-dev-rpath6.4.1/miopen-hip-dev-rpath6.4.1_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "name": "miopen-hip-devel-rpath",
+        "sha256": "b37839d6c33355fb7c99346504d43a3d8de40eef8bab4e19415ee7567db36303",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/miopen-hip-devel-rpath6.4.1-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       },
       {
         "name": "miopen-hip-rpath",
-        "sha256": "6f4881d4dd87d8e6b592c0eee45b637af5f94fb585d63913a73610401a212155",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/miopen-hip-rpath6.4.1/miopen-hip-rpath6.4.1_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "sha256": "39c6272aad1a853a10c655a5ee720bb8f0a38bc43ac4aba81084dab3e885b513",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/miopen-hip-rpath6.4.1-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       }
     ],
-    "version": "3.4.0.60401-83"
+    "version": "3.4.0.60401"
   },
   "miopen-hip-asan": {
     "deps": [
@@ -1041,18 +1041,18 @@
     "components": [
       {
         "name": "miopen-hip-asan",
-        "sha256": "297ab78684f580b4d3ecc206b76474f6aaadc97fe5acea6026579eda8accc5ff",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/miopen-hip-asan/miopen-hip-asan_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "sha256": "752afa666b2595cbad18b4808e1bcba03f7bd837f3f72245d9b08dc31d976561",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/miopen-hip-asan-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       },
       {
         "name": "miopen-hip-asan-rpath",
-        "sha256": "7da9ef3c258314de328c1211c5d5df20bfdae0ad24cc6497b32fb84651ff84a8",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/miopen-hip-asan-rpath6.4.1/miopen-hip-asan-rpath6.4.1_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "sha256": "887b56233630f8555e7373f2383eeb49d2f3e79a2754143e040fc09ab0b0bb72",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/miopen-hip-asan-rpath6.4.1-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       }
     ],
-    "version": "3.4.0.60401-83"
+    "version": "3.4.0.60401"
   },
   "miopen-hip-gfx1030kdb": {
     "deps": [
@@ -1067,18 +1067,18 @@
     "components": [
       {
         "name": "miopen-hip-gfx1030kdb",
-        "sha256": "0d94949fe8cfbc27a157d6a33058945a7d17b3c1843ca8062fa51c914d2cd330",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/miopen-hip-gfx1030kdb/miopen-hip-gfx1030kdb_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "sha256": "71d8c54ac467fd0889018991141a1b902d119b888d3951b702631158932b592c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/miopen-hip-gfx1030kdb-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       },
       {
         "name": "miopen-hip-gfx1030kdb-rpath",
-        "sha256": "7e650df86ee66d04f755645a441314875aa7e91b8582316c5c74644759dc4d38",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/miopen-hip-gfx1030kdb-rpath6.4.1/miopen-hip-gfx1030kdb-rpath6.4.1_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "sha256": "6b25d2fb99c55d068dd0804de6f2e212347b20dd92a6302793969a26ddd424a6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/miopen-hip-gfx1030kdb-rpath6.4.1-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       }
     ],
-    "version": "3.4.0.60401-83"
+    "version": "3.4.0.60401"
   },
   "miopen-hip-gfx900kdb": {
     "deps": [
@@ -1093,18 +1093,18 @@
     "components": [
       {
         "name": "miopen-hip-gfx900kdb",
-        "sha256": "98b060ed4174994464f4f34ba8fd0742830e63414ed99d3c9ac4a18b2f331bde",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/miopen-hip-gfx900kdb/miopen-hip-gfx900kdb_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "sha256": "5e45e6b37dae3ff625c6af0095a273b7f9ed3520557acdaea6fa7bb9029156ac",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/miopen-hip-gfx900kdb-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       },
       {
         "name": "miopen-hip-gfx900kdb-rpath",
-        "sha256": "4b16bc9aa0743a60739f02337eade99fe824f6140c2d1733db9de74ef4a3cd40",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/miopen-hip-gfx900kdb-rpath6.4.1/miopen-hip-gfx900kdb-rpath6.4.1_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "sha256": "2709ee0dcbc8261d7bbcfbf63bde74eeab33f3c3f64308a48d2a646f19c92f28",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/miopen-hip-gfx900kdb-rpath6.4.1-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       }
     ],
-    "version": "3.4.0.60401-83"
+    "version": "3.4.0.60401"
   },
   "miopen-hip-gfx906kdb": {
     "deps": [
@@ -1119,18 +1119,18 @@
     "components": [
       {
         "name": "miopen-hip-gfx906kdb",
-        "sha256": "527f15774fc70f986d64894a2156686aa123ba1dbaa50eeab4460024b8932686",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/miopen-hip-gfx906kdb/miopen-hip-gfx906kdb_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "sha256": "2d646fb483555800ca8e6fbdf9dd2cc0a641d20d2d285e475358be20237af705",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/miopen-hip-gfx906kdb-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       },
       {
         "name": "miopen-hip-gfx906kdb-rpath",
-        "sha256": "0fe98872bf8a7da31ed71a8f19828b4a040c28ffaa4ff199c37cabd95f1af3cc",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/miopen-hip-gfx906kdb-rpath6.4.1/miopen-hip-gfx906kdb-rpath6.4.1_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "sha256": "be43cd967094767fb0b2ee9610e1918cecb224bb933903a10e49e9652aaff30e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/miopen-hip-gfx906kdb-rpath6.4.1-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       }
     ],
-    "version": "3.4.0.60401-83"
+    "version": "3.4.0.60401"
   },
   "miopen-hip-gfx908kdb": {
     "deps": [
@@ -1145,18 +1145,18 @@
     "components": [
       {
         "name": "miopen-hip-gfx908kdb",
-        "sha256": "734356619ef614fa0650f91f14b7c12a3c0cbc83478e74e5fc2d14de9c57c588",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/miopen-hip-gfx908kdb/miopen-hip-gfx908kdb_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "sha256": "373306c23c9f9f80ba85dbd6d3c2a80d697209683d00356a539147920ba1d971",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/miopen-hip-gfx908kdb-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       },
       {
         "name": "miopen-hip-gfx908kdb-rpath",
-        "sha256": "756600d388929ef18bf279422fe46fd2f9914cc8becabd22074bba110763d03a",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/miopen-hip-gfx908kdb-rpath6.4.1/miopen-hip-gfx908kdb-rpath6.4.1_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "sha256": "28dd178f38e8f632e175c4e80a4f608cf1e7a09f2780dfdd1790b4526a40593f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/miopen-hip-gfx908kdb-rpath6.4.1-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       }
     ],
-    "version": "3.4.0.60401-83"
+    "version": "3.4.0.60401"
   },
   "miopen-hip-gfx90akdb": {
     "deps": [
@@ -1171,18 +1171,18 @@
     "components": [
       {
         "name": "miopen-hip-gfx90akdb",
-        "sha256": "83975281b7448f1d6a33cfab9d2abc619b8675a044042c480a4b7c144db87463",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/miopen-hip-gfx90akdb/miopen-hip-gfx90akdb_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "sha256": "cf3d01bc96c175174e422a296d0bec67dd177089e33c9ff4a7e2d46a2ed30d4c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/miopen-hip-gfx90akdb-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       },
       {
         "name": "miopen-hip-gfx90akdb-rpath",
-        "sha256": "aeba3702d1c725bcdccfb5e07222e61cd0af8faf85e7388ed8bb4425f998713b",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/miopen-hip-gfx90akdb-rpath6.4.1/miopen-hip-gfx90akdb-rpath6.4.1_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "sha256": "cb0f85b415f1a481f44400cfb8bc0e7e7b1677352580552957cdd361a91f7cf4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/miopen-hip-gfx90akdb-rpath6.4.1-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       }
     ],
-    "version": "3.4.0.60401-83"
+    "version": "3.4.0.60401"
   },
   "miopen-hip-gfx942kdb": {
     "deps": [
@@ -1197,25 +1197,25 @@
     "components": [
       {
         "name": "miopen-hip-gfx942kdb",
-        "sha256": "3364159106265ce469e03aa1f521cf8fd954f0b8a0422ecc3ae99105f291b88e",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/miopen-hip-gfx942kdb/miopen-hip-gfx942kdb_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "sha256": "dd9ebb7a8c300799bf6558c64a05ed854be427f4b0624d3a8815b27392444d6e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/miopen-hip-gfx942kdb-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       },
       {
         "name": "miopen-hip-gfx942kdb-rpath",
-        "sha256": "dc080bc84d50facb2bb9892b771622eb60777e3335780669f4c6be07e0a8e110",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/miopen-hip-gfx942kdb-rpath6.4.1/miopen-hip-gfx942kdb-rpath6.4.1_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "sha256": "9d77717d3f1103d3efdd37b3406aa21acf04c846a65768703e1723eda15ca3ac",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/miopen-hip-gfx942kdb-rpath6.4.1-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       }
     ],
-    "version": "3.4.0.60401-83"
+    "version": "3.4.0.60401"
   },
   "mivisionx": {
     "deps": [
       "half",
       "migraphx",
       "miopen-hip",
-      "openmp-extras-dev",
+      "openmp-extras-devel",
       "openmp-extras-runtime",
       "rocblas",
       "rocm-core",
@@ -1225,30 +1225,30 @@
     "components": [
       {
         "name": "mivisionx",
-        "sha256": "6427ca42b319c899ff528679467ef04fb34168b74b33249c3fc55ca243a0b162",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/mivisionx/mivisionx_3.2.0.60401-83~22.04_amd64.deb",
-        "version": "3.2.0.60401-83"
+        "sha256": "e483a691375f7af9cf636d3784b76e19acea86e3c783765e5f6669e03eddc37e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/mivisionx-3.2.0.60401-83.x86_64.rpm",
+        "version": "3.2.0.60401"
       },
       {
-        "name": "mivisionx-dev",
-        "sha256": "cad23936813014d694ca2f8359f34f3f7f28e11bc6dd01988de0502c4e0cb94b",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/mivisionx-dev/mivisionx-dev_3.2.0.60401-83~22.04_amd64.deb",
-        "version": "3.2.0.60401-83"
+        "name": "mivisionx-devel",
+        "sha256": "9d2cf88b83c4fbf44c24f8ed2297842e7cff0edb2c3c9d29608b2ae04f569f27",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/mivisionx-devel-3.2.0.60401-83.x86_64.rpm",
+        "version": "3.2.0.60401"
       },
       {
-        "name": "mivisionx-dev-rpath",
-        "sha256": "4e7df8189e622b71f458689725ee477640e5417bf3193f4f2e238a0c3d8ca3be",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/mivisionx-dev-rpath6.4.1/mivisionx-dev-rpath6.4.1_3.2.0.60401-83~22.04_amd64.deb",
-        "version": "3.2.0.60401-83"
+        "name": "mivisionx-devel-rpath",
+        "sha256": "9f427d4acce03fc5c859cc9498a383440f353c9d57a2d900ebf875b8b612a790",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/mivisionx-devel-rpath6.4.1-3.2.0.60401-83.x86_64.rpm",
+        "version": "3.2.0.60401"
       },
       {
         "name": "mivisionx-rpath",
-        "sha256": "83d03cdc8233fe2ccdb8312693a688a40d87019a055aaa173e81e7764f7ebce3",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/mivisionx-rpath6.4.1/mivisionx-rpath6.4.1_3.2.0.60401-83~22.04_amd64.deb",
-        "version": "3.2.0.60401-83"
+        "sha256": "5379672721995ec672ff2b0b81ce9fce632a6f56d01a259b84df0362971ab3f7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/mivisionx-rpath6.4.1-3.2.0.60401-83.x86_64.rpm",
+        "version": "3.2.0.60401"
       }
     ],
-    "version": "3.2.0.60401-83"
+    "version": "3.2.0.60401"
   },
   "mivisionx-asan": {
     "deps": [
@@ -1263,18 +1263,18 @@
     "components": [
       {
         "name": "mivisionx-asan",
-        "sha256": "1f88558ea3e75bbf27d91e5736e36cd7c42d8e4eec32c33f98ada8c7a2364c39",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/mivisionx-asan/mivisionx-asan_3.2.0.60401-83~22.04_amd64.deb",
-        "version": "3.2.0.60401-83"
+        "sha256": "9eba3e9fd21f59ae17df2e8879e5322e73e65fb6649ee70d3c75717959442abb",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/mivisionx-asan-3.2.0.60401-83.x86_64.rpm",
+        "version": "3.2.0.60401"
       },
       {
         "name": "mivisionx-asan-rpath",
-        "sha256": "c19c0ee1a7b9de15f1d9bdee3f1c9e18a09cfd4d19cee0f424a16a76c38fd557",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/mivisionx-asan-rpath6.4.1/mivisionx-asan-rpath6.4.1_3.2.0.60401-83~22.04_amd64.deb",
-        "version": "3.2.0.60401-83"
+        "sha256": "e7fb5d937c84fa836c87b407557da311a4eeaea21037be03f76d0634accd7332",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/mivisionx-asan-rpath6.4.1-3.2.0.60401-83.x86_64.rpm",
+        "version": "3.2.0.60401"
       }
     ],
-    "version": "3.2.0.60401-83"
+    "version": "3.2.0.60401"
   },
   "mivisionx-test": {
     "deps": [
@@ -1284,18 +1284,18 @@
     "components": [
       {
         "name": "mivisionx-test",
-        "sha256": "4315783e3173e9f3bec8ffd6bb4c5a390faa53b08250cc55267b3f0f992a9203",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/mivisionx-test/mivisionx-test_3.2.0.60401-83~22.04_amd64.deb",
-        "version": "3.2.0.60401-83"
+        "sha256": "0e2e147a2768165062221fb8c4995df75d7a9283324093e6b0abaf8a144b1875",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/mivisionx-test-3.2.0.60401-83.x86_64.rpm",
+        "version": "3.2.0.60401"
       },
       {
         "name": "mivisionx-test-rpath",
-        "sha256": "7f22b76567e7bf25a19056e8fb56ced6d25cccc550609bb162e4d2498088dbd2",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/m/mivisionx-test-rpath6.4.1/mivisionx-test-rpath6.4.1_3.2.0.60401-83~22.04_amd64.deb",
-        "version": "3.2.0.60401-83"
+        "sha256": "b3c8218d11bc85187edc6dcfe418147e1d5083155e9706ab15c385dac68f7705",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/mivisionx-test-rpath6.4.1-3.2.0.60401-83.x86_64.rpm",
+        "version": "3.2.0.60401"
       }
     ],
-    "version": "3.2.0.60401-83"
+    "version": "3.2.0.60401"
   },
   "openmp-extras-asan": {
     "deps": [
@@ -1305,20 +1305,20 @@
     "components": [
       {
         "name": "openmp-extras-asan",
-        "sha256": "e07946614ffb762fa719d13db78b4a7a83fb627d7e872a088c3f52e3b62dbf22",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/o/openmp-extras-asan/openmp-extras-asan_18.63.0.60401-83~22.04_amd64.deb",
-        "version": "18.63.0.60401-83"
+        "sha256": "4d7df608bad1109072e2b3060d366493d6e3379ebaf789dbf79d207a0ebb3788",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/openmp-extras-asan-18.63.0.60401-83.el8.x86_64.rpm",
+        "version": "18.63.0.60401"
       },
       {
         "name": "openmp-extras-asan-rpath",
-        "sha256": "2fbe74d43b4da010af0e5ee89120b53d4085d303b1a56cacdb9b22c777e9c689",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/o/openmp-extras-asan-rpath6.4.1/openmp-extras-asan-rpath6.4.1_18.63.0.60401-83~22.04_amd64.deb",
-        "version": "18.63.0.60401-83"
+        "sha256": "201bc413fd0b5f87dc1033ef3e6a2d869e69ebe21bfde722506772e25993ba81",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/openmp-extras-asan-rpath6.4.1-18.63.0.60401-83.el8.x86_64.rpm",
+        "version": "18.63.0.60401"
       }
     ],
-    "version": "18.63.0.60401-83"
+    "version": "18.63.0.60401"
   },
-  "openmp-extras-dev": {
+  "openmp-extras-devel": {
     "deps": [
       "hsa-rocr",
       "openmp-extras-runtime",
@@ -1328,19 +1328,19 @@
     ],
     "components": [
       {
-        "name": "openmp-extras-dev",
-        "sha256": "973fc5a040be9b80c53407256eab518d0714355bc53f34281266e1c24d788c98",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/o/openmp-extras-dev/openmp-extras-dev_18.63.0.60401-83~22.04_amd64.deb",
-        "version": "18.63.0.60401-83"
+        "name": "openmp-extras-devel",
+        "sha256": "aa8c476e55cccb44f69eac0c719f01a679f8eb539d52526b7f2acf7c6031e58c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/openmp-extras-devel-18.63.0.60401-83.el8.x86_64.rpm",
+        "version": "18.63.0.60401"
       },
       {
-        "name": "openmp-extras-dev-rpath",
-        "sha256": "1ad7861ae14737f38359419bc91b8202a04e397b88f3bddba58b60d4078ae73c",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/o/openmp-extras-dev-rpath6.4.1/openmp-extras-dev-rpath6.4.1_18.63.0.60401-83~22.04_amd64.deb",
-        "version": "18.63.0.60401-83"
+        "name": "openmp-extras-devel-rpath",
+        "sha256": "a48cab41667142cec577f4041a88098759cc3fd8017ca26503f2180e5b34d78d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/openmp-extras-devel-rpath6.4.1-18.63.0.60401-83.el8.x86_64.rpm",
+        "version": "18.63.0.60401"
       }
     ],
-    "version": "18.63.0.60401-83"
+    "version": "18.63.0.60401"
   },
   "openmp-extras-runtime": {
     "deps": [
@@ -1350,18 +1350,18 @@
     "components": [
       {
         "name": "openmp-extras-runtime",
-        "sha256": "d09b8062ae72113b3486bfab6a3d648cdcf60ef334c08f6c95466d803b0aa216",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/o/openmp-extras-runtime/openmp-extras-runtime_18.63.0.60401-83~22.04_amd64.deb",
-        "version": "18.63.0.60401-83"
+        "sha256": "0debfadc7ec49b4c4c03abb86f8756033f1a8967aa424f3680c829e684c642a5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/openmp-extras-runtime-18.63.0.60401-83.el8.x86_64.rpm",
+        "version": "18.63.0.60401"
       },
       {
         "name": "openmp-extras-runtime-rpath",
-        "sha256": "88540f7faf63218b8ac07c45ea19d1d1a3ad2875be8261473aa15d2840052369",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/o/openmp-extras-runtime-rpath6.4.1/openmp-extras-runtime-rpath6.4.1_18.63.0.60401-83~22.04_amd64.deb",
-        "version": "18.63.0.60401-83"
+        "sha256": "a17b6308aafa11c95f668fb691cbec1e1c5436b587407705b63dafc40388319c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/openmp-extras-runtime-rpath6.4.1-18.63.0.60401-83.el8.x86_64.rpm",
+        "version": "18.63.0.60401"
       }
     ],
-    "version": "18.63.0.60401-83"
+    "version": "18.63.0.60401"
   },
   "rccl": {
     "deps": [
@@ -1372,53 +1372,52 @@
     "components": [
       {
         "name": "rccl",
-        "sha256": "6b5675f7bb81b03387a64478a896a671d10e83a5629e54a0c3a8bf503a7ac106",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rccl/rccl_2.22.3.60401-83~22.04_amd64.deb",
-        "version": "2.22.3.60401-83"
+        "sha256": "1280e3adfc2bab0c449561afd0899e6422be427e937efce1e474e3fe5b007170",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rccl-2.22.3.60401-83.el8.x86_64.rpm",
+        "version": "2.22.3.60401"
       },
       {
-        "name": "rccl-dev",
-        "sha256": "fa563de9f06da443203e2b3d893d4a412541ba23e7a426200914aecd99baadeb",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rccl-dev/rccl-dev_2.22.3.60401-83~22.04_amd64.deb",
-        "version": "2.22.3.60401-83"
+        "name": "rccl-devel",
+        "sha256": "30a74cdf81b10651269734b3ec1c94f42cdf307de8548593e8fed6e740693f50",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rccl-devel-2.22.3.60401-83.el8.x86_64.rpm",
+        "version": "2.22.3.60401"
       },
       {
-        "name": "rccl-dev-rpath",
-        "sha256": "7fef24767b7b0915d9769ec6ccfe9684a1ec6e81154b6c67f591bd8bc43d7017",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rccl-dev-rpath6.4.1/rccl-dev-rpath6.4.1_2.22.3.60401-83~22.04_amd64.deb",
-        "version": "2.22.3.60401-83"
+        "name": "rccl-devel-rpath",
+        "sha256": "3820f3841ef458dbbcbc1138bd14e020dd916e4031d25eadc3bf058b6c31573a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rccl-devel-rpath6.4.1-2.22.3.60401-83.el8.x86_64.rpm",
+        "version": "2.22.3.60401"
       },
       {
         "name": "rccl-rpath",
-        "sha256": "ac467aa0177e872fe919f36163c4b5ab5189d29eb0be93991910e45ba340871a",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rccl-rpath6.4.1/rccl-rpath6.4.1_2.22.3.60401-83~22.04_amd64.deb",
-        "version": "2.22.3.60401-83"
+        "sha256": "147511ddd51cc3381c213ca2d803311ea81d982e9f0ff383470a08ade42c7a22",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rccl-rpath6.4.1-2.22.3.60401-83.el8.x86_64.rpm",
+        "version": "2.22.3.60401"
       }
     ],
-    "version": "2.22.3.60401-83"
+    "version": "2.22.3.60401"
   },
   "rccl-asan": {
     "deps": [
       "hip-runtime-amd-asan",
       "rocm-core-asan",
-      "rocm-smi-lib",
-      "rocprofiler-register"
+      "rocm-smi-lib"
     ],
     "components": [
       {
         "name": "rccl-asan",
-        "sha256": "205ebe6360fedb0f3554285194b7c79196509e1d27a19633c6cffb08ea750456",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rccl-asan/rccl-asan_2.22.3.60401-83~22.04_amd64.deb",
-        "version": "2.22.3.60401-83"
+        "sha256": "8cac4ee68ad877d3e2b093f33d3913fdae4b58813e5b29fb45f914b38b1599d2",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rccl-asan-2.22.3.60401-83.el8.x86_64.rpm",
+        "version": "2.22.3.60401"
       },
       {
         "name": "rccl-asan-rpath",
-        "sha256": "f17c7e426ac1f0d8cf54de6f4c01a126793892759b7547f688c92cfba1c5d870",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rccl-asan-rpath6.4.1/rccl-asan-rpath6.4.1_2.22.3.60401-83~22.04_amd64.deb",
-        "version": "2.22.3.60401-83"
+        "sha256": "b11213a6d2555590929dcadad553387bdd71f2ead7a0f787449650a565c5325a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rccl-asan-rpath6.4.1-2.22.3.60401-83.el8.x86_64.rpm",
+        "version": "2.22.3.60401"
       }
     ],
-    "version": "2.22.3.60401-83"
+    "version": "2.22.3.60401"
   },
   "rccl-unittests": {
     "deps": [
@@ -1427,18 +1426,18 @@
     "components": [
       {
         "name": "rccl-unittests",
-        "sha256": "467b2e3a9bee13206392156c43a599309ce915620c7216594cc264360e1f3433",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rccl-unittests/rccl-unittests_2.22.3.60401-83~22.04_amd64.deb",
-        "version": "2.22.3.60401-83"
+        "sha256": "2e13b25e12e07f2c562f32520f2cd5ff862e073e4387c49d51896f75c47a065c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rccl-unittests-2.22.3.60401-83.el8.x86_64.rpm",
+        "version": "2.22.3.60401"
       },
       {
         "name": "rccl-unittests-rpath",
-        "sha256": "71b565f01418bcd292d2c852ce5952f9f43700383caf5db532cb9031815bd75c",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rccl-unittests-rpath6.4.1/rccl-unittests-rpath6.4.1_2.22.3.60401-83~22.04_amd64.deb",
-        "version": "2.22.3.60401-83"
+        "sha256": "699c6115147e246b53e6b5d23bf365060b38abbcdc2bd59ebe8d40a8686669f0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rccl-unittests-rpath6.4.1-2.22.3.60401-83.el8.x86_64.rpm",
+        "version": "2.22.3.60401"
       }
     ],
-    "version": "2.22.3.60401-83"
+    "version": "2.22.3.60401"
   },
   "rdc": {
     "deps": [
@@ -1447,18 +1446,18 @@
     "components": [
       {
         "name": "rdc",
-        "sha256": "c0326a2b41a661d8d1b6671216e860504fc88ded78bda4bacdf29a301be0155d",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rdc/rdc_0.3.0.60401-83~22.04_amd64.deb",
-        "version": "0.3.0.60401-83"
+        "sha256": "818339612a8083260876cc879308d8a01c58157bc23eeb9746c21cdd50829536",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rdc-0.3.0.60401-83.el8.x86_64.rpm",
+        "version": "0.3.0.60401"
       },
       {
         "name": "rdc-rpath",
-        "sha256": "594c093c8a294b7313af8a65b198c2c092275a8f0f634e21452cc84a84cbf894",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rdc-rpath6.4.1/rdc-rpath6.4.1_0.3.0.60401-83~22.04_amd64.deb",
-        "version": "0.3.0.60401-83"
+        "sha256": "d835439cb20f6e1c14217dcaa90cf6c67e022065d3045ed37836140872b5ea95",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rdc-rpath6.4.1-0.3.0.60401-83.el8.x86_64.rpm",
+        "version": "0.3.0.60401"
       }
     ],
-    "version": "0.3.0.60401-83"
+    "version": "0.3.0.60401"
   },
   "rocal": {
     "deps": [
@@ -1468,30 +1467,30 @@
     "components": [
       {
         "name": "rocal",
-        "sha256": "dbecd41f3ea697fc528106ebd82f4aac6d6fac360e752925fab3c744c346feb0",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocal/rocal_2.2.0.60401-83~22.04_amd64.deb",
-        "version": "2.2.0.60401-83"
+        "sha256": "1209b69636a029bfb1060b3c7caae27c45f545c3d3788ff053402f93a8d4905f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocal-2.2.0.60401-83.x86_64.rpm",
+        "version": "2.2.0.60401"
       },
       {
-        "name": "rocal-dev",
-        "sha256": "c08222589c54dc3c862a52c7f76c595ab66eadf5038dd434b5a1783a02bc5c56",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocal-dev/rocal-dev_2.2.0.60401-83~22.04_amd64.deb",
-        "version": "2.2.0.60401-83"
+        "name": "rocal-devel",
+        "sha256": "b00ec2bcc36a3cd1f3eeee201c5064efbce5760c784b1740e32e9e8db9305a10",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocal-devel-2.2.0.60401-83.x86_64.rpm",
+        "version": "2.2.0.60401"
       },
       {
-        "name": "rocal-dev-rpath",
-        "sha256": "a2365d59af68aad599c2d98e91266e27ea83062acd22d017fc6fbaaaf26f6acd",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocal-dev-rpath6.4.1/rocal-dev-rpath6.4.1_2.2.0.60401-83~22.04_amd64.deb",
-        "version": "2.2.0.60401-83"
+        "name": "rocal-devel-rpath",
+        "sha256": "8dc324d4cccebcbc9ceaaa31b1a1eb09eb5bec6d189d3b16c5ea29a89321ac6c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocal-devel-rpath6.4.1-2.2.0.60401-83.x86_64.rpm",
+        "version": "2.2.0.60401"
       },
       {
         "name": "rocal-rpath",
-        "sha256": "21cbab94880920934d42d61ed84f4f001ec570887b5f2220703b00edd4088a2c",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocal-rpath6.4.1/rocal-rpath6.4.1_2.2.0.60401-83~22.04_amd64.deb",
-        "version": "2.2.0.60401-83"
+        "sha256": "b5942fd9dba4a1c8a6d99145575ad954ad4b39db405e14897437635fa8589029",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocal-rpath6.4.1-2.2.0.60401-83.x86_64.rpm",
+        "version": "2.2.0.60401"
       }
     ],
-    "version": "2.2.0.60401-83"
+    "version": "2.2.0.60401"
   },
   "rocal-test": {
     "deps": [
@@ -1500,18 +1499,18 @@
     "components": [
       {
         "name": "rocal-test",
-        "sha256": "5183d24ed44a79f25bf8cdbdef74706292b9571c84650ab85dd2e48a2d99dd78",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocal-test/rocal-test_2.2.0.60401-83~22.04_amd64.deb",
-        "version": "2.2.0.60401-83"
+        "sha256": "bf2af6791ba77e4f744bb5d79d975fb91cff2d7ba15f3a9fa8f660cee32c88e1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocal-test-2.2.0.60401-83.x86_64.rpm",
+        "version": "2.2.0.60401"
       },
       {
         "name": "rocal-test-rpath",
-        "sha256": "4263cb74ced5db7ebd90b330b949714e6ec070633b8fd42d6c95b2fe1cc5a844",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocal-test-rpath6.4.1/rocal-test-rpath6.4.1_2.2.0.60401-83~22.04_amd64.deb",
-        "version": "2.2.0.60401-83"
+        "sha256": "b3fdd5fc6148e881c5b671f039b9db20cb813308dfc52b267538fe03e7e0dc3b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocal-test-rpath6.4.1-2.2.0.60401-83.x86_64.rpm",
+        "version": "2.2.0.60401"
       }
     ],
-    "version": "2.2.0.60401-83"
+    "version": "2.2.0.60401"
   },
   "rocalution": {
     "deps": [
@@ -1524,30 +1523,30 @@
     "components": [
       {
         "name": "rocalution",
-        "sha256": "e4ed7ff01779b2ba65b30ba4692fa5d32486cfa24c8257a2f292379e02ad361b",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocalution/rocalution_3.2.3.60401-83~22.04_amd64.deb",
-        "version": "3.2.3.60401-83"
+        "sha256": "d29ce644bd5771b5d0c1a30a23edce1ed790afbdc140677b9eb556c81e213fbd",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocalution-3.2.3.60401-83.el8.x86_64.rpm",
+        "version": "3.2.3.60401"
       },
       {
-        "name": "rocalution-dev",
-        "sha256": "f92fd52326dc37cb01da296df6eed57332eed14260558fd3f3eab105af6d745b",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocalution-dev/rocalution-dev_3.2.3.60401-83~22.04_amd64.deb",
-        "version": "3.2.3.60401-83"
+        "name": "rocalution-devel",
+        "sha256": "60fa06be5d85d36adbcbbc50a9dc83640af49578627e1958c974b0c52b9b0d75",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocalution-devel-3.2.3.60401-83.el8.x86_64.rpm",
+        "version": "3.2.3.60401"
       },
       {
-        "name": "rocalution-dev-rpath",
-        "sha256": "e213720450ee21eee7a65d19420d8d8a4d12aa35756ce1fa9ed28abd4dd8f670",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocalution-dev-rpath6.4.1/rocalution-dev-rpath6.4.1_3.2.3.60401-83~22.04_amd64.deb",
-        "version": "3.2.3.60401-83"
+        "name": "rocalution-devel-rpath",
+        "sha256": "7282812b0691e37c52774c67d0865c5162ed9915e00d3afe5bd0622fc39ef7d6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocalution-devel-rpath6.4.1-3.2.3.60401-83.el8.x86_64.rpm",
+        "version": "3.2.3.60401"
       },
       {
         "name": "rocalution-rpath",
-        "sha256": "efe82b4140ff69b6127fb7ff98220e3e3675c981805be2609977530fa549f32a",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocalution-rpath6.4.1/rocalution-rpath6.4.1_3.2.3.60401-83~22.04_amd64.deb",
-        "version": "3.2.3.60401-83"
+        "sha256": "766d4e41996e947007d23e4b66fc8f6c7d42e6de79d5c415fb839784f65f4227",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocalution-rpath6.4.1-3.2.3.60401-83.el8.x86_64.rpm",
+        "version": "3.2.3.60401"
       }
     ],
-    "version": "3.2.3.60401-83"
+    "version": "3.2.3.60401"
   },
   "rocalution-asan": {
     "deps": [
@@ -1560,18 +1559,18 @@
     "components": [
       {
         "name": "rocalution-asan",
-        "sha256": "399a56898051ff5d42e8c4248a467726f014d2e4f650fa9c3f4b6421dd714586",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocalution-asan/rocalution-asan_3.2.3.60401-83~22.04_amd64.deb",
-        "version": "3.2.3.60401-83"
+        "sha256": "edf6be46993a7e9a2881a90d431968153a59c9bfa94b1b9e2fbb988533b19d5b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocalution-asan-3.2.3.60401-83.el8.x86_64.rpm",
+        "version": "3.2.3.60401"
       },
       {
         "name": "rocalution-asan-rpath",
-        "sha256": "8bf969961a929696824169db2ae802a365e1ddc4b9710dbf0695aa9364b38939",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocalution-asan-rpath6.4.1/rocalution-asan-rpath6.4.1_3.2.3.60401-83~22.04_amd64.deb",
-        "version": "3.2.3.60401-83"
+        "sha256": "5ca4af236a78be5f6d8b1bea1fe30fc6023b2bfb4bdcc85dc3648ee41e240d00",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocalution-asan-rpath6.4.1-3.2.3.60401-83.el8.x86_64.rpm",
+        "version": "3.2.3.60401"
       }
     ],
-    "version": "3.2.3.60401-83"
+    "version": "3.2.3.60401"
   },
   "rocblas": {
     "deps": [
@@ -1582,30 +1581,30 @@
     "components": [
       {
         "name": "rocblas",
-        "sha256": "0f850a080c312d80c0b928b48efca4fb507c64e95536aaefe7f23c6fc0c1fe09",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocblas/rocblas_4.4.0.60401-83~22.04_amd64.deb",
-        "version": "4.4.0.60401-83"
+        "sha256": "ae8309b4e0987b7a792f6e6f536314e7a30a6725cd9bd16f0b59cfdaedf75fce",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocblas-4.4.0.60401-83.el8.x86_64.rpm",
+        "version": "4.4.0.60401"
       },
       {
-        "name": "rocblas-dev",
-        "sha256": "caffc1656c4a6e5507fdf1e24ef1e30def2f5fa02ac0dd1ff3cdbc7a27f2cd0c",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocblas-dev/rocblas-dev_4.4.0.60401-83~22.04_amd64.deb",
-        "version": "4.4.0.60401-83"
+        "name": "rocblas-devel",
+        "sha256": "87f29911d664a7306ceaf6dffafb4a98e94a42faf7178c2ae469bfe31816b392",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocblas-devel-4.4.0.60401-83.el8.x86_64.rpm",
+        "version": "4.4.0.60401"
       },
       {
-        "name": "rocblas-dev-rpath",
-        "sha256": "f891c4c14451b82e42ed456a4a48d58045c2b01bad8c47d9cbb8ed00f0d2d0da",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocblas-dev-rpath6.4.1/rocblas-dev-rpath6.4.1_4.4.0.60401-83~22.04_amd64.deb",
-        "version": "4.4.0.60401-83"
+        "name": "rocblas-devel-rpath",
+        "sha256": "9306c9a031040c02ed10be10aebf5ce65b24f1ea3e0202fc484558ae051a58e1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocblas-devel-rpath6.4.1-4.4.0.60401-83.el8.x86_64.rpm",
+        "version": "4.4.0.60401"
       },
       {
         "name": "rocblas-rpath",
-        "sha256": "b72b451e965c4b153691b935cd71c6c0e1cd4cc4438d0cf0baf980681c27fab1",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocblas-rpath6.4.1/rocblas-rpath6.4.1_4.4.0.60401-83~22.04_amd64.deb",
-        "version": "4.4.0.60401-83"
+        "sha256": "19fec459b20538e5a5f7ae9512edd8c59e7c138ab7d8544eb859e0ec8f9cabb6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocblas-rpath6.4.1-4.4.0.60401-83.el8.x86_64.rpm",
+        "version": "4.4.0.60401"
       }
     ],
-    "version": "4.4.0.60401-83"
+    "version": "4.4.0.60401"
   },
   "rocblas-asan": {
     "deps": [
@@ -1616,18 +1615,18 @@
     "components": [
       {
         "name": "rocblas-asan",
-        "sha256": "b36acae0e4ef9280e20cd77e72841d63b8e03440488bfd054d297de643984fd1",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocblas-asan/rocblas-asan_4.4.0.60401-83~22.04_amd64.deb",
-        "version": "4.4.0.60401-83"
+        "sha256": "ad941ffbb7b2f37d9455b2ec5a9610ae4bc01a836bc17263e84376f3d8608bc2",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocblas-asan-4.4.0.60401-83.el8.x86_64.rpm",
+        "version": "4.4.0.60401"
       },
       {
         "name": "rocblas-asan-rpath",
-        "sha256": "ee96f0d16702f10d2c5939ad20a2fc7c6b58155014f487fadd3944bf208c3a8b",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocblas-asan-rpath6.4.1/rocblas-asan-rpath6.4.1_4.4.0.60401-83~22.04_amd64.deb",
-        "version": "4.4.0.60401-83"
+        "sha256": "4567c424bcbc9776ae72863df638e0b44301a9ce077bead8fc2ec8cc29d9fa55",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocblas-asan-rpath6.4.1-4.4.0.60401-83.el8.x86_64.rpm",
+        "version": "4.4.0.60401"
       }
     ],
-    "version": "4.4.0.60401-83"
+    "version": "4.4.0.60401"
   },
   "rocdecode": {
     "deps": [
@@ -1638,30 +1637,30 @@
     "components": [
       {
         "name": "rocdecode",
-        "sha256": "d54cb25b1de11baced19c02b2d593ae0170a7ae0899a4618c724b1bfda8c9c26",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocdecode/rocdecode_0.10.0.60401-83~22.04_amd64.deb",
-        "version": "0.10.0.60401-83"
+        "sha256": "758c89fe91af013549c511b699ddd233308439658f60efdd316174e32f0daa11",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocdecode-0.10.0.60401-83.x86_64.rpm",
+        "version": "0.10.0.60401"
       },
       {
-        "name": "rocdecode-dev",
-        "sha256": "84a5b1ca4e4d0e0752c2d0496d78cad98a8b549d9a2828ece21e23c5105d8675",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocdecode-dev/rocdecode-dev_0.10.0.60401-83~22.04_amd64.deb",
-        "version": "0.10.0.60401-83"
+        "name": "rocdecode-devel",
+        "sha256": "acb23e8d0b7d5469d795c3025254cee4e971500eb3e6ec442e2a9e5b8b66e433",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocdecode-devel-0.10.0.60401-83.x86_64.rpm",
+        "version": "0.10.0.60401"
       },
       {
-        "name": "rocdecode-dev-rpath",
-        "sha256": "f6a877d81662ad92da581a7e3fcd9ed4a81f856f282b8db1c12580f2334c3bfc",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocdecode-dev-rpath6.4.1/rocdecode-dev-rpath6.4.1_0.10.0.60401-83~22.04_amd64.deb",
-        "version": "0.10.0.60401-83"
+        "name": "rocdecode-devel-rpath",
+        "sha256": "11caf72ba5eabcbc460e9e9cae42b0983dc80821fed6f485c2af755f04298e01",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocdecode-devel-rpath6.4.1-0.10.0.60401-83.x86_64.rpm",
+        "version": "0.10.0.60401"
       },
       {
         "name": "rocdecode-rpath",
-        "sha256": "e8a49ef1e9d3f18ce3cc97ae7a9e2bb59a0980478b675143547b75e25ddb62f4",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocdecode-rpath6.4.1/rocdecode-rpath6.4.1_0.10.0.60401-83~22.04_amd64.deb",
-        "version": "0.10.0.60401-83"
+        "sha256": "f9baef2aab64c38712c9a9c880d19984cbea7a801801b97bca48ee6f87e76dd0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocdecode-rpath6.4.1-0.10.0.60401-83.x86_64.rpm",
+        "version": "0.10.0.60401"
       }
     ],
-    "version": "0.10.0.60401-83"
+    "version": "0.10.0.60401"
   },
   "rocdecode-test": {
     "deps": [
@@ -1671,18 +1670,18 @@
     "components": [
       {
         "name": "rocdecode-test",
-        "sha256": "4257b265a66adfca2038114514b24dd48391e090ea167a1c44eb3aeb3cbf2954",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocdecode-test/rocdecode-test_0.10.0.60401-83~22.04_amd64.deb",
-        "version": "0.10.0.60401-83"
+        "sha256": "a5fcc499107f1e8192e8d42dfebc1f01cf47d22171a61b59f95bf56c4a20d4fb",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocdecode-test-0.10.0.60401-83.x86_64.rpm",
+        "version": "0.10.0.60401"
       },
       {
         "name": "rocdecode-test-rpath",
-        "sha256": "3ebadf0079995e08720199e887a008c2740b01aafb7105b56ac062ca759029b6",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocdecode-test-rpath6.4.1/rocdecode-test-rpath6.4.1_0.10.0.60401-83~22.04_amd64.deb",
-        "version": "0.10.0.60401-83"
+        "sha256": "80c58250c947c1e824d679564cb723371a93b7a2be038e25d7fbd3e3ff0497f7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocdecode-test-rpath6.4.1-0.10.0.60401-83.x86_64.rpm",
+        "version": "0.10.0.60401"
       }
     ],
-    "version": "0.10.0.60401-83"
+    "version": "0.10.0.60401"
   },
   "rocfft": {
     "deps": [
@@ -1691,30 +1690,30 @@
     "components": [
       {
         "name": "rocfft",
-        "sha256": "0c2ec9e4b492adb6d782db21d6438751d93be4c0ac64a9b8d0dd294a32ca7586",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocfft/rocfft_1.0.32.60401-83~22.04_amd64.deb",
-        "version": "1.0.32.60401-83"
+        "sha256": "d6b88381c84b4aa8121cd6a6aa747947b79b45d2990df53892ee79e7980059cb",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocfft-1.0.32.60401-83.el8.x86_64.rpm",
+        "version": "1.0.32.60401"
       },
       {
-        "name": "rocfft-dev",
-        "sha256": "d0b91fdedc947ca4d023ae8aca3d04471d91ee7ba541e1b2f0bd4fbae59198a2",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocfft-dev/rocfft-dev_1.0.32.60401-83~22.04_amd64.deb",
-        "version": "1.0.32.60401-83"
+        "name": "rocfft-devel",
+        "sha256": "93efc5e9516cdee2eda9f52366fca05b6b6171039e3bcde1ed2e5356bdcb7d0e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocfft-devel-1.0.32.60401-83.el8.x86_64.rpm",
+        "version": "1.0.32.60401"
       },
       {
-        "name": "rocfft-dev-rpath",
-        "sha256": "0869b386fee5fb76b7eb20013398d6130b1565a55a3fd3b1e7b5212f4413dda0",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocfft-dev-rpath6.4.1/rocfft-dev-rpath6.4.1_1.0.32.60401-83~22.04_amd64.deb",
-        "version": "1.0.32.60401-83"
+        "name": "rocfft-devel-rpath",
+        "sha256": "42bbd1c43adcc0e970dd76829fdac8314aace34d3532831e885dab66e7d6bb52",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocfft-devel-rpath6.4.1-1.0.32.60401-83.el8.x86_64.rpm",
+        "version": "1.0.32.60401"
       },
       {
         "name": "rocfft-rpath",
-        "sha256": "d122f81cdd499b108b76e412e58184a837a4bc4d9743d1310a5175fe5817341a",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocfft-rpath6.4.1/rocfft-rpath6.4.1_1.0.32.60401-83~22.04_amd64.deb",
-        "version": "1.0.32.60401-83"
+        "sha256": "55e45016030889e1942bbe1828f327585813e12749d50560abcb81ab0b25de52",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocfft-rpath6.4.1-1.0.32.60401-83.el8.x86_64.rpm",
+        "version": "1.0.32.60401"
       }
     ],
-    "version": "1.0.32.60401-83"
+    "version": "1.0.32.60401"
   },
   "rocfft-asan": {
     "deps": [
@@ -1723,18 +1722,18 @@
     "components": [
       {
         "name": "rocfft-asan",
-        "sha256": "f733746ade59104f43dcdf9c3c993ab7544c62ee580a847276afe4b9de34df3f",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocfft-asan/rocfft-asan_1.0.32.60401-83~22.04_amd64.deb",
-        "version": "1.0.32.60401-83"
+        "sha256": "bd13b628b568eccb93bb0dae27b9ae518b4f06fce155d53e18f1dcbc8f0f9587",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocfft-asan-1.0.32.60401-83.el8.x86_64.rpm",
+        "version": "1.0.32.60401"
       },
       {
         "name": "rocfft-asan-rpath",
-        "sha256": "f17dfa379752709ea22fdc87f20b27fd885e4eef1af6a43dc885da867f07ecf0",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocfft-asan-rpath6.4.1/rocfft-asan-rpath6.4.1_1.0.32.60401-83~22.04_amd64.deb",
-        "version": "1.0.32.60401-83"
+        "sha256": "bd7889b99baa0cabcb0d798d2a95c46bd7cfb60f91388b70348d6901dd2b0a62",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocfft-asan-rpath6.4.1-1.0.32.60401-83.el8.x86_64.rpm",
+        "version": "1.0.32.60401"
       }
     ],
-    "version": "1.0.32.60401-83"
+    "version": "1.0.32.60401"
   },
   "rocjpeg": {
     "deps": [
@@ -1745,30 +1744,30 @@
     "components": [
       {
         "name": "rocjpeg",
-        "sha256": "4b1963e86df3379a8067f5d75e0dc15bb24d050e2c6f47e2f95650264a28b3b5",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocjpeg/rocjpeg_0.8.0.60401-83~22.04_amd64.deb",
-        "version": "0.8.0.60401-83"
+        "sha256": "774693749e531fa57c788bfc19ba652f69f3d8e1d12a49d947726d0345be9f0d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocjpeg-0.8.0.60401-83.x86_64.rpm",
+        "version": "0.8.0.60401"
       },
       {
-        "name": "rocjpeg-dev",
-        "sha256": "ac62e6ac447b65f123fa6849162df75c8ae14d3e9b1462de0dc0524df5abea69",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocjpeg-dev/rocjpeg-dev_0.8.0.60401-83~22.04_amd64.deb",
-        "version": "0.8.0.60401-83"
+        "name": "rocjpeg-devel",
+        "sha256": "eff40d51c442d7bc97f44caeea145ecd7fe77300cf810172c84e0d4ddff73f51",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocjpeg-devel-0.8.0.60401-83.x86_64.rpm",
+        "version": "0.8.0.60401"
       },
       {
-        "name": "rocjpeg-dev-rpath",
-        "sha256": "4ada2e04ef5e11483d0baf65b6ffdb1f6f35ee191e5c5cd230b14ce10e59c4bf",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocjpeg-dev-rpath6.4.1/rocjpeg-dev-rpath6.4.1_0.8.0.60401-83~22.04_amd64.deb",
-        "version": "0.8.0.60401-83"
+        "name": "rocjpeg-devel-rpath",
+        "sha256": "2cb047ec7fa26e7be02451f2e4e44953388b1c4fc2da1a1cab6fd79d5121796d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocjpeg-devel-rpath6.4.1-0.8.0.60401-83.x86_64.rpm",
+        "version": "0.8.0.60401"
       },
       {
         "name": "rocjpeg-rpath",
-        "sha256": "9f9e61e81db6090800970167f7aaa8c019476a5d4ec016731166d005a252ca91",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocjpeg-rpath6.4.1/rocjpeg-rpath6.4.1_0.8.0.60401-83~22.04_amd64.deb",
-        "version": "0.8.0.60401-83"
+        "sha256": "5e8c43bf4caec491d986385f44adc25c13cc410bb1df6d5f7a1d56c77b0062de",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocjpeg-rpath6.4.1-0.8.0.60401-83.x86_64.rpm",
+        "version": "0.8.0.60401"
       }
     ],
-    "version": "0.8.0.60401-83"
+    "version": "0.8.0.60401"
   },
   "rocjpeg-test": {
     "deps": [
@@ -1778,84 +1777,46 @@
     "components": [
       {
         "name": "rocjpeg-test",
-        "sha256": "f64726a30471947bb516bfb627dfd01c6e8416dae0af25e84f9e969351a4b5dd",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocjpeg-test/rocjpeg-test_0.8.0.60401-83~22.04_amd64.deb",
-        "version": "0.8.0.60401-83"
+        "sha256": "5bbf18cc379be8cf2a84a386a345ead303347909b0efcf125a4543f9efb2cecc",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocjpeg-test-0.8.0.60401-83.x86_64.rpm",
+        "version": "0.8.0.60401"
       },
       {
         "name": "rocjpeg-test-rpath",
-        "sha256": "a5909d5f1d3fa43f061f90c9bb4ad47a732b4e31a400fe373d01f5e2f15c61d0",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocjpeg-test-rpath6.4.1/rocjpeg-test-rpath6.4.1_0.8.0.60401-83~22.04_amd64.deb",
-        "version": "0.8.0.60401-83"
+        "sha256": "2d9582ea8fa73aabb46bdee5aa5aa3831d69f1e2bf79a534edce60b47c139639",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocjpeg-test-rpath6.4.1-0.8.0.60401-83.x86_64.rpm",
+        "version": "0.8.0.60401"
       }
     ],
-    "version": "0.8.0.60401-83"
+    "version": "0.8.0.60401"
   },
   "rocm": {
     "deps": [
-      "amd-smi-lib",
-      "comgr",
-      "hip-dev",
-      "hip-doc",
-      "hip-runtime-amd",
-      "hip-samples",
-      "hipcc",
-      "hipify-clang",
-      "hsa-amd-aqlprofile",
-      "hsa-rocr",
       "migraphx",
       "mivisionx",
-      "openmp-extras-dev",
-      "openmp-extras-runtime",
-      "rocm-cmake",
       "rocm-core",
-      "rocm-dbgapi",
-      "rocm-debug-agent",
       "rocm-developer-tools",
-      "rocm-device-libs",
-      "rocm-gdb",
-      "rocm-llvm",
       "rocm-ml-sdk",
-      "rocm-opencl",
       "rocm-opencl-sdk",
       "rocm-openmp-sdk",
-      "rocm-smi-lib",
       "rocm-utils",
-      "rocprofiler",
-      "rocprofiler-plugins",
-      "rocprofiler-register",
-      "rocprofiler-sdk",
-      "rocprofiler-sdk-roctx",
-      "roctracer",
       "rpp"
     ],
     "components": [
       {
         "name": "rocm",
-        "sha256": "79e33d1eb05122e8d856780f199ea87220439e8ce3836df7027e70ff813fe6ee",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm/rocm_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
-      },
-      {
-        "name": "rocm-dev",
-        "sha256": "b06fb5e5c26109a73a6aef1f340909a1730781315579892d55faca92e9fcb9cc",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-dev/rocm-dev_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
-      },
-      {
-        "name": "rocm-dev-rpath",
-        "sha256": "3848dcaf143970e8b4faa8cab190bd45dd3e3a88b0fff50a7919cb362d46035f",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-dev-rpath6.4.1/rocm-dev-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "65aad0e7175229549aeffc471959e9ae3620d063cd6a5fad0681c9cd531a0671",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-rpath",
-        "sha256": "a1fcc64b26a6738652d35b9f87dbab42c8bdae3dcabaf59a577f0182b66a327b",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-rpath6.4.1/rocm-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "6cfe8841b8f5b03c10385e5d4ce31d5124f9a0de005e611704c02d23fab91a2b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-asan": {
     "deps": [
@@ -1871,18 +1832,18 @@
     "components": [
       {
         "name": "rocm-asan",
-        "sha256": "3ac2099cebf5aa2539d20b5f3ef339878ac1afe088943d3c864759fcd58a8643",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-asan/rocm-asan_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "4b7712cf8c92c72a443ddbcad63bfd3dcc18ae0351aec103c3bab56e3f8a9458",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-asan-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-asan-rpath",
-        "sha256": "703e7c572405e73ea2fd469abc1ca6604972c5d27d6e1a9192a04de36c01f28f",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-asan-rpath6.4.1/rocm-asan-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "c74f76deb32c1b92425a7b374ca93d98a92c06d0b334ef8402191d8a5ebf3865",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-asan-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-bandwidth-test": {
     "deps": [
@@ -1891,18 +1852,18 @@
     "components": [
       {
         "name": "rocm-bandwidth-test",
-        "sha256": "65facc0681a82c7e4bf35cbc894f918e9949ca1393168fcb4d4f862ab1df5f5d",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-bandwidth-test/rocm-bandwidth-test_1.4.0.60401-83~22.04_amd64.deb",
-        "version": "1.4.0.60401-83"
+        "sha256": "7daff7600d932356bd89798442012ce5cbdd600df8e02a4c517e91847b40927d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-bandwidth-test-1.4.0.60401-83.el8.x86_64.rpm",
+        "version": "1.4.0.60401"
       },
       {
         "name": "rocm-bandwidth-test-rpath",
-        "sha256": "2607bf465cf17b893bcb1ea297c2f1df89c01521364d475b924c3810f7850caa",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-bandwidth-test-rpath6.4.1/rocm-bandwidth-test-rpath6.4.1_1.4.0.60401-83~22.04_amd64.deb",
-        "version": "1.4.0.60401-83"
+        "sha256": "1a4feda8f0d6e53737626b0b1de191b56c844e869282b8470339f5df7fa848cd",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-bandwidth-test-rpath6.4.1-1.4.0.60401-83.el8.x86_64.rpm",
+        "version": "1.4.0.60401"
       }
     ],
-    "version": "1.4.0.60401-83"
+    "version": "1.4.0.60401"
   },
   "rocm-cmake": {
     "deps": [
@@ -1911,36 +1872,36 @@
     "components": [
       {
         "name": "rocm-cmake",
-        "sha256": "8df81128faf1f4f3ba21a62e6f3433b6ac27e51c2070f243e5b6ed30941de174",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-cmake/rocm-cmake_0.14.0.60401-83~22.04_amd64.deb",
-        "version": "0.14.0.60401-83"
+        "sha256": "a428c4589468bb3cdb8ddb8c8c38c54fd87674e111c9ae22eb0d1ed0ba33fb33",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-cmake-0.14.0.60401-83.el8.x86_64.rpm",
+        "version": "0.14.0.60401"
       },
       {
         "name": "rocm-cmake-rpath",
-        "sha256": "164f46e1edad1eabd32c08e0e4d1c2827a9b6b455763c7c641a31d5cca1abd53",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-cmake-rpath6.4.1/rocm-cmake-rpath6.4.1_0.14.0.60401-83~22.04_amd64.deb",
-        "version": "0.14.0.60401-83"
+        "sha256": "880541ba78a976bfffad99e1cc68016bd48dc57eac91f570e7328c9069e9c5a4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-cmake-rpath6.4.1-0.14.0.60401-83.el8.x86_64.rpm",
+        "version": "0.14.0.60401"
       }
     ],
-    "version": "0.14.0.60401-83"
+    "version": "0.14.0.60401"
   },
   "rocm-core": {
     "deps": [],
     "components": [
       {
         "name": "rocm-core",
-        "sha256": "221236cf665597beea8c6faeffa1569fc35a6ad4cab89d5c8931974120b42621",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-core/rocm-core_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "371bd404f42a341763f524fa24bd7faccc5edb59610f6163a0fa034fd23b37c5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-core-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-core-rpath",
-        "sha256": "833792c9efba7d12568a8f951a8ae5302ddd65067f411df059d7e2e2fd462397",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-core-rpath6.4.1/rocm-core-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "534ecdfa8cc2d19598bfa04c98d390d476fa9fb86e269a30c2d02b496918f453",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-core-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-core-asan": {
     "deps": [
@@ -1949,58 +1910,60 @@
     "components": [
       {
         "name": "rocm-core-asan",
-        "sha256": "8de132cc26b33b8b8c9211cd4e41f40a5c9d0eaaa17ced1b1226dc50123315aa",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-core-asan/rocm-core-asan_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "e1da03e84959ce27cd050756b67364d711eb49167caa18bcef91dcc740cdeb06",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-core-asan-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-core-asan-rpath",
-        "sha256": "7573a7c0750ed4b29df49e44368825b365e817e5c598f01b8bffa433988e606a",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-core-asan-rpath6.4.1/rocm-core-asan-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "6f05841853d8074bc7624e1aaeadab356a30bbb4bad83f11b63a21586db84f4a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-core-asan-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-dbgapi": {
     "deps": [
+      "comgr",
       "rocm-core"
     ],
     "components": [
       {
         "name": "rocm-dbgapi",
-        "sha256": "a80130dd6332f86d891d3a345a27a4a9489a632bcda232dcb1c64878e5c0d2d7",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-dbgapi/rocm-dbgapi_0.77.2.60401-83~22.04_amd64.deb",
-        "version": "0.77.2.60401-83"
+        "sha256": "413753f1bf41c453b77dd041f685e54edc4aad56226a02a9acd46c22317fd9b5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-dbgapi-0.77.2.60401-83.el8.x86_64.rpm",
+        "version": "0.77.2.60401"
       },
       {
         "name": "rocm-dbgapi-rpath",
-        "sha256": "c3c80e02f4980ee7b0560445c3717e9cb6de5bba7538078f50af856a522e772f",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-dbgapi-rpath6.4.1/rocm-dbgapi-rpath6.4.1_0.77.2.60401-83~22.04_amd64.deb",
-        "version": "0.77.2.60401-83"
+        "sha256": "d0064c76785c29c88e8abd28a0c3866a1d88eb03bf2ec8959a2033a87a5f46f4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-dbgapi-rpath6.4.1-0.77.2.60401-83.el8.x86_64.rpm",
+        "version": "0.77.2.60401"
       }
     ],
-    "version": "0.77.2.60401-83"
+    "version": "0.77.2.60401"
   },
   "rocm-dbgapi-asan": {
     "deps": [
+      "comgr-asan",
       "rocm-core-asan"
     ],
     "components": [
       {
         "name": "rocm-dbgapi-asan",
-        "sha256": "5e67a3244b5b91eb17d864676c600c46e18224087449ea9591892e1b0955e19d",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-dbgapi-asan/rocm-dbgapi-asan_0.77.2.60401-83~22.04_amd64.deb",
-        "version": "0.77.2.60401-83"
+        "sha256": "cef088c0de129cc6fa6da859f92f3501463454347a495b7c2937e217c0b34264",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-dbgapi-asan-0.77.2.60401-83.el8.x86_64.rpm",
+        "version": "0.77.2.60401"
       },
       {
         "name": "rocm-dbgapi-asan-rpath",
-        "sha256": "a00be2a98787fc8038f6830f27c1ac305525e94cac7b3802853a5478fb56081b",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-dbgapi-asan-rpath6.4.1/rocm-dbgapi-asan-rpath6.4.1_0.77.2.60401-83~22.04_amd64.deb",
-        "version": "0.77.2.60401-83"
+        "sha256": "7d27c6f9c2c2f6434339b48d54deabcbee04cf65220a613caa1a05c43653ae58",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-dbgapi-asan-rpath6.4.1-0.77.2.60401-83.el8.x86_64.rpm",
+        "version": "0.77.2.60401"
       }
     ],
-    "version": "0.77.2.60401-83"
+    "version": "0.77.2.60401"
   },
   "rocm-debug-agent": {
     "deps": [
@@ -2010,18 +1973,18 @@
     "components": [
       {
         "name": "rocm-debug-agent",
-        "sha256": "d180451bc02625a2e62c11fec72c9ca684ba47841ea05347e4d35cb880938395",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-debug-agent/rocm-debug-agent_2.0.4.60401-83~22.04_amd64.deb",
-        "version": "2.0.4.60401-83"
+        "sha256": "afc8e72db847b4b7032cac12f813e71ff2c4c6bfe275c60da0e8f2133f90ce03",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-debug-agent-2.0.4.60401-83.el8.x86_64.rpm",
+        "version": "2.0.4.60401"
       },
       {
         "name": "rocm-debug-agent-rpath",
-        "sha256": "25a6d645f2ed1f62f8c7a867941f98a226c21df89ac57bd57ccb60c0b90aa0cc",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-debug-agent-rpath6.4.1/rocm-debug-agent-rpath6.4.1_2.0.4.60401-83~22.04_amd64.deb",
-        "version": "2.0.4.60401-83"
+        "sha256": "168d4554d4c2542a50241fe0d8b6392f0f32d0eba0bb348d3653987192976507",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-debug-agent-rpath6.4.1-2.0.4.60401-83.el8.x86_64.rpm",
+        "version": "2.0.4.60401"
       }
     ],
-    "version": "2.0.4.60401-83"
+    "version": "2.0.4.60401"
   },
   "rocm-debug-agent-asan": {
     "deps": [
@@ -2031,18 +1994,65 @@
     "components": [
       {
         "name": "rocm-debug-agent-asan",
-        "sha256": "2ca4effa9b245d8baf1c0edf1a08a719139fcdf763aff74b1b71a5fa81c61b14",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-debug-agent-asan/rocm-debug-agent-asan_2.0.4.60401-83~22.04_amd64.deb",
-        "version": "2.0.4.60401-83"
+        "sha256": "1e54a639548a9317e39406d23f192f14686fdfd682cfafbe56f9d8dbefd3530a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-debug-agent-asan-2.0.4.60401-83.el8.x86_64.rpm",
+        "version": "2.0.4.60401"
       },
       {
         "name": "rocm-debug-agent-asan-rpath",
-        "sha256": "e85ea66307bb3ecf5de88b021b396f1373c554b0283bb575d1e7ba8a0c547b71",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-debug-agent-asan-rpath6.4.1/rocm-debug-agent-asan-rpath6.4.1_2.0.4.60401-83~22.04_amd64.deb",
-        "version": "2.0.4.60401-83"
+        "sha256": "b2a9f10594f8505e1f5b2abc791f2722661fc22b2a2a0d321bb66c91971b0ec8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-debug-agent-asan-rpath6.4.1-2.0.4.60401-83.el8.x86_64.rpm",
+        "version": "2.0.4.60401"
       }
     ],
-    "version": "2.0.4.60401-83"
+    "version": "2.0.4.60401"
+  },
+  "rocm-dev": {
+    "deps": [
+      "amd-smi-lib",
+      "comgr",
+      "hip-devel",
+      "hip-doc",
+      "hip-runtime-amd",
+      "hip-samples",
+      "hipcc",
+      "hipify-clang",
+      "hsa-amd-aqlprofile",
+      "hsa-rocr",
+      "openmp-extras-devel",
+      "openmp-extras-runtime",
+      "rocm-cmake",
+      "rocm-core",
+      "rocm-dbgapi",
+      "rocm-debug-agent",
+      "rocm-device-libs",
+      "rocm-gdb",
+      "rocm-llvm",
+      "rocm-opencl",
+      "rocm-smi-lib",
+      "rocm-utils",
+      "rocprofiler",
+      "rocprofiler-plugins",
+      "rocprofiler-register",
+      "rocprofiler-sdk",
+      "rocprofiler-sdk-roctx",
+      "roctracer"
+    ],
+    "components": [
+      {
+        "name": "rocm-dev",
+        "sha256": "30b7c122a80022e23644786ab6483d1dfa26b2083833fc0438340300bf2e18c7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-dev-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
+      },
+      {
+        "name": "rocm-dev-rpath",
+        "sha256": "a15f1f982cbaf337987b55b7d24af088667ce8b854d2de41fe8d56e8e0140d54",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-dev-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
+      }
+    ],
+    "version": "6.4.1.60401"
   },
   "rocm-dev-asan": {
     "deps": [
@@ -2052,10 +2062,10 @@
       "hsa-amd-aqlprofile-asan",
       "hsa-rocr-asan",
       "openmp-extras-asan",
-      "rocm",
       "rocm-core-asan",
       "rocm-dbgapi-asan",
       "rocm-debug-agent-asan",
+      "rocm-dev",
       "rocm-opencl-asan",
       "rocm-smi-lib-asan",
       "rocprofiler-asan",
@@ -2064,18 +2074,18 @@
     "components": [
       {
         "name": "rocm-dev-asan",
-        "sha256": "c945960cf65ecbf497a2fce14a8e52e1971703fa1a45933470b8de840544490e",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-dev-asan/rocm-dev-asan_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "31e892ee55039833373f433a3be5d6f847a9af268b8c34269d773f88933016d4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-dev-asan-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-dev-asan-rpath",
-        "sha256": "034dccbdcacc07d5c299ec26853ab7cbb19ee007d0ecf0765dea205bbd69f4a6",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-dev-asan-rpath6.4.1/rocm-dev-asan-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "07728ab08aa715439cf7f6594fcec3597189b1c4b757f056252fe454fdfeb742",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-dev-asan-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-developer-tools": {
     "deps": [
@@ -2099,18 +2109,18 @@
     "components": [
       {
         "name": "rocm-developer-tools",
-        "sha256": "dc34bb9d5b5b9ba0056d680389b029ea7210f9fb64a036d7afb55337b5bd76fb",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-developer-tools/rocm-developer-tools_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "baa69641a72e035c9056adad0ea5a39648c0b7045736ba6d2f0b2062fc58a322",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-developer-tools-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-developer-tools-rpath",
-        "sha256": "1574067a6df18e556ed1bf07b57cf2cdd2a40d92e15382f439b2725084f04fc1",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-developer-tools-rpath6.4.1/rocm-developer-tools-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "d08e443520f372b77538a658b9eece8893755c7f0f4592724ecdb93d236ce836",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-developer-tools-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-developer-tools-asan": {
     "deps": [
@@ -2128,18 +2138,18 @@
     "components": [
       {
         "name": "rocm-developer-tools-asan",
-        "sha256": "c5a6020665aacbfcd3ba1331d790b9a0966eaed41900207cd0bf78ec77e6b6ff",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-developer-tools-asan/rocm-developer-tools-asan_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "2b349108060face057bd7beb9f48b11e42a336ba519ffea5bee0fd311dac5d78",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-developer-tools-asan-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-developer-tools-asan-rpath",
-        "sha256": "88acfe48a1a8760a195877099efee747a2cf4cc0930f5aec0ad0eca077e20dc3",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-developer-tools-asan-rpath6.4.1/rocm-developer-tools-asan-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "ffc4bf8c0f61f48b692b8f6be34fcffc502b388c17bc2f5fcd94a6aa35c904ef",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-developer-tools-asan-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-device-libs": {
     "deps": [
@@ -2148,18 +2158,18 @@
     "components": [
       {
         "name": "rocm-device-libs",
-        "sha256": "080c1cbcade5a22cea800256eccc993116ae05b60f11785fda76beffe68c38bf",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-device-libs/rocm-device-libs_1.0.0.60401-83~22.04_amd64.deb",
-        "version": "1.0.0.60401-83"
+        "sha256": "313fcf8d469ae7f8abaa9d0902c6601711474a53ea31cecde92d86df550a3241",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-device-libs-1.0.0.60401-83.el8.x86_64.rpm",
+        "version": "1.0.0.60401"
       },
       {
         "name": "rocm-device-libs-rpath",
-        "sha256": "fcd8f066242562a6e789a5f126dc0296a08a74ef6ab0378d24895613aed5a906",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-device-libs-rpath6.4.1/rocm-device-libs-rpath6.4.1_1.0.0.60401-83~22.04_amd64.deb",
-        "version": "1.0.0.60401-83"
+        "sha256": "c8737ac0c67702846d4f7eb7adab2261e92884674d4fadc270fdc526e6075061",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-device-libs-rpath6.4.1-1.0.0.60401-83.el8.x86_64.rpm",
+        "version": "1.0.0.60401"
       }
     ],
-    "version": "1.0.0.60401-83"
+    "version": "1.0.0.60401"
   },
   "rocm-gdb": {
     "deps": [
@@ -2169,18 +2179,18 @@
     "components": [
       {
         "name": "rocm-gdb",
-        "sha256": "5a02416d962278d7fd83e285894d53ace5e4cb4430982e8bf79ffa17aaabab83",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-gdb/rocm-gdb_15.2.60401-83~22.04_amd64.deb",
-        "version": "15.2.60401-83"
+        "sha256": "98038f30486585fe52e20d770c3ec09270d8fdca4bf9c32ef8dea31d459b7c67",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-gdb-15.2.60401-83.el8.x86_64.rpm",
+        "version": "15.2.60401"
       },
       {
         "name": "rocm-gdb-rpath",
-        "sha256": "efe979a50e404d00b4687731893391c3243bdc4df3732ec4b48a1f9dbec62195",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-gdb-rpath6.4.1/rocm-gdb-rpath6.4.1_15.2.60401-83~22.04_amd64.deb",
-        "version": "15.2.60401-83"
+        "sha256": "de6a913cf23a35864a9eb397201bc03743f81b541c590585258b12c65f335f27",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-gdb-rpath6.4.1-15.2.60401-83.el8.x86_64.rpm",
+        "version": "15.2.60401"
       }
     ],
-    "version": "15.2.60401-83"
+    "version": "15.2.60401"
   },
   "rocm-hip-libraries": {
     "deps": [
@@ -2206,18 +2216,18 @@
     "components": [
       {
         "name": "rocm-hip-libraries",
-        "sha256": "b902aa964db9d9a0ae6b55f5ab4c62f0eba180e114971c5fec82e9cc6ef30fde",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-hip-libraries/rocm-hip-libraries_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "960a59810e2d3a14575e1dbdfd44673c190e1e7fb0e16869748d32a8e2f82660",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-hip-libraries-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-hip-libraries-rpath",
-        "sha256": "a2a1beb9ee833667f336ac8c6c1e95a97fa8302150545445321558beee7e2055",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-hip-libraries-rpath6.4.1/rocm-hip-libraries-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "242f34dbc2cc3ff8b76f8d3fbba141a9971e9266597c93a2f5681d6576f55fa4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-hip-libraries-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-hip-libraries-asan": {
     "deps": [
@@ -2244,22 +2254,22 @@
     "components": [
       {
         "name": "rocm-hip-libraries-asan",
-        "sha256": "977b02cb3b425116511f3d0fc2e85fb7e6dd011e6f4c7f258d279302ecbce940",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-hip-libraries-asan/rocm-hip-libraries-asan_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "32ae8fe576868470b9a3c1bf431e9c1f6923e13e732aca9a811c444d252bb639",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-hip-libraries-asan-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-hip-libraries-asan-rpath",
-        "sha256": "b14f5664243bd8616d71c2ffd9d5a48923f12588896c4eba6d8e1a288518afed",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-hip-libraries-asan-rpath6.4.1/rocm-hip-libraries-asan-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "7091b48760030c146f2c8df4e60ac7a5411666b8a6a736d6ebd60376de10ad17",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-hip-libraries-asan-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-hip-runtime": {
     "deps": [
-      "hip-dev",
+      "hip-devel",
       "hip-doc",
       "hip-runtime-amd",
       "hip-samples",
@@ -2276,30 +2286,30 @@
     "components": [
       {
         "name": "rocm-hip-runtime",
-        "sha256": "b99805af43f0e3280fcf8d4cf21c5870a12b67a66910da00ea6ca745d4e19282",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-hip-runtime/rocm-hip-runtime_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "7ff23018e3d98eb41dacb4949ee8f366a09c4f2d8ab9593fb585d79b4943f2eb",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-hip-runtime-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
-        "name": "rocm-hip-runtime-dev",
-        "sha256": "f9996ad43c175bf6afdd166b0f33cc044bf4fd324dcb9ef78f77f5b71ec9bdfc",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-hip-runtime-dev/rocm-hip-runtime-dev_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "name": "rocm-hip-runtime-devel",
+        "sha256": "736f0d2ccf256f6ec52b77756b610386cfa019cafd76f5218672b3985eb55275",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-hip-runtime-devel-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
-        "name": "rocm-hip-runtime-dev-rpath",
-        "sha256": "d00e528ac2d4ef1c2e55412f488266232a75cc6df5e2404749b608369cb7983b",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-hip-runtime-dev-rpath6.4.1/rocm-hip-runtime-dev-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "name": "rocm-hip-runtime-devel-rpath",
+        "sha256": "c634f38f2373780c4cca65e88da732116a125010952b0d71777ea0ac03cb7dac",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-hip-runtime-devel-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-hip-runtime-rpath",
-        "sha256": "193c3eb6bb04226d6cb21720c91d8f174026e2a544e3d9195a212195d79eea70",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-hip-runtime-rpath6.4.1/rocm-hip-runtime-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "27d8dc37c040b1262922c414289345dd56c18c038c1f622a56a0b8bdfb5efc24",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-hip-runtime-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-hip-runtime-asan": {
     "deps": [
@@ -2311,28 +2321,28 @@
     "components": [
       {
         "name": "rocm-hip-runtime-asan",
-        "sha256": "6f9a43a93dfb342da6f55f6c2bf47d9e95b901ea07904a9393d9a51abd15bb8f",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-hip-runtime-asan/rocm-hip-runtime-asan_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "8e7648860e41e48600c1d306d25049d829dde8986c8a239638efaecce5355ab5",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-hip-runtime-asan-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-hip-runtime-asan-rpath",
-        "sha256": "1f9ea1f5b4233224c3d6ef679336c18fd2be41629b1d7b0192721b95d977669c",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-hip-runtime-asan-rpath6.4.1/rocm-hip-runtime-asan-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "85cb7e1966f4cc9324f8a94a2d5b9bb18b572e69262dc2faa1fb5fab5bb0b85b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-hip-runtime-asan-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-hip-sdk": {
     "deps": [
-      "composablekernel-dev",
+      "composablekernel-devel",
       "hipblas",
-      "hipblas-common-dev",
+      "hipblas-common-devel",
       "hipblaslt",
-      "hipcub-dev",
+      "hipcub-devel",
       "hipfft",
-      "hipfort-dev",
+      "hipfort-devel",
       "hiprand",
       "hipsolver",
       "hipsparse",
@@ -2345,28 +2355,28 @@
       "rocm-core",
       "rocm-hip-libraries",
       "rocm-hip-runtime",
-      "rocprim-dev",
+      "rocprim-devel",
       "rocrand",
       "rocsolver",
       "rocsparse",
-      "rocthrust-dev",
-      "rocwmma-dev"
+      "rocthrust-devel",
+      "rocwmma-devel"
     ],
     "components": [
       {
         "name": "rocm-hip-sdk",
-        "sha256": "0eeec9452c8f0f072c459b2b9638e7c9e7129d5fab73e1b2a734992e1eea8b5a",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-hip-sdk/rocm-hip-sdk_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "551b576938b60f93dd51a94b54662bec3446e9f528ad51371d45afaefb4606ec",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-hip-sdk-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-hip-sdk-rpath",
-        "sha256": "991a920d20f357f13ad92e1bcd8d5d83fdf7175af287cfb76462a628cd89e98c",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-hip-sdk-rpath6.4.1/rocm-hip-sdk-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "a1db9d30bf7d7dd2a191cee6973317b0962ee1917b63ae9594f5b6e8b7ba9442",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-hip-sdk-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-language-runtime": {
     "deps": [
@@ -2378,18 +2388,18 @@
     "components": [
       {
         "name": "rocm-language-runtime",
-        "sha256": "cda08716b516c872c39e7b2a160118f0c0c7ae0ef7f9ffd246af8b6d231d33ff",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-language-runtime/rocm-language-runtime_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "d158815802685e42597e069b0ec3ba65e05a2112415a01832e897594ce64102e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-language-runtime-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-language-runtime-rpath",
-        "sha256": "bc77fc08224d0b8f4469dcdfc8698111328161d0284c0fa71a2fc80bde11cfc4",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-language-runtime-rpath6.4.1/rocm-language-runtime-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "b22de2929956731c41abcd1cf9beb6d2f3a188fa26ea403749d435f9e2f11b11",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-language-runtime-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-language-runtime-asan": {
     "deps": [
@@ -2402,27 +2412,27 @@
     "components": [
       {
         "name": "rocm-language-runtime-asan",
-        "sha256": "dd2af20f71a7d536c42d2a0c2c37e8ec8db934e8fc541a44c471d07d313c5112",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-language-runtime-asan/rocm-language-runtime-asan_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "aa15d5ac74fcb5a4508cd62de507f4ef21da4803aa3ee852537d656e2fbafffd",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-language-runtime-asan-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-language-runtime-asan-rpath",
-        "sha256": "74bb5a72294d1e860c89bf3cf40e90e49916f32d2b12cb4db2b6a3701a3de96b",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-language-runtime-asan-rpath6.4.1/rocm-language-runtime-asan-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "3fa388edbc2b3b6b2ded748a74b7252e4daa268dea941f5474c9389425e860e3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-language-runtime-asan-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-libs": {
     "deps": [
-      "composablekernel-dev",
+      "composablekernel-devel",
       "half",
       "hipblas",
-      "hipblas-common-dev",
+      "hipblas-common-devel",
       "hipblaslt",
-      "hipcub-dev",
+      "hipcub-devel",
       "hipfft",
       "hiprand",
       "hipsolver",
@@ -2435,28 +2445,28 @@
       "rocblas",
       "rocfft",
       "rocm-core",
-      "rocprim-dev",
+      "rocprim-devel",
       "rocrand",
       "rocsolver",
       "rocsparse",
-      "rocthrust-dev",
-      "rocwmma-dev"
+      "rocthrust-devel",
+      "rocwmma-devel"
     ],
     "components": [
       {
         "name": "rocm-libs",
-        "sha256": "af2aca54d073efc7fcd89ad7d38cba0550d61a014b3dcdc6e54572ce590481c3",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-libs/rocm-libs_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "287cbb75faa9fb9c55034bda64e74a0c47bbe9f6421364c44ae39d84e826a46e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-libs-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-libs-rpath",
-        "sha256": "25557c38c064ea018c648fa31a3b23ec6070e50401ae213067f9ee902fed38b4",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-libs-rpath6.4.1/rocm-libs-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "a17c236c26ca485f5e3cf25902adbb07bab372aecf0e410d273e1f606ce97d6b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-libs-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-llvm": {
     "deps": [
@@ -2465,30 +2475,30 @@
     "components": [
       {
         "name": "rocm-llvm",
-        "sha256": "1dec6406f10c8f2b8fa2baefd1b7a8af844908d7da1493fca407ea696f5b0877",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-llvm/rocm-llvm_19.0.0.25184.60401-83~22.04_amd64.deb",
-        "version": "19.0.0.25184.60401-83"
+        "sha256": "aa57d4dc2d19490bb0faa770b9ec22c2b437cbd748776d8ec8485b78890185c3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-llvm-19.0.0.25184.60401-83.el8.x86_64.rpm",
+        "version": "19.0.0.25184.60401"
       },
       {
-        "name": "rocm-llvm-dev",
-        "sha256": "b36fe5c9fb769a2133f25c3ecd5288961ee3bfdd0aef8d5714004b18d9744aef",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-llvm-dev/rocm-llvm-dev_19.0.0.25184.60401-83~22.04_amd64.deb",
-        "version": "19.0.0.25184.60401-83"
+        "name": "rocm-llvm-devel",
+        "sha256": "bef6b78097793636d431e726dcdbdf09cdbf8e435c003ed8533905189fd3fa4e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-llvm-devel-19.0.0.25184.60401-83.el8.x86_64.rpm",
+        "version": "19.0.0.25184.60401"
       },
       {
-        "name": "rocm-llvm-dev-rpath",
-        "sha256": "685f518f4e78a740fc719621c5fd46e564a302bf25e7d297412ca443db1b1fec",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-llvm-dev-rpath6.4.1/rocm-llvm-dev-rpath6.4.1_19.0.0.25184.60401-83~22.04_amd64.deb",
-        "version": "19.0.0.25184.60401-83"
+        "name": "rocm-llvm-devel-rpath",
+        "sha256": "8408243658d705158a97f424bd5d5716b529ead0980544d9d8ccf683dc52c23b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-llvm-devel-rpath6.4.1-19.0.0.25184.60401-83.el8.x86_64.rpm",
+        "version": "19.0.0.25184.60401"
       },
       {
         "name": "rocm-llvm-rpath",
-        "sha256": "c66a957d161a60dc4c9c188ccbe4b87cfc99a74b331d018b70de8530940af873",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-llvm-rpath6.4.1/rocm-llvm-rpath6.4.1_19.0.0.25184.60401-83~22.04_amd64.deb",
-        "version": "19.0.0.25184.60401-83"
+        "sha256": "87bc03ab9560d22c8c1dd56699f8f773b9fe7bcf445e0554cea6e8b93532290f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-llvm-rpath6.4.1-19.0.0.25184.60401-83.el8.x86_64.rpm",
+        "version": "19.0.0.25184.60401"
       }
     ],
-    "version": "19.0.0.25184.60401-83"
+    "version": "19.0.0.25184.60401"
   },
   "rocm-llvm-docs": {
     "deps": [
@@ -2497,18 +2507,18 @@
     "components": [
       {
         "name": "rocm-llvm-docs",
-        "sha256": "e35b0e797e662acaa2ef9ca11ab2758bf1a124ec8187a1b23bd41d401c533568",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-llvm-docs/rocm-llvm-docs_19.0.0.25184.60401-83~22.04_amd64.deb",
-        "version": "19.0.0.25184.60401-83"
+        "sha256": "80948a124c850e29866aa68a3fb2eac5bfc8bfd869e5e5b2c45b29cdb6308d84",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-llvm-docs-19.0.0.25184.60401-83.el8.x86_64.rpm",
+        "version": "19.0.0.25184.60401"
       },
       {
         "name": "rocm-llvm-docs-rpath",
-        "sha256": "8432e591f9a056f41416b3f103db9d61e5e60b9ce75f515ab22be3fddac3d407",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-llvm-docs-rpath6.4.1/rocm-llvm-docs-rpath6.4.1_19.0.0.25184.60401-83~22.04_amd64.deb",
-        "version": "19.0.0.25184.60401-83"
+        "sha256": "978f8485b2c627eefc8bc0b425ee6b437027bb6bf1bb09604b2dc87367f82982",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-llvm-docs-rpath6.4.1-19.0.0.25184.60401-83.el8.x86_64.rpm",
+        "version": "19.0.0.25184.60401"
       }
     ],
-    "version": "19.0.0.25184.60401-83"
+    "version": "19.0.0.25184.60401"
   },
   "rocm-ml-libraries": {
     "deps": [
@@ -2521,18 +2531,18 @@
     "components": [
       {
         "name": "rocm-ml-libraries",
-        "sha256": "63f7242b83f58d827a0fcf8db45c88195a01bc669b43d5a20e95295fe064a303",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-ml-libraries/rocm-ml-libraries_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "664f4a5708dd780defdf6e197cdc21048d97609aabb827c05311d1bd8d16fe1f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-ml-libraries-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-ml-libraries-rpath",
-        "sha256": "13a7b0dacdb999cd5ebf4f23ef6a88666ef5fa0cab1eecc292a09cb4a3562cd8",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-ml-libraries-rpath6.4.1/rocm-ml-libraries-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "d38efbb8bcc5c85de6383a9da06b28bc913feed3bb1b33f5fca37f7eb3a30e91",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-ml-libraries-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-ml-libraries-asan": {
     "deps": [
@@ -2544,18 +2554,18 @@
     "components": [
       {
         "name": "rocm-ml-libraries-asan",
-        "sha256": "a4b017a05fbf1cd559908a036c33852c4a1aec95ad6592d0ebf407d3101bd484",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-ml-libraries-asan/rocm-ml-libraries-asan_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "671a14962cdabf035a65b339dfbaf1dcff34c7070e32145ffc653cc209131bd7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-ml-libraries-asan-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-ml-libraries-asan-rpath",
-        "sha256": "2b99fcd8409fc727d0db1628cadebff6e4de10597c2179f52654108c624f2ada",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-ml-libraries-asan-rpath6.4.1/rocm-ml-libraries-asan-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "35e082d8eaded1a76408939ff01662eff682ef082972476dc7d1d0521fa3276b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-ml-libraries-asan-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-ml-sdk": {
     "deps": [
@@ -2567,18 +2577,18 @@
     "components": [
       {
         "name": "rocm-ml-sdk",
-        "sha256": "22e0b280d40b364bdecad871eead3bbc6a7a5cee680994be93091760ac34a9b3",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-ml-sdk/rocm-ml-sdk_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "ee1698dde43b6235bd4665d00cac3a27953525dc8ead750f43e841785bf87dc4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-ml-sdk-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-ml-sdk-rpath",
-        "sha256": "5a3f1dfa011f0a983c3a9e559f88c2ed0da3852fff7c165f10de0132eaf2586e",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-ml-sdk-rpath6.4.1/rocm-ml-sdk-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "816a56b4202d837982dbee08c01d02c4d918e071c013e969f04cbfc2dee9a6b6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-ml-sdk-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-ml-sdk-asan": {
     "deps": [
@@ -2589,36 +2599,36 @@
     "components": [
       {
         "name": "rocm-ml-sdk-asan",
-        "sha256": "e47e29f5c57f81f1714e8223c4791e52b88ebe9b73265dee2b18665eba96f5a4",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-ml-sdk-asan/rocm-ml-sdk-asan_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "5c5a173bfca57fadf1ba64800a51a493b433338c58a5e96baff109bcc60c8dd4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-ml-sdk-asan-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-ml-sdk-asan-rpath",
-        "sha256": "20570ca76c60ed8cfe34817fcd13db10bd65b4f224eaf9b8948a9e8950a99e73",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-ml-sdk-asan-rpath6.4.1/rocm-ml-sdk-asan-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "5e360ff286d4acf7b895ac5b8b7bf628232ced74a0044b02242bbfbc2e502dc4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-ml-sdk-asan-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-ocltst": {
     "deps": [],
     "components": [
       {
         "name": "rocm-ocltst",
-        "sha256": "4306b61f09372c5afd39398a7a1355309065680ae03e65943b23e91c62d94168",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-ocltst/rocm-ocltst_2.0.0.60401-83~22.04_amd64.deb",
-        "version": "2.0.0.60401-83"
+        "sha256": "d1232dd571ec1a81c5364dee5bcd4e2e3fc55d11fb89ae401ee3601a186cb674",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-ocltst-2.0.0.60401-83.el8.x86_64.rpm",
+        "version": "2.0.0.60401"
       },
       {
         "name": "rocm-ocltst-rpath",
-        "sha256": "347159218bef0b6bc0cee15e19050c576905547b311c6ba205db1a6c1cb711fb",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-ocltst-rpath6.4.1/rocm-ocltst-rpath6.4.1_2.0.0.60401-83~22.04_amd64.deb",
-        "version": "2.0.0.60401-83"
+        "sha256": "dea5feababc92aa282388b3e2413b8c0c9640ddf8eb19cc72570b09ff5c39169",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-ocltst-rpath6.4.1-2.0.0.60401-83.el8.x86_64.rpm",
+        "version": "2.0.0.60401"
       }
     ],
-    "version": "2.0.0.60401-83"
+    "version": "2.0.0.60401"
   },
   "rocm-opencl": {
     "deps": [
@@ -2629,30 +2639,30 @@
     "components": [
       {
         "name": "rocm-opencl",
-        "sha256": "4ebe784a380f990c9e1956412feee70ae964a476dfc8767aa678cfd651714234",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-opencl/rocm-opencl_2.0.0.60401-83~22.04_amd64.deb",
-        "version": "2.0.0.60401-83"
+        "sha256": "ded0746949fdb7ff0ab824f70de31b49010b1ca099ced0afc168cc09bd479aed",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-opencl-2.0.0.60401-83.el8.x86_64.rpm",
+        "version": "2.0.0.60401"
       },
       {
-        "name": "rocm-opencl-dev",
-        "sha256": "3ec802a44dc7a3e5831b1ac169f4767febf94729c61b81a8f30cff81aea38287",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-opencl-dev/rocm-opencl-dev_2.0.0.60401-83~22.04_amd64.deb",
-        "version": "2.0.0.60401-83"
+        "name": "rocm-opencl-devel",
+        "sha256": "306dd4c7b6d8b274cf52f1e4abb2002075a11ff110b9643f74c4204a587d1c00",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-opencl-devel-2.0.0.60401-83.el8.x86_64.rpm",
+        "version": "2.0.0.60401"
       },
       {
-        "name": "rocm-opencl-dev-rpath",
-        "sha256": "68e229cd5bef25d96e00064cf9d064c2fa41dd47bceec81f3f5e2b95072b053b",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-opencl-dev-rpath6.4.1/rocm-opencl-dev-rpath6.4.1_2.0.0.60401-83~22.04_amd64.deb",
-        "version": "2.0.0.60401-83"
+        "name": "rocm-opencl-devel-rpath",
+        "sha256": "d9b2444c79726fa9601b780c1a3fb12a5ec0ac9e98279d9c6834eeb623484dbc",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-opencl-devel-rpath6.4.1-2.0.0.60401-83.el8.x86_64.rpm",
+        "version": "2.0.0.60401"
       },
       {
         "name": "rocm-opencl-rpath",
-        "sha256": "2dd3e40358f1b92d4f9b9d91bbe769e02cd887035ddd44bdc6240efd87ea77e5",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-opencl-rpath6.4.1/rocm-opencl-rpath6.4.1_2.0.0.60401-83~22.04_amd64.deb",
-        "version": "2.0.0.60401-83"
+        "sha256": "4424fcaae1094320528e4995a6c59084afdaab2f9db8168797423ebb66fa9c7a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-opencl-rpath6.4.1-2.0.0.60401-83.el8.x86_64.rpm",
+        "version": "2.0.0.60401"
       }
     ],
-    "version": "2.0.0.60401-83"
+    "version": "2.0.0.60401"
   },
   "rocm-opencl-asan": {
     "deps": [
@@ -2663,18 +2673,18 @@
     "components": [
       {
         "name": "rocm-opencl-asan",
-        "sha256": "9d2e7a67c7f314bda4bb444787993e3e9bac29d0612f0289b48302de610e2cab",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-opencl-asan/rocm-opencl-asan_2.0.0.60401-83~22.04_amd64.deb",
-        "version": "2.0.0.60401-83"
+        "sha256": "c8c3cdf1c5bfc0d7109d754b14573aef0a6c3a6950a5612809aeffdda6abb901",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-opencl-asan-2.0.0.60401-83.el8.x86_64.rpm",
+        "version": "2.0.0.60401"
       },
       {
         "name": "rocm-opencl-asan-rpath",
-        "sha256": "56859466872e6b32538fc5881c29c3645f19f5196bba1cd359d40e97a7975d3e",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-opencl-asan-rpath6.4.1/rocm-opencl-asan-rpath6.4.1_2.0.0.60401-83~22.04_amd64.deb",
-        "version": "2.0.0.60401-83"
+        "sha256": "88bf5e6708189433f565c08b910df169b54a53b9edb134446564c1e286f845f0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-opencl-asan-rpath6.4.1-2.0.0.60401-83.el8.x86_64.rpm",
+        "version": "2.0.0.60401"
       }
     ],
-    "version": "2.0.0.60401-83"
+    "version": "2.0.0.60401"
   },
   "rocm-opencl-runtime": {
     "deps": [
@@ -2685,18 +2695,18 @@
     "components": [
       {
         "name": "rocm-opencl-runtime",
-        "sha256": "70665be8bad9a28d931f45f4acdb244a01094dd47d7be07c51ee3ed76869655c",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-opencl-runtime/rocm-opencl-runtime_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "b4267b685ba74cb6d390a1228f5a8c62bfcacd31285f240e8cc2e6ae778504a1",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-opencl-runtime-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-opencl-runtime-rpath",
-        "sha256": "c290be227df4765baae733c7de8716b0ae14e62fd91ab030b5acc26b507e36c4",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-opencl-runtime-rpath6.4.1/rocm-opencl-runtime-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "6fd9cfe4cde98f3cdfd461ed53a94dd4c9852a5540fcbef71cfb70f37c03cfed",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-opencl-runtime-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-opencl-runtime-asan": {
     "deps": [
@@ -2708,18 +2718,18 @@
     "components": [
       {
         "name": "rocm-opencl-runtime-asan",
-        "sha256": "04b640ad3e257611669fe3977864934b009190aea231c2fa1254b82861f96bda",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-opencl-runtime-asan/rocm-opencl-runtime-asan_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "07115afcdade5776db45c180aa4bc76d5328ed066033b7380cea3dd3e7133bca",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-opencl-runtime-asan-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-opencl-runtime-asan-rpath",
-        "sha256": "5b73901ec12525865a2fe1fd7d1c04a525039144698730a1347049523bbaf76e",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-opencl-runtime-asan-rpath6.4.1/rocm-opencl-runtime-asan-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "f595ce2f9ea246173e2f37180939923746e3e2152d54d47b58a7a3514e1ef0e3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-opencl-runtime-asan-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-opencl-sdk": {
     "deps": [
@@ -2731,23 +2741,23 @@
     "components": [
       {
         "name": "rocm-opencl-sdk",
-        "sha256": "e3ebdb4b7d6dbc9f83af2e1e728d1df60fabb2a4cc0f09dae583b7cd1bfd9ae5",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-opencl-sdk/rocm-opencl-sdk_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "ec5bc567d82593736eafd30982239101ac7feb613bb0548d57f2a9962c74374e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-opencl-sdk-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-opencl-sdk-rpath",
-        "sha256": "4177a190d854c4dbae922f444bb8a7121152bf2f21491ed09e69fd65a05d926b",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-opencl-sdk-rpath6.4.1/rocm-opencl-sdk-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "258696219043f4467fb659821b9958748c4f06354ae0d1e883d0b95dd7cc6cee",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-opencl-sdk-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-openmp-sdk": {
     "deps": [
       "hsa-rocr",
-      "openmp-extras-dev",
+      "openmp-extras-devel",
       "rocm-core",
       "rocm-device-libs",
       "rocm-language-runtime",
@@ -2756,58 +2766,54 @@
     "components": [
       {
         "name": "rocm-openmp-sdk",
-        "sha256": "7ed34b9c3a2a4e4a64f60dc2c60c722bf515cb2c32a6f9aea1d50faf0357590f",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-openmp-sdk/rocm-openmp-sdk_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "52ba40082ad137e432ae0f10602284a945d1b246d2858ce15f819511e37dd4d0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-openmp-sdk-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-openmp-sdk-rpath",
-        "sha256": "4dd9419edcc1a77ea3be2e097607cd849a796e5c445b722727ae27a8a260ff4c",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-openmp-sdk-rpath6.4.1/rocm-openmp-sdk-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "e7dd857fa475867258446f0085b86d2c93da7e0923096705810cc5675de81283",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-openmp-sdk-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-smi-lib": {
-    "deps": [
-      "rocm-core"
-    ],
+    "deps": [],
     "components": [
       {
         "name": "rocm-smi-lib",
-        "sha256": "3db3358e0ae302b4589e586d6b9dae2ae183d521e61979723d9eb918c7bfbde1",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-smi-lib/rocm-smi-lib_7.5.0.60401-83~22.04_amd64.deb",
-        "version": "7.5.0.60401-83"
+        "sha256": "072ce3b2d7c25b6422dc2f4ddcb854d4b0059d296695923ccc909719639847a6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-smi-lib-7.5.0.60401-83.el8.x86_64.rpm",
+        "version": "7.5.0.60401"
       },
       {
         "name": "rocm-smi-lib-rpath",
-        "sha256": "0bae5be336c87fd7cd1dd8d9d516fd4528b461320080fcf25db95569addf2ad3",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-smi-lib-rpath6.4.1/rocm-smi-lib-rpath6.4.1_7.5.0.60401-83~22.04_amd64.deb",
-        "version": "7.5.0.60401-83"
+        "sha256": "cc7d2235d580107a652c67dc89248a0bfadb22586e4d290cb5512c373662660c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-smi-lib-rpath6.4.1-7.5.0.60401-83.el8.x86_64.rpm",
+        "version": "7.5.0.60401"
       }
     ],
-    "version": "7.5.0.60401-83"
+    "version": "7.5.0.60401"
   },
   "rocm-smi-lib-asan": {
-    "deps": [
-      "rocm-core-asan"
-    ],
+    "deps": [],
     "components": [
       {
         "name": "rocm-smi-lib-asan",
-        "sha256": "691fd4c28be233fb93de342a6fb08fa66e5ce84d77a1039a1493e9c73360da83",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-smi-lib-asan/rocm-smi-lib-asan_7.5.0.60401-83~22.04_amd64.deb",
-        "version": "7.5.0.60401-83"
+        "sha256": "040aff9dbcd6e766a210cfde7fc6775fc4728605263f438692982317f86509f8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-smi-lib-asan-7.5.0.60401-83.el8.x86_64.rpm",
+        "version": "7.5.0.60401"
       },
       {
         "name": "rocm-smi-lib-asan-rpath",
-        "sha256": "159357b9be9443fe89255620f2d2faf72b7da61031e476efe57b3fcde4ec7789",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-smi-lib-asan-rpath6.4.1/rocm-smi-lib-asan-rpath6.4.1_7.5.0.60401-83~22.04_amd64.deb",
-        "version": "7.5.0.60401-83"
+        "sha256": "ffc6af5d16ca2cfd09bd7379e50540d03ae4cc97288045db25df9d00da07a034",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-smi-lib-asan-rpath6.4.1-7.5.0.60401-83.el8.x86_64.rpm",
+        "version": "7.5.0.60401"
       }
     ],
-    "version": "7.5.0.60401-83"
+    "version": "7.5.0.60401"
   },
   "rocm-utils": {
     "deps": [
@@ -2818,18 +2824,18 @@
     "components": [
       {
         "name": "rocm-utils",
-        "sha256": "e789cbafbb57215464fa8c2ae8d83b5f45b0a447cbf563a4d8c35a0c1d72812c",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-utils/rocm-utils_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "2f569bd9a9a5321677502ad91a9ae753f4d36362b8de5019622a9edcdb1c9e71",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-utils-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       },
       {
         "name": "rocm-utils-rpath",
-        "sha256": "a840fc24bfcb01eadad559ac6ae0b3c7b1a663b8bf97b4b99f140f826422147f",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-utils-rpath6.4.1/rocm-utils-rpath6.4.1_6.4.1.60401-83~22.04_amd64.deb",
-        "version": "6.4.1.60401-83"
+        "sha256": "f055b32b8aa5d60ab5c4ca37690baf7895271cf4fc15c9be61403f0b8cdf0dfb",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-utils-rpath6.4.1-6.4.1.60401-83.el8.x86_64.rpm",
+        "version": "6.4.1.60401"
       }
     ],
-    "version": "6.4.1.60401-83"
+    "version": "6.4.1.60401"
   },
   "rocm-validation-suite": {
     "deps": [
@@ -2845,18 +2851,18 @@
     "components": [
       {
         "name": "rocm-validation-suite",
-        "sha256": "a4c33c94199725fbd8f5a046393a9160c7b193f86dfb16c6f72e0c5bd2844d32",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-validation-suite/rocm-validation-suite_1.1.0.60401-83~22.04_amd64.deb",
-        "version": "1.1.0.60401-83"
+        "sha256": "3cbf605dfad34f7280689c808f05abaad2531b3489ca81f147d24da60829a141",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-validation-suite-1.1.0.60401-83.el8.x86_64.rpm",
+        "version": "1.1.0.60401"
       },
       {
         "name": "rocm-validation-suite-rpath",
-        "sha256": "4bf6709eb1f7bec7641cb63b7052ad785c14f25f034a5af4421c7a97d17c2d13",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocm-validation-suite-rpath6.4.1/rocm-validation-suite-rpath6.4.1_1.1.0.60401-83~22.04_amd64.deb",
-        "version": "1.1.0.60401-83"
+        "sha256": "88f4c135c567f1ed7ba70a1d61d8714ac503bed21f13b883dc4e7919e229445e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocm-validation-suite-rpath6.4.1-1.1.0.60401-83.el8.x86_64.rpm",
+        "version": "1.1.0.60401"
       }
     ],
-    "version": "1.1.0.60401-83"
+    "version": "1.1.0.60401"
   },
   "rocminfo": {
     "deps": [
@@ -2866,39 +2872,39 @@
     "components": [
       {
         "name": "rocminfo",
-        "sha256": "55d19b59464dd444002d12bf1fe8c762c15f2ae79f9dccbbf38360b42e3156b6",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocminfo/rocminfo_1.0.0.60401-83~22.04_amd64.deb",
-        "version": "1.0.0.60401-83"
+        "sha256": "53cc4d304ea0aaceff045895796a406038d749c4828a6d131e4ced3be7b63a73",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocminfo-1.0.0.60401-83.el8.x86_64.rpm",
+        "version": "1.0.0.60401"
       },
       {
         "name": "rocminfo-rpath",
-        "sha256": "081a44e0a430c3bfdf3c31ab59602cc8843f653ba77462b5a31f80aa1d7a305e",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocminfo-rpath6.4.1/rocminfo-rpath6.4.1_1.0.0.60401-83~22.04_amd64.deb",
-        "version": "1.0.0.60401-83"
+        "sha256": "f57179a8d23cb284a2dc6bf95ab0c995bb4919e03cd80c7ce339fa6f5619731c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocminfo-rpath6.4.1-1.0.0.60401-83.el8.x86_64.rpm",
+        "version": "1.0.0.60401"
       }
     ],
-    "version": "1.0.0.60401-83"
+    "version": "1.0.0.60401"
   },
-  "rocprim-dev": {
+  "rocprim-devel": {
     "deps": [
       "hip-runtime-amd",
       "rocm-core"
     ],
     "components": [
       {
-        "name": "rocprim-dev",
-        "sha256": "e42b3945e186fdc02764fe0fcc5a1df6d5b42aa76123075adae6f6aa0e18c358",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprim-dev/rocprim-dev_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "name": "rocprim-devel",
+        "sha256": "0c35fb7511624632e0a53b7b3e8ab502d558ca95dcf8a6ea8bd2781183e7b0eb",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprim-devel-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       },
       {
-        "name": "rocprim-dev-rpath",
-        "sha256": "430931f176b601bcc7a19a24ca5cc9b20b4d966bce52d9e89ef47fae1a3cfb31",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprim-dev-rpath6.4.1/rocprim-dev-rpath6.4.1_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "name": "rocprim-devel-rpath",
+        "sha256": "065abc6e8f4b5a173e62131116549874b0b5740210bcd84e29ca72b1f18ee580",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprim-devel-rpath6.4.1-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       }
     ],
-    "version": "3.4.0.60401-83"
+    "version": "3.4.0.60401"
   },
   "rocprofiler": {
     "deps": [
@@ -2909,30 +2915,30 @@
     "components": [
       {
         "name": "rocprofiler",
-        "sha256": "67ce087b2ab127375ad95e574a7a5c88f8d8794f9ed1926bd3a6d8abd65604db",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprofiler/rocprofiler_2.0.60401.60401-83~22.04_amd64.deb",
-        "version": "2.0.60401.60401-83"
+        "sha256": "ff53a41dfb9f4ac1c3fad4acd670d5001ace19c7658ea073673749af68fe7e91",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprofiler-2.0.60401.60401-83.el8.x86_64.rpm",
+        "version": "2.0.60401.60401"
       },
       {
-        "name": "rocprofiler-dev",
-        "sha256": "f3767c98fb814ef3fd53c9d37415817652e8067ea82398a4be3fb30852524885",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprofiler-dev/rocprofiler-dev_2.0.60401.60401-83~22.04_amd64.deb",
-        "version": "2.0.60401.60401-83"
+        "name": "rocprofiler-devel",
+        "sha256": "93961521ae1566b1e1f6ba0a012088660d810389423183c913964ee9fda064ca",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprofiler-devel-2.0.60401.60401-83.el8.x86_64.rpm",
+        "version": "2.0.60401.60401"
       },
       {
-        "name": "rocprofiler-dev-rpath",
-        "sha256": "ce19deb57d2258718ff3c638dd26c5af65873e4670d48aea109d2dca1f522d41",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprofiler-dev-rpath6.4.1/rocprofiler-dev-rpath6.4.1_2.0.60401.60401-83~22.04_amd64.deb",
-        "version": "2.0.60401.60401-83"
+        "name": "rocprofiler-devel-rpath",
+        "sha256": "86e7f5af607b85d3526876b5046eea69c8347d1641724076e7779f4c361e512d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprofiler-devel-rpath6.4.1-2.0.60401.60401-83.el8.x86_64.rpm",
+        "version": "2.0.60401.60401"
       },
       {
         "name": "rocprofiler-rpath",
-        "sha256": "da1188636b20359c5ac22199c537b2e4550d0c3695ae2977a158ee6ed0f35c11",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprofiler-rpath6.4.1/rocprofiler-rpath6.4.1_2.0.60401.60401-83~22.04_amd64.deb",
-        "version": "2.0.60401.60401-83"
+        "sha256": "12769d680a083db00ada00286106795aed2b30ff155b07faa1b51c29393c24d7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprofiler-rpath6.4.1-2.0.60401.60401-83.el8.x86_64.rpm",
+        "version": "2.0.60401.60401"
       }
     ],
-    "version": "2.0.60401.60401-83"
+    "version": "2.0.60401.60401"
   },
   "rocprofiler-asan": {
     "deps": [
@@ -2942,18 +2948,18 @@
     "components": [
       {
         "name": "rocprofiler-asan",
-        "sha256": "9e8662b955242bc860d7cc98a7f0a5c68ee8efa50238185822c92b130e512092",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprofiler-asan/rocprofiler-asan_2.0.60401.60401-83~22.04_amd64.deb",
-        "version": "2.0.60401.60401-83"
+        "sha256": "1587d5d2faf7e87027a1f59aaaa751183b27a57e2c10c47cc0c0917120cb5a6d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprofiler-asan-2.0.60401.60401-83.el8.x86_64.rpm",
+        "version": "2.0.60401.60401"
       },
       {
         "name": "rocprofiler-asan-rpath",
-        "sha256": "9ce3f471566daabe6c20d5574cd7d427e73f7ee7a63fe3bd868bc6a44e04442d",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprofiler-asan-rpath6.4.1/rocprofiler-asan-rpath6.4.1_2.0.60401.60401-83~22.04_amd64.deb",
-        "version": "2.0.60401.60401-83"
+        "sha256": "e245643301aea2c86bb72b89151a42350528d66f25f914374d1925ca6de7303d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprofiler-asan-rpath6.4.1-2.0.60401.60401-83.el8.x86_64.rpm",
+        "version": "2.0.60401.60401"
       }
     ],
-    "version": "2.0.60401.60401-83"
+    "version": "2.0.60401.60401"
   },
   "rocprofiler-compute": {
     "deps": [
@@ -2962,18 +2968,18 @@
     "components": [
       {
         "name": "rocprofiler-compute",
-        "sha256": "abc0891d28660727844c31cdb1bdeff50233b7bf56e8354612eb9f65239d9714",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprofiler-compute/rocprofiler-compute_3.1.0.60401-83~22.04_amd64.deb",
-        "version": "3.1.0.60401-83"
+        "sha256": "6557ef5fec8cd2a264ad2e062132da9e354e5423f12cd4ca33f3924d16966f42",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprofiler-compute-3.1.0.60401-83.el8.x86_64.rpm",
+        "version": "3.1.0.60401"
       },
       {
         "name": "rocprofiler-compute-rpath",
-        "sha256": "e60fe8284c173232213d3300041464e7d4c486d8bc5be708afc4ea0952bbb9cc",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprofiler-compute-rpath6.4.1/rocprofiler-compute-rpath6.4.1_3.1.0.60401-83~22.04_amd64.deb",
-        "version": "3.1.0.60401-83"
+        "sha256": "54b9bc80ba01109f47aa1d80f464569789ef1287aae460df23a37228c71cc1b0",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprofiler-compute-rpath6.4.1-3.1.0.60401-83.el8.x86_64.rpm",
+        "version": "3.1.0.60401"
       }
     ],
-    "version": "3.1.0.60401-83"
+    "version": "3.1.0.60401"
   },
   "rocprofiler-docs": {
     "deps": [
@@ -2984,18 +2990,18 @@
     "components": [
       {
         "name": "rocprofiler-docs",
-        "sha256": "7e52afe0455270dc392d404f13d3bf5f24c1c3c748327896f02a530237d8f7d2",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprofiler-docs/rocprofiler-docs_2.0.60401.60401-83~22.04_amd64.deb",
-        "version": "2.0.60401.60401-83"
+        "sha256": "d3f5c774cb3c8233f72978d3c9d01610b37bdefae9c608281efc880beed2c5c3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprofiler-docs-2.0.60401.60401-83.el8.x86_64.rpm",
+        "version": "2.0.60401.60401"
       },
       {
         "name": "rocprofiler-docs-rpath",
-        "sha256": "04412a70e3048a2d4b0ebd129ca4899cd84007dedfa0d92766d6fa2e77fc60d4",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprofiler-docs-rpath6.4.1/rocprofiler-docs-rpath6.4.1_2.0.60401.60401-83~22.04_amd64.deb",
-        "version": "2.0.60401.60401-83"
+        "sha256": "98fb7ad8f447f31c8e17434f31c798fd5cf881cdfab0b38d2fc821a7e33c593b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprofiler-docs-rpath6.4.1-2.0.60401.60401-83.el8.x86_64.rpm",
+        "version": "2.0.60401.60401"
       }
     ],
-    "version": "2.0.60401.60401-83"
+    "version": "2.0.60401.60401"
   },
   "rocprofiler-plugins": {
     "deps": [
@@ -3006,18 +3012,18 @@
     "components": [
       {
         "name": "rocprofiler-plugins",
-        "sha256": "9d7d8aa8e2ee47e0c86bba64be453da7a38af02836ed92b6d3a09921588cf572",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprofiler-plugins/rocprofiler-plugins_2.0.60401.60401-83~22.04_amd64.deb",
-        "version": "2.0.60401.60401-83"
+        "sha256": "750eef8d82da05ff2e08f11f82556f24101ad86c7341ec0c128a69f3a5677636",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprofiler-plugins-2.0.60401.60401-83.el8.x86_64.rpm",
+        "version": "2.0.60401.60401"
       },
       {
         "name": "rocprofiler-plugins-rpath",
-        "sha256": "3d706774f76162beb93fe2471bd50e56490308b7b01853cf8ccd0cb4dce85dc8",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprofiler-plugins-rpath6.4.1/rocprofiler-plugins-rpath6.4.1_2.0.60401.60401-83~22.04_amd64.deb",
-        "version": "2.0.60401.60401-83"
+        "sha256": "3b555cb6286de518c4be0edf0fb66b247162ed1ef3523f0bf9ee8bba22a0907c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprofiler-plugins-rpath6.4.1-2.0.60401.60401-83.el8.x86_64.rpm",
+        "version": "2.0.60401.60401"
       }
     ],
-    "version": "2.0.60401.60401-83"
+    "version": "2.0.60401.60401"
   },
   "rocprofiler-register": {
     "deps": [
@@ -3026,18 +3032,18 @@
     "components": [
       {
         "name": "rocprofiler-register",
-        "sha256": "da49a66ca3e6ee8b9491777c2b5170b6020e8308371e26b869d7af81bc50f571",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprofiler-register/rocprofiler-register_0.4.0.60401-83~22.04_amd64.deb",
-        "version": "0.4.0.60401-83"
+        "sha256": "faa999de69c01c73167a793208ff1fb07a4bd50e8903e43a59fb1ee87ce7da57",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprofiler-register-0.4.0.60401-83.el8.x86_64.rpm",
+        "version": "0.4.0.60401"
       },
       {
         "name": "rocprofiler-register-rpath",
-        "sha256": "72704db5f450e4c20a1d3d154778137fcdc63ffba8da4f36c00093f426b20908",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprofiler-register-rpath6.4.1/rocprofiler-register-rpath6.4.1_0.4.0.60401-83~22.04_amd64.deb",
-        "version": "0.4.0.60401-83"
+        "sha256": "b7680442f7f407798ad20d389e1eade992684f95f279ea8788de944f070c8ca4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprofiler-register-rpath6.4.1-0.4.0.60401-83.el8.x86_64.rpm",
+        "version": "0.4.0.60401"
       }
     ],
-    "version": "0.4.0.60401-83"
+    "version": "0.4.0.60401"
   },
   "rocprofiler-sdk": {
     "deps": [
@@ -3047,18 +3053,18 @@
     "components": [
       {
         "name": "rocprofiler-sdk",
-        "sha256": "9890bc2ddbf563edbb50fc8d227a56da462a8bcdd08dbc2f549c924b89c42a59",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprofiler-sdk/rocprofiler-sdk_0.6.0-83~22.04_amd64.deb",
-        "version": "0.6.0-83"
+        "sha256": "dd84c4e28ac12a7fe621008750b5a7825cc36d7e4dcf80332ada87a09864a21f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprofiler-sdk-0.6.0.60401-83.el8.x86_64.rpm",
+        "version": "0.6.0.60401"
       },
       {
         "name": "rocprofiler-sdk-rpath",
-        "sha256": "aaf3a8c7814089eeccb16780d04c8dd1c436c191a65b5bd4a9e29712815b25db",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprofiler-sdk-rpath6.4.1/rocprofiler-sdk-rpath6.4.1_0.6.0-83~22.04_amd64.deb",
-        "version": "0.6.0-83"
+        "sha256": "b0f605c0a27e0b809b0ae44fcbab7c1bcd2022aba82451fc1821b985c35fcbc6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprofiler-sdk-rpath6.4.1-0.6.0.60401-83.el8.x86_64.rpm",
+        "version": "0.6.0.60401"
       }
     ],
-    "version": "0.6.0-83"
+    "version": "0.6.0.60401"
   },
   "rocprofiler-sdk-roctx": {
     "deps": [
@@ -3067,39 +3073,36 @@
     "components": [
       {
         "name": "rocprofiler-sdk-roctx",
-        "sha256": "87eddf255f80bbe3c371e0a087a1045ec82766903077de2fb708ed1958ab62fb",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprofiler-sdk-roctx/rocprofiler-sdk-roctx_0.6.0-83~22.04_amd64.deb",
-        "version": "0.6.0-83"
+        "sha256": "477e947347e5624ea987214380d582c56d9d02dd12cadb34e685871ea7c0c393",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprofiler-sdk-roctx-0.6.0.60401-83.el8.x86_64.rpm",
+        "version": "0.6.0.60401"
       },
       {
         "name": "rocprofiler-sdk-roctx-rpath",
-        "sha256": "0a7a649b1cf5168289e71f17360fb1732d476540c014ad1541a84a18442e1cf6",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprofiler-sdk-roctx-rpath6.4.1/rocprofiler-sdk-roctx-rpath6.4.1_0.6.0-83~22.04_amd64.deb",
-        "version": "0.6.0-83"
+        "sha256": "ef1a98b2e744cedc4eefd0181eb7f4c8d162a4fb34c6ea7fb1d97774cda68879",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprofiler-sdk-roctx-rpath6.4.1-0.6.0.60401-83.el8.x86_64.rpm",
+        "version": "0.6.0.60401"
       }
     ],
-    "version": "0.6.0-83"
+    "version": "0.6.0.60401"
   },
   "rocprofiler-systems": {
-    "deps": [
-      "rocm-smi-lib",
-      "rocprofiler-sdk"
-    ],
+    "deps": [],
     "components": [
       {
         "name": "rocprofiler-systems",
-        "sha256": "6a0811c7b7751278d24d7fbdf9a085271b41b23b7dece1539d86ad104ec74108",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprofiler-systems/rocprofiler-systems_1.0.1.60401-83~22.04_amd64.deb",
-        "version": "1.0.1.60401-83"
+        "sha256": "3c5cc6b2a06e8d1342a7c9e006360396f4ad6d164fd7e77f050f1e8e2415d457",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprofiler-systems-1.0.1.60401-83.el8.x86_64.rpm",
+        "version": "1.0.1.60401"
       },
       {
         "name": "rocprofiler-systems-rpath",
-        "sha256": "212497e00274c28a7957fcaaae9d6ce44aa9803da55b4a3117e6c8f14ba02a24",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocprofiler-systems-rpath6.4.1/rocprofiler-systems-rpath6.4.1_1.0.1.60401-83~22.04_amd64.deb",
-        "version": "1.0.1.60401-83"
+        "sha256": "b7c75195a86873b3be3e2fdee8b882a8f764de880e2a56dc482249727003c8ad",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocprofiler-systems-rpath6.4.1-1.0.1.60401-83.el8.x86_64.rpm",
+        "version": "1.0.1.60401"
       }
     ],
-    "version": "1.0.1.60401-83"
+    "version": "1.0.1.60401"
   },
   "rocrand": {
     "deps": [
@@ -3108,30 +3111,30 @@
     "components": [
       {
         "name": "rocrand",
-        "sha256": "8d77ce48dc4256bcdba122c9243febd083ffc9147c340ef793f362d8611e35d3",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocrand/rocrand_3.3.0.60401-83~22.04_amd64.deb",
-        "version": "3.3.0.60401-83"
+        "sha256": "cede33e6884e699df6d4cedaabe2607fb05538c7b866561a96586784c13c481b",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocrand-3.3.0.60401-83.el8.x86_64.rpm",
+        "version": "3.3.0.60401"
       },
       {
-        "name": "rocrand-dev",
-        "sha256": "eeaa28b540cf1ca190a668ad386aecccde8b90fe632e1b3a969f337c7478509d",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocrand-dev/rocrand-dev_3.3.0.60401-83~22.04_amd64.deb",
-        "version": "3.3.0.60401-83"
+        "name": "rocrand-devel",
+        "sha256": "6543d7141a5eb74ab731c6ed2db3a312545827a7101e936b090346ca2efdb057",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocrand-devel-3.3.0.60401-83.el8.x86_64.rpm",
+        "version": "3.3.0.60401"
       },
       {
-        "name": "rocrand-dev-rpath",
-        "sha256": "d1456526fe703211732d272b361ebe4d7a26f364193375d09416be5e4daa41fd",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocrand-dev-rpath6.4.1/rocrand-dev-rpath6.4.1_3.3.0.60401-83~22.04_amd64.deb",
-        "version": "3.3.0.60401-83"
+        "name": "rocrand-devel-rpath",
+        "sha256": "ec840b28fd181c956188ab986818b0fb204eddfc5e03a40fe14edb30e34c9d34",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocrand-devel-rpath6.4.1-3.3.0.60401-83.el8.x86_64.rpm",
+        "version": "3.3.0.60401"
       },
       {
         "name": "rocrand-rpath",
-        "sha256": "a25db860a1933ddf455ef5bdd47966df1c5a74d5f0a48dae4a3851e9a58550cd",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocrand-rpath6.4.1/rocrand-rpath6.4.1_3.3.0.60401-83~22.04_amd64.deb",
-        "version": "3.3.0.60401-83"
+        "sha256": "a5f6e0a49aa0a307592b0541f958a7fff8843bc6f6cefb57d881e5ad2b3f17e3",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocrand-rpath6.4.1-3.3.0.60401-83.el8.x86_64.rpm",
+        "version": "3.3.0.60401"
       }
     ],
-    "version": "3.3.0.60401-83"
+    "version": "3.3.0.60401"
   },
   "rocrand-asan": {
     "deps": [
@@ -3140,41 +3143,41 @@
     "components": [
       {
         "name": "rocrand-asan",
-        "sha256": "bf2da93b503cf3fe22df8324d161e2095a6e485aded4ad0425f9a06c5f7c98a5",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocrand-asan/rocrand-asan_3.3.0.60401-83~22.04_amd64.deb",
-        "version": "3.3.0.60401-83"
+        "sha256": "a5dacb3a82e707780e7d2debd9b6d1f4666882744ef4c0cbdd4320a71e10e389",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocrand-asan-3.3.0.60401-83.el8.x86_64.rpm",
+        "version": "3.3.0.60401"
       },
       {
         "name": "rocrand-asan-rpath",
-        "sha256": "7e16fa298e4f9c17b81252f8b3063c7829a430c8bbe8ffa99db795d2b33c35ea",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocrand-asan-rpath6.4.1/rocrand-asan-rpath6.4.1_3.3.0.60401-83~22.04_amd64.deb",
-        "version": "3.3.0.60401-83"
+        "sha256": "434049eba6aa4dc16d273b2058b681bb6b33d4175d24de4c12b94be9e08b038d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocrand-asan-rpath6.4.1-3.3.0.60401-83.el8.x86_64.rpm",
+        "version": "3.3.0.60401"
       }
     ],
-    "version": "3.3.0.60401-83"
+    "version": "3.3.0.60401"
   },
-  "rocshmem-dev": {
+  "rocshmem-devel": {
     "deps": [
       "hip-runtime-amd",
       "hsa-rocr",
-      "rocm",
-      "rocm-core"
+      "rocm-core",
+      "rocm-dev"
     ],
     "components": [
       {
-        "name": "rocshmem-dev",
-        "sha256": "5533a4dc2db190dea8c1ac258cc914fcfe3851f27727c40b3fcf3efd89061f7a",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocshmem-dev/rocshmem-dev_2.0.0.60401-83~22.04_amd64.deb",
-        "version": "2.0.0.60401-83"
+        "name": "rocshmem-devel",
+        "sha256": "c6acaa7e2d880043f36a7e1e80278c5d7ef611135eccb0de1f48802eda42037d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocshmem-devel-2.0.0.60401-83.el8.x86_64.rpm",
+        "version": "2.0.0.60401"
       },
       {
-        "name": "rocshmem-dev-rpath",
-        "sha256": "05f1071f51575e67504c052e24edbc19f71482b093efcef2ed3b885299825c3c",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocshmem-dev-rpath6.4.1/rocshmem-dev-rpath6.4.1_2.0.0.60401-83~22.04_amd64.deb",
-        "version": "2.0.0.60401-83"
+        "name": "rocshmem-devel-rpath",
+        "sha256": "dd9ceeed449351d8f9bdfbd00275da1770ceb25f04e3a96c5a53a0dc9ccc8c90",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocshmem-devel-rpath6.4.1-2.0.0.60401-83.el8.x86_64.rpm",
+        "version": "2.0.0.60401"
       }
     ],
-    "version": "2.0.0.60401-83"
+    "version": "2.0.0.60401"
   },
   "rocsolver": {
     "deps": [
@@ -3184,30 +3187,30 @@
     "components": [
       {
         "name": "rocsolver",
-        "sha256": "82451d985c3f9ea9472df45e044651a16cc7a8d510a338e57e0d7c19b04a7243",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocsolver/rocsolver_3.28.0.60401-83~22.04_amd64.deb",
-        "version": "3.28.0.60401-83"
+        "sha256": "78456b3db33ad57eeac711d5721ea7841cecf93ebec21f45eef89175ea8eed41",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocsolver-3.28.0.60401-83.el8.x86_64.rpm",
+        "version": "3.28.0.60401"
       },
       {
-        "name": "rocsolver-dev",
-        "sha256": "26b4bfc60e41655b4780d35204df775ec2c1f847b1da26c718dd4d649e18376e",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocsolver-dev/rocsolver-dev_3.28.0.60401-83~22.04_amd64.deb",
-        "version": "3.28.0.60401-83"
+        "name": "rocsolver-devel",
+        "sha256": "50d23c4b84c35cdc1d8d0a4819ed8a89fd4240db9f6c617941b195ea124d5917",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocsolver-devel-3.28.0.60401-83.el8.x86_64.rpm",
+        "version": "3.28.0.60401"
       },
       {
-        "name": "rocsolver-dev-rpath",
-        "sha256": "ec607c9c9cdd7729840d68f612867ad378fe3553d92838a027af7325f0c1e1b4",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocsolver-dev-rpath6.4.1/rocsolver-dev-rpath6.4.1_3.28.0.60401-83~22.04_amd64.deb",
-        "version": "3.28.0.60401-83"
+        "name": "rocsolver-devel-rpath",
+        "sha256": "16eb8e5739ef96b18f489a31334a0381ed14a634d6db079535b60cd9bcbde6bf",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocsolver-devel-rpath6.4.1-3.28.0.60401-83.el8.x86_64.rpm",
+        "version": "3.28.0.60401"
       },
       {
         "name": "rocsolver-rpath",
-        "sha256": "2aa31c1214e8f5dbee6dec87d6c63d2f9c0d10bea09a1217e1786b10fbbfea42",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocsolver-rpath6.4.1/rocsolver-rpath6.4.1_3.28.0.60401-83~22.04_amd64.deb",
-        "version": "3.28.0.60401-83"
+        "sha256": "14797d90f1440f402c46e671aa6a554d2cffc599464ab9ed1b27773c731f240e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocsolver-rpath6.4.1-3.28.0.60401-83.el8.x86_64.rpm",
+        "version": "3.28.0.60401"
       }
     ],
-    "version": "3.28.0.60401-83"
+    "version": "3.28.0.60401"
   },
   "rocsolver-asan": {
     "deps": [
@@ -3217,18 +3220,18 @@
     "components": [
       {
         "name": "rocsolver-asan",
-        "sha256": "19963ff4203c7b9527047c1f8789e867af7466c0e0b4a29ca2515ce8fc314543",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocsolver-asan/rocsolver-asan_3.28.0.60401-83~22.04_amd64.deb",
-        "version": "3.28.0.60401-83"
+        "sha256": "ee6c70d610f12c6f443d665188627053b64c39d7bf697631b85fa3d91ead9049",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocsolver-asan-3.28.0.60401-83.el8.x86_64.rpm",
+        "version": "3.28.0.60401"
       },
       {
         "name": "rocsolver-asan-rpath",
-        "sha256": "8e42fd49edcaa8ae42a8912f4e8d86c4df12ccca792ccd5859e2122f74af3714",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocsolver-asan-rpath6.4.1/rocsolver-asan-rpath6.4.1_3.28.0.60401-83~22.04_amd64.deb",
-        "version": "3.28.0.60401-83"
+        "sha256": "aaf63636c3cb52fbf129f32b7ee72e87b7930121faaf9164afb57ba2cc667a72",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocsolver-asan-rpath6.4.1-3.28.0.60401-83.el8.x86_64.rpm",
+        "version": "3.28.0.60401"
       }
     ],
-    "version": "3.28.0.60401-83"
+    "version": "3.28.0.60401"
   },
   "rocsparse": {
     "deps": [
@@ -3238,30 +3241,30 @@
     "components": [
       {
         "name": "rocsparse",
-        "sha256": "d30ed6c108371c578874e1bd76e964ba429f774beebf92c682ddda94497b5780",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocsparse/rocsparse_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "sha256": "9fab622cda8c6009ad5e93c50b8d2c0be809d15dfa48cdfa2ea0c3ec8f87d063",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocsparse-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       },
       {
-        "name": "rocsparse-dev",
-        "sha256": "ba4a1e0c53a2bfc296e799171dd7c3ca7663323427258cf7a93a64c5b0f88d96",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocsparse-dev/rocsparse-dev_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "name": "rocsparse-devel",
+        "sha256": "024d3d8c67aae619909d0d7980f3a6c60908efeb36ce899bea3b57981a978864",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocsparse-devel-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       },
       {
-        "name": "rocsparse-dev-rpath",
-        "sha256": "cb9bb7a11b78e4ddecc5772b1a9a10130ecbae271dcb4e2cc6d16fc9de231a8d",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocsparse-dev-rpath6.4.1/rocsparse-dev-rpath6.4.1_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "name": "rocsparse-devel-rpath",
+        "sha256": "a8dc3ea4862403caca11f3fc9e4af098c8c7632c32ca77993b35467c009459c7",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocsparse-devel-rpath6.4.1-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       },
       {
         "name": "rocsparse-rpath",
-        "sha256": "fb4352962f6c7c1e7bfbe6e571e3a4d98895647feba4bbaaaeb9113cc1572d21",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocsparse-rpath6.4.1/rocsparse-rpath6.4.1_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "sha256": "8df6c4ca6823b76140fcebcf156ae38336863560540ff357638dad221b36c327",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocsparse-rpath6.4.1-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       }
     ],
-    "version": "3.4.0.60401-83"
+    "version": "3.4.0.60401"
   },
   "rocsparse-asan": {
     "deps": [
@@ -3272,72 +3275,71 @@
     "components": [
       {
         "name": "rocsparse-asan",
-        "sha256": "9717fee6cc61364e61ef9c1e0361e25969c013ef289c663624ed6f5eaafa452a",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocsparse-asan/rocsparse-asan_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "sha256": "74cb13692c99fe4a2737582c0ec6497285ee7e9e680f229f0e8950edcf818fa2",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocsparse-asan-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       },
       {
         "name": "rocsparse-asan-rpath",
-        "sha256": "c40f295a2d104621786ee10033eb9389175c1de5aa9e0c96ec0ccfd965b4d3d6",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocsparse-asan-rpath6.4.1/rocsparse-asan-rpath6.4.1_3.4.0.60401-83~22.04_amd64.deb",
-        "version": "3.4.0.60401-83"
+        "sha256": "3e74aa76e52a5cc35c703df63def1d0fc35013c465b717d1310b0d86af172d57",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocsparse-asan-rpath6.4.1-3.4.0.60401-83.el8.x86_64.rpm",
+        "version": "3.4.0.60401"
       }
     ],
-    "version": "3.4.0.60401-83"
+    "version": "3.4.0.60401"
   },
-  "rocthrust-dev": {
+  "rocthrust-devel": {
     "deps": [
       "rocm-core",
-      "rocprim-dev"
+      "rocprim-devel"
     ],
     "components": [
       {
-        "name": "rocthrust-dev",
-        "sha256": "961400899a7d484b26fa7f91b772bd3f06b2199bd63fd35f6df7c89d049acdcb",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocthrust-dev/rocthrust-dev_3.3.0.60401-83~22.04_amd64.deb",
-        "version": "3.3.0.60401-83"
+        "name": "rocthrust-devel",
+        "sha256": "a9c42f86c39d3cfddf2bc853d264f763c00a2f8d82d21480893a14e2ef4e20b9",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocthrust-devel-3.3.0.60401-83.el8.x86_64.rpm",
+        "version": "3.3.0.60401"
       },
       {
-        "name": "rocthrust-dev-rpath",
-        "sha256": "2fccf9f839e4785534dea1378adcdb936c7997a7119e563c535119a8909c901b",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocthrust-dev-rpath6.4.1/rocthrust-dev-rpath6.4.1_3.3.0.60401-83~22.04_amd64.deb",
-        "version": "3.3.0.60401-83"
+        "name": "rocthrust-devel-rpath",
+        "sha256": "2c8929b8ee0a16c81f0d06f0be919b96c5cd84f44f38359ccfc694d924d2045c",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocthrust-devel-rpath6.4.1-3.3.0.60401-83.el8.x86_64.rpm",
+        "version": "3.3.0.60401"
       }
     ],
-    "version": "3.3.0.60401-83"
+    "version": "3.3.0.60401"
   },
   "roctracer": {
     "deps": [
-      "hsa-rocr",
       "rocm-core"
     ],
     "components": [
       {
         "name": "roctracer",
-        "sha256": "58cead537cf07c8a8770bfe28346c3b3c92cc4297b51e307c9032b04434b187c",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/roctracer/roctracer_4.1.60401.60401-83~22.04_amd64.deb",
-        "version": "4.1.60401.60401-83"
+        "sha256": "58ab1da8b0badb25d92379cbc774b71d4b024f39456ec1fcb8d2d4dc210762c6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/roctracer-4.1.60401.60401-83.el8.x86_64.rpm",
+        "version": "4.1.60401.60401"
       },
       {
-        "name": "roctracer-dev",
-        "sha256": "5bb52357a3326edabde80a8cbd89d95d68083e1f8e5e3751989b0b81e51420b1",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/roctracer-dev/roctracer-dev_4.1.60401.60401-83~22.04_amd64.deb",
-        "version": "4.1.60401.60401-83"
+        "name": "roctracer-devel",
+        "sha256": "4ef7861740fbb258912e9ccfc89a4f817c55390da00188587cf63cfebe39cae4",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/roctracer-devel-4.1.60401.60401-83.el8.x86_64.rpm",
+        "version": "4.1.60401.60401"
       },
       {
-        "name": "roctracer-dev-rpath",
-        "sha256": "ee89f6ea5993b5360375995498347f986f2834353ae4c4435d0a044e1569a835",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/roctracer-dev-rpath6.4.1/roctracer-dev-rpath6.4.1_4.1.60401.60401-83~22.04_amd64.deb",
-        "version": "4.1.60401.60401-83"
+        "name": "roctracer-devel-rpath",
+        "sha256": "127c195d3b29bc19815ab198dd1f43e821c0a7ddcb36e592e28c2c8814a74ea8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/roctracer-devel-rpath6.4.1-4.1.60401.60401-83.el8.x86_64.rpm",
+        "version": "4.1.60401.60401"
       },
       {
         "name": "roctracer-rpath",
-        "sha256": "ec2d8564c9aa7ba0cb63c7f5071965f6758f843019bc793534a0af31de25e15f",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/roctracer-rpath6.4.1/roctracer-rpath6.4.1_4.1.60401.60401-83~22.04_amd64.deb",
-        "version": "4.1.60401.60401-83"
+        "sha256": "5f535fa3a81b948d0208918b6213b27fc784216567e22366e8e22b71a37c520d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/roctracer-rpath6.4.1-4.1.60401.60401-83.el8.x86_64.rpm",
+        "version": "4.1.60401.60401"
       }
     ],
-    "version": "4.1.60401.60401-83"
+    "version": "4.1.60401.60401"
   },
   "roctracer-asan": {
     "deps": [
@@ -3346,73 +3348,73 @@
     "components": [
       {
         "name": "roctracer-asan",
-        "sha256": "4bb47694acf8c38219790fbffebcc89ca2859a2c1bacc49e57463629fade5bd6",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/roctracer-asan/roctracer-asan_4.1.60401.60401-83~22.04_amd64.deb",
-        "version": "4.1.60401.60401-83"
+        "sha256": "4014c4ccec451b3a3419d4759bfda615fe3bb9e7fbe33c53cdd99e2483c9e999",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/roctracer-asan-4.1.60401.60401-83.el8.x86_64.rpm",
+        "version": "4.1.60401.60401"
       },
       {
         "name": "roctracer-asan-rpath",
-        "sha256": "5f6c411cbe2735bc83df62686611d5dd1ff5b3cc06d4799c55beb9710147d9d7",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/roctracer-asan-rpath6.4.1/roctracer-asan-rpath6.4.1_4.1.60401.60401-83~22.04_amd64.deb",
-        "version": "4.1.60401.60401-83"
+        "sha256": "78e506603a8acc6509f34170ff14f708d2147b6c8b8c75349fef17305e400e7a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/roctracer-asan-rpath6.4.1-4.1.60401.60401-83.el8.x86_64.rpm",
+        "version": "4.1.60401.60401"
       }
     ],
-    "version": "4.1.60401.60401-83"
+    "version": "4.1.60401.60401"
   },
-  "rocwmma-dev": {
+  "rocwmma-devel": {
     "deps": [
       "rocm-core"
     ],
     "components": [
       {
-        "name": "rocwmma-dev",
-        "sha256": "e3ecdf8d5ce28bd09c6851d5489874f772e808f033cc8810b59ce88e30a49715",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocwmma-dev/rocwmma-dev_1.7.0.60401-83~22.04_amd64.deb",
-        "version": "1.7.0.60401-83"
+        "name": "rocwmma-devel",
+        "sha256": "351fa85f0bb5ef80788bba4a8da6a3feb6689166d38ad67a805149645fe577cf",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocwmma-devel-1.7.0.60401-83.el8.x86_64.rpm",
+        "version": "1.7.0.60401"
       },
       {
-        "name": "rocwmma-dev-rpath",
-        "sha256": "e6ed65692630dd67d6336c99c53f64331e253be1bde361c960f2c28d5aeaf619",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rocwmma-dev-rpath6.4.1/rocwmma-dev-rpath6.4.1_1.7.0.60401-83~22.04_amd64.deb",
-        "version": "1.7.0.60401-83"
+        "name": "rocwmma-devel-rpath",
+        "sha256": "60361801f03435575f01ca38730dfad6cd957a77d544522e2b9abb6ff848a59a",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rocwmma-devel-rpath6.4.1-1.7.0.60401-83.el8.x86_64.rpm",
+        "version": "1.7.0.60401"
       }
     ],
-    "version": "1.7.0.60401-83"
+    "version": "1.7.0.60401"
   },
   "rpp": {
     "deps": [
       "half",
-      "openmp-extras-dev",
+      "openmp-extras-devel",
       "openmp-extras-runtime",
       "rocm-hip-runtime"
     ],
     "components": [
       {
         "name": "rpp",
-        "sha256": "2eacbb917f7f729c02599dde84b54f4c11c8a7d70259be3db1ae9edf4992e2d1",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rpp/rpp_1.9.10.60401-83~22.04_amd64.deb",
-        "version": "1.9.10.60401-83"
+        "sha256": "9b681e9df9ca4cacde378aa0386f52a1c9146a763821d613b28fb51f6d335d7d",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rpp-1.9.10.60401-83.el8.x86_64.rpm",
+        "version": "1.9.10.60401"
       },
       {
-        "name": "rpp-dev",
-        "sha256": "67df8b9ff1588dd114dbcf394254a9812307588b2519a5b88cae033ad1ac0c73",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rpp-dev/rpp-dev_1.9.10.60401-83~22.04_amd64.deb",
-        "version": "1.9.10.60401-83"
+        "name": "rpp-devel",
+        "sha256": "f2de22819037202e72849bcbd8fbe4af51e3836b966ebc185d54c3ef015923aa",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rpp-devel-1.9.10.60401-83.el8.x86_64.rpm",
+        "version": "1.9.10.60401"
       },
       {
-        "name": "rpp-dev-rpath",
-        "sha256": "0ad1cf8f15980d9be1af75b1bff584259aa3ecfe872c3b2f6b30c89f2d443e1e",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rpp-dev-rpath6.4.1/rpp-dev-rpath6.4.1_1.9.10.60401-83~22.04_amd64.deb",
-        "version": "1.9.10.60401-83"
+        "name": "rpp-devel-rpath",
+        "sha256": "0b3302c105bdf549c0a07c7b7f65e6e7cc7259a2b87b17d6c9de0369e74e16e8",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rpp-devel-rpath6.4.1-1.9.10.60401-83.el8.x86_64.rpm",
+        "version": "1.9.10.60401"
       },
       {
         "name": "rpp-rpath",
-        "sha256": "5e44ac69b003e65caef4964fc368f18c84e05cc14ff790d483b10499c13389cb",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rpp-rpath6.4.1/rpp-rpath6.4.1_1.9.10.60401-83~22.04_amd64.deb",
-        "version": "1.9.10.60401-83"
+        "sha256": "b89205b77b61b78bfe1605ad7c686a423cf19e376b84063c241e17d7ddc04ea2",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rpp-rpath6.4.1-1.9.10.60401-83.el8.x86_64.rpm",
+        "version": "1.9.10.60401"
       }
     ],
-    "version": "1.9.10.60401-83"
+    "version": "1.9.10.60401"
   },
   "rpp-asan": {
     "deps": [
@@ -3421,18 +3423,18 @@
     "components": [
       {
         "name": "rpp-asan",
-        "sha256": "c0608d87d8547c9e802346fbb323c5782a23828f0f50d89e0a9d194177df8ed9",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rpp-asan/rpp-asan_1.9.10.60401-83~22.04_amd64.deb",
-        "version": "1.9.10.60401-83"
+        "sha256": "1c92445a962a80c5a74ad78a2e4c53bb32df273acd7e9e8bb83cfb5b163a3640",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rpp-asan-1.9.10.60401-83.el8.x86_64.rpm",
+        "version": "1.9.10.60401"
       },
       {
         "name": "rpp-asan-rpath",
-        "sha256": "943379d85c93703c7ecb73394a75fd8d71fc0e22a8c479055eeac50e51a74f0c",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rpp-asan-rpath6.4.1/rpp-asan-rpath6.4.1_1.9.10.60401-83~22.04_amd64.deb",
-        "version": "1.9.10.60401-83"
+        "sha256": "4b47bfd895a39af7721b36e23cabfe45c5a4c57c446f876d101fc772e5b3894f",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rpp-asan-rpath6.4.1-1.9.10.60401-83.el8.x86_64.rpm",
+        "version": "1.9.10.60401"
       }
     ],
-    "version": "1.9.10.60401-83"
+    "version": "1.9.10.60401"
   },
   "rpp-test": {
     "deps": [
@@ -3441,38 +3443,38 @@
     "components": [
       {
         "name": "rpp-test",
-        "sha256": "fb57b90167efd60168efb8df674e1d42217313b99ed4075f263ed5f03dbe1df9",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rpp-test/rpp-test_1.9.10.60401-83~22.04_amd64.deb",
-        "version": "1.9.10.60401-83"
+        "sha256": "0472dbee94a819ac01f9fac583bdb6ee600894725c05cd066ce7ad9dfa17be3e",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rpp-test-1.9.10.60401-83.el8.x86_64.rpm",
+        "version": "1.9.10.60401"
       },
       {
         "name": "rpp-test-rpath",
-        "sha256": "9d60eee70f77221993c23e373fc61f9dbe8c804c00a83c1dafdf15f395c9705f",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/r/rpp-test-rpath6.4.1/rpp-test-rpath6.4.1_1.9.10.60401-83~22.04_amd64.deb",
-        "version": "1.9.10.60401-83"
+        "sha256": "e18c8464e424f70bf10b3abfb5b42898f7ef45eed8e98dd7206754f06caaeac6",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/rpp-test-rpath6.4.1-1.9.10.60401-83.el8.x86_64.rpm",
+        "version": "1.9.10.60401"
       }
     ],
-    "version": "1.9.10.60401-83"
+    "version": "1.9.10.60401"
   },
-  "transferbench-dev": {
+  "transferbench-devel": {
     "deps": [
       "hsa-rocr",
       "rocm-core"
     ],
     "components": [
       {
-        "name": "transferbench-dev",
-        "sha256": "4f9687d65d4274e45d110451b611869ce7fae0c35739ae7bd6952a381925ac10",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/t/transferbench-dev/transferbench-dev_1.57.0.60401-83~22.04_amd64.deb",
-        "version": "1.57.0.60401-83"
+        "name": "transferbench-devel",
+        "sha256": "af40288aa02827ee2116325f9f6c5b59a9b3f7b8d47571e5f0d77b7c240f6faa",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/transferbench-devel-1.57.0.60401-83.el8.x86_64.rpm",
+        "version": "1.57.0.60401"
       },
       {
-        "name": "transferbench-dev-rpath",
-        "sha256": "36f29a7367c87dea2515f56657178d0166ff5f13bf9168db56303246dc9cf018",
-        "url": "https://repo.radeon.com/rocm/apt/6.4.1/pool/main/t/transferbench-dev-rpath6.4.1/transferbench-dev-rpath6.4.1_1.57.0.60401-83~22.04_amd64.deb",
-        "version": "1.57.0.60401-83"
+        "name": "transferbench-devel-rpath",
+        "sha256": "e1df5aa4d8f5964c44a4885f6c1df1305e0cf1687cffb7260c3c23d9f285c389",
+        "url": "https://repo.radeon.com/rocm/rhel8/6.4.1/main/transferbench-devel-rpath6.4.1-1.57.0.60401-83.el8.x86_64.rpm",
+        "version": "1.57.0.60401"
       }
     ],
-    "version": "1.57.0.60401-83"
+    "version": "1.57.0.60401"
   }
 }


### PR DESCRIPTION
Change the source package set... again. ROCm 6.4.1 is now only provided for Ubuntu 22.04 and later. However, that breaks manylinux_2_28 compatibility. So it seems that using the RHEL packages is the only remaining ancient Linux path.